### PR TITLE
Add bipartite Claude Code skill for unified CLI guidance

### DIFF
--- a/.claude/skills/bipartite/SKILL.md
+++ b/.claude/skills/bipartite/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: bipartite
+description: Unified guidance for using the bipartite reference library CLI. Use when searching for papers, managing the library, or exploring literature via S2/ASTA.
+---
+
+# Bipartite Reference Library
+
+A CLI tool for managing academic references with local storage and external paper search.
+
+**Repository**: `/Users/matsen/re/bipartite`
+**PDF Storage**: `/Users/matsen/Google Drive/My Drive/Paperpile`
+
+## Quick Reference
+
+| Task | Command |
+|------|---------|
+| Search local library | `./bp search "query"` |
+| Semantic search | `./bp semantic "query"` |
+| Get paper details | `./bp get <id>` |
+| Add paper to collection | `./bp s2 add DOI:10.1234/...` |
+| Find literature gaps | `./bp s2 gaps` |
+| Fast paper search (external) | `./bp asta search "query"` |
+| Find text snippets | `./bp asta snippet "query"` |
+
+## S2 vs ASTA: When to Use Which
+
+Both access Semantic Scholar's paper database but through different APIs:
+
+| Use Case | Command | Why |
+|----------|---------|-----|
+| Add paper to collection | `bp s2 add` | Only S2 can modify local library |
+| Find literature gaps | `bp s2 gaps` | Analyzes your collection |
+| Explore without adding | `bp asta *` | Faster, read-only |
+| Find text snippets in papers | `bp asta snippet` | Unique to ASTA |
+| Fast paper search | `bp asta search` | 10x faster rate limit |
+| Get citations/references | Either works | ASTA is faster |
+
+**Rule of thumb**: Use `bp asta` for exploration, `bp s2` when you want to modify your library.
+
+See [api-guide.md](api-guide.md) for detailed comparison.
+
+## Common Workflows
+
+### Find a Paper
+
+1. **Search local library first**:
+   ```bash
+   ./bp search "Schmidler phylogenetics"
+   # or for topic-heavy queries:
+   ./bp semantic "importance sampling MCMC"
+   ```
+
+2. **Get PDF path** for a result:
+   ```bash
+   ./bp get <id>
+   # pdf_path field + "/Users/matsen/Google Drive/My Drive/Paperpile"
+   ```
+
+3. **If not in library**, search externally:
+   ```bash
+   ./bp asta search "phylogenetic inference"
+   ```
+
+### Update Library from Paperpile
+
+1. Export from Paperpile (JSON format) to ~/Downloads
+2. Find the export file:
+   ```bash
+   ls -t ~/Downloads/Paperpile*.json | head -1
+   ```
+3. Import:
+   ```bash
+   ./bp import --format paperpile "<path>"
+   ```
+4. Optionally delete the export file after confirming success
+
+### Explore Literature
+
+1. **Search by topic**:
+   ```bash
+   ./bp asta search "variational inference phylogenetics" --limit 20
+   ```
+
+2. **Find specific text passages**:
+   ```bash
+   ./bp asta snippet "Bayesian phylogenetic inference"
+   ```
+
+3. **Trace citations**:
+   ```bash
+   ./bp asta citations DOI:10.1093/sysbio/syy032
+   ./bp asta references DOI:10.1093/sysbio/syy032
+   ```
+
+4. **Add interesting papers** to your collection:
+   ```bash
+   ./bp s2 add DOI:10.1093/sysbio/syy032
+   ```
+
+See [workflows.md](workflows.md) for detailed workflow instructions.
+
+## Output Format
+
+All commands output JSON by default. Add `--human` for readable format:
+
+```bash
+./bp asta search "phylogenetics" --human
+./bp s2 lookup DOI:10.1234/example --human
+```
+
+## Paper ID Formats
+
+Both S2 and ASTA accept these identifier formats:
+- `DOI:10.1093/sysbio/syy032`
+- `ARXIV:2106.15928`
+- `PMID:19872477`
+- `CorpusId:215416146`
+- Raw Semantic Scholar ID (40-char hex)

--- a/.claude/skills/bipartite/api-guide.md
+++ b/.claude/skills/bipartite/api-guide.md
@@ -1,0 +1,129 @@
+# S2 vs ASTA API Guide
+
+Both `bp s2` and `bp asta` commands access Semantic Scholar's paper database, but through different APIs with different capabilities.
+
+## Quick Comparison
+
+| Feature | `bp s2` | `bp asta` |
+|---------|---------|-----------|
+| API | Semantic Scholar REST | Allen AI ASTA MCP |
+| Rate limit | 1 req/sec | 10 req/sec |
+| Snippet search | No | Yes |
+| Add to collection | Yes | No (read-only) |
+| Auth | S2_API_KEY | ASTA_API_KEY |
+
+## When to Use S2
+
+Use `bp s2` when you need to **modify your local collection**:
+
+```bash
+# Add a paper to your collection
+./bp s2 add DOI:10.1093/sysbio/syy032
+
+# Look up paper info (slower, 1 req/sec)
+./bp s2 lookup DOI:10.1093/sysbio/syy032
+
+# Find citing papers
+./bp s2 citations <paper-id>
+
+# Find referenced papers
+./bp s2 references <paper-id>
+
+# Find literature gaps (papers cited by collection but not in it)
+./bp s2 gaps
+```
+
+**Key S2 capabilities**:
+- `bp s2 add` - Add papers to your local collection
+- `bp s2 gaps` - Analyze your collection for missing papers
+
+## When to Use ASTA
+
+Use `bp asta` for **fast, read-only exploration**:
+
+```bash
+# Fast paper search (10x faster rate limit)
+./bp asta search "phylogenetic inference" --limit 20 --human
+
+# UNIQUE: Search text snippets within papers
+./bp asta snippet "variational inference" --human
+
+# Get paper details
+./bp asta paper DOI:10.1093/sysbio/syy032 --human
+
+# Get citations (faster than S2)
+./bp asta citations DOI:10.1093/sysbio/syy032 --human
+
+# Get references
+./bp asta references DOI:10.1093/sysbio/syy032 --human
+
+# Search for authors
+./bp asta author "Frederick Matsen" --human
+
+# Get author's papers
+./bp asta author-papers 145666442 --human
+```
+
+**Key ASTA capabilities**:
+- `bp asta snippet` - Search actual text within papers (unique to ASTA)
+- 10x faster rate limit for bulk exploration
+- Author search functionality
+
+## ASTA MCP Tools
+
+When using Claude Code, you can also access ASTA directly via MCP tools:
+
+| MCP Tool | Equivalent CLI |
+|----------|---------------|
+| `mcp__asta__search_papers_by_relevance` | `bp asta search` |
+| `mcp__asta__search_paper_by_title` | `bp asta search` (by title) |
+| `mcp__asta__snippet_search` | `bp asta snippet` |
+| `mcp__asta__get_paper` | `bp asta paper` |
+| `mcp__asta__get_citations` | `bp asta citations` |
+| `mcp__asta__search_authors_by_name` | `bp asta author` |
+| `mcp__asta__get_author_papers` | `bp asta author-papers` |
+
+## Paper ID Formats
+
+Both APIs accept the same identifier formats:
+
+| Format | Example |
+|--------|---------|
+| DOI | `DOI:10.1093/sysbio/syy032` |
+| arXiv | `ARXIV:2106.15928` |
+| PubMed | `PMID:19872477` |
+| PubMed Central | `PMCID:2323736` |
+| Corpus ID | `CorpusId:215416146` |
+| Raw S2 ID | `649def34f8be52c8b66281af98ae884c09aef38b` |
+| URL | `URL:https://arxiv.org/abs/2106.15928v1` |
+
+## Output Format
+
+Both command families output JSON by default. Add `--human` for readable output:
+
+```bash
+./bp s2 lookup DOI:10.1093/sysbio/syy032 --human
+./bp asta search "phylogenetics" --human
+```
+
+## Environment Variables
+
+```bash
+# In .env file
+S2_API_KEY=your_s2_api_key      # For bp s2 commands
+ASTA_API_KEY=your_asta_api_key  # For bp asta commands
+```
+
+## Decision Flowchart
+
+```
+Want to modify your collection?
+├── Yes → Use bp s2
+│   ├── Add paper → bp s2 add
+│   └── Find gaps → bp s2 gaps
+└── No (read-only exploration)
+    ├── Need text snippets? → bp asta snippet
+    ├── Bulk search? → bp asta search (faster)
+    ├── Author info? → bp asta author
+    └── Citations/refs → bp asta (faster)
+```

--- a/.claude/skills/bipartite/workflows.md
+++ b/.claude/skills/bipartite/workflows.md
@@ -1,0 +1,196 @@
+# Bipartite Workflows
+
+Detailed instructions for common bipartite workflows.
+
+## Find Papers (bp-find)
+
+Search for papers in the local library and return Google Drive PDF paths.
+
+### Query Parsing
+
+Parse user queries to identify:
+- **Author names**: "Schmidler", "Mathews and Schmidler"
+- **Years/ranges**: "2025", "recent", "last 2 years"
+- **Topics/keywords**: "importance sampling", "B cell"
+- **Combinations**: "Schmidler papers from 2025 about phylogenetics"
+
+### Search Strategy
+
+1. **Search the local library**:
+   ```bash
+   cd /Users/matsen/re/bipartite
+   ./bp search "<constructed query>"
+   ```
+
+2. **For topic-heavy queries**, also try semantic search:
+   ```bash
+   ./bp semantic "<topic>"
+   ```
+
+3. **Filter results** by author/year criteria from the query.
+
+### Present Results
+
+Display results numbered, showing:
+- Title
+- Authors
+- Year
+
+### Handle Selection
+
+- **Single paper** (e.g., "3"): Return its PDF path
+- **Multiple papers** (e.g., "2, 4, 5" or "all"): Return all PDF paths
+- **Refine search**: Help narrow down if requested
+
+### Return PDF Paths
+
+Combine:
+- Root: `/Users/matsen/Google Drive/My Drive/Paperpile`
+- Plus `pdf_path` from `./bp get <id>`
+
+### Example Interactions
+
+- "Schmidler" -> list all Schmidler papers, user picks subset
+- "importance sampling 2025" -> papers matching both criteria
+- "recent MCMC papers" -> semantic search, filtered to last 2 years
+
+---
+
+## If Paper NOT in Local Library
+
+Use ASTA MCP tools (or `bp asta` commands) to search broader literature:
+
+### Search by Title/Keyword
+
+```bash
+./bp asta search "phylogenetic inference" --human
+```
+
+Or via MCP tools:
+```
+mcp__asta__search_papers_by_relevance
+mcp__asta__search_paper_by_title
+```
+
+### Get Verbatim Quotes (for provenance)
+
+```bash
+./bp asta snippet "exact phrase to find"
+```
+
+Or via MCP:
+```
+mcp__asta__snippet_search with query like "exact phrase to find"
+```
+
+### Trace Citations
+
+```bash
+./bp asta citations DOI:10.1093/sysbio/syy032
+./bp asta references DOI:10.1093/sysbio/syy032
+```
+
+Or via MCP:
+```
+mcp__asta__get_citations
+mcp__asta__get_paper (with references field)
+```
+
+### Get Paper Details
+
+```bash
+./bp asta paper DOI:10.1093/sysbio/syy032 --human
+```
+
+Or via MCP:
+```
+mcp__asta__get_paper with fields "title,authors,year,abstract,venue,url"
+```
+
+This is useful for:
+- Finding papers not in the local library
+- Tracing citation chains to establish provenance
+- Getting direct quotes as evidence
+
+---
+
+## Update Library (bp-update)
+
+Import references from a Paperpile export.
+
+### Steps
+
+1. **Find the most recent Paperpile export**:
+   ```bash
+   ls -t ~/Downloads/Paperpile*.json | head -1
+   ```
+
+2. **Confirm with user** which file to use (show filename and date).
+
+3. **Run the import**:
+   ```bash
+   cd /Users/matsen/re/bipartite
+   ./bp import --format paperpile "<path>"
+   ```
+
+4. **Report results**: Show new/updated/unchanged counts.
+
+5. **Ask about cleanup**: Offer to remove the import file from Downloads if user wants.
+
+---
+
+## Explore Literature
+
+For open-ended literature exploration without adding to your collection.
+
+### Topic Discovery
+
+```bash
+# Search by keyword relevance
+./bp asta search "variational inference" --limit 30 --human
+
+# Filter by year
+./bp asta search "deep learning phylogenetics" --year 2023:2025 --human
+```
+
+### Citation Network Exploration
+
+```bash
+# Find papers citing a foundational paper
+./bp asta citations DOI:10.1093/sysbio/syy032 --limit 50 --human
+
+# Find what a paper builds on
+./bp asta references DOI:10.1093/sysbio/syy032 --human
+```
+
+### Author Exploration
+
+```bash
+# Find an author
+./bp asta author "Frederick Matsen" --human
+
+# Get their papers (use author ID from previous result)
+./bp asta author-papers 145666442 --human
+```
+
+### Add Papers to Collection
+
+When you find papers worth keeping:
+```bash
+./bp s2 add DOI:10.1093/sysbio/syy032
+```
+
+---
+
+## Find Literature Gaps
+
+Identify papers cited by your collection but not in it.
+
+```bash
+./bp s2 gaps --human
+```
+
+Review the gaps and add interesting papers:
+```bash
+./bp s2 add DOI:10.xxxx/yyyy
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,10 +78,9 @@ When modifying SQLite schema (e.g., adding columns to FTS5 tables):
 
 Note: `CREATE ... IF NOT EXISTS` does not update existing table schemas - you must delete the database file for schema changes to take effect.
 
-## Bipartite Skills
+## Bipartite Skill
 
-- `/bp-find <query>` - Search for papers and return Google Drive PDF paths. Supports author names, years, topics, and combinations (e.g., "Schmidler 2021", "importance sampling recent").
-- `/bp-update` - Import references from the most recent Paperpile JSON export in ~/Downloads.
+Use `/bipartite` for unified CLI guidance including paper search, library management, and S2 vs ASTA command selection. The skill is defined in `.claude/skills/bipartite/` and symlinked to `~/.claude/skills/` for global availability.
 
 ## Ralph Loop
 


### PR DESCRIPTION
## Summary
- Creates new `.claude/skills/bipartite/` skill structure with SKILL.md (overview), workflows.md (bp-find/bp-update logic), and api-guide.md (S2 vs ASTA comparison)
- Symlinks to `~/.claude/skills/` for global availability
- Updates CLAUDE.md with brief skill reference
- Deletes old `~/.claude/commands/bp-find.md` and `bp-update.md` files

Closes #10

## Test plan
- [ ] Verify skill is discoverable via `/bipartite` in Claude Code
- [ ] Verify symlink works: `ls -la ~/.claude/skills/bipartite`
- [ ] Test paper search workflow guidance
- [ ] Verify S2 vs ASTA decision guide is clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)