### PR TITLE
Add shared repository workflow commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,8 @@
 - JSONL (concepts.jsonl) + ephemeral SQLite (rebuilt on `bip rebuild`) (006-concept-nodes)
 - Go 1.25.5 + spf13/cobra (CLI), modernc.org/sqlite (storage), html/template (HTML generation) (007-knowledge-graph-viz)
 - SQLite (read from existing refs, concepts, edges tables rebuilt from JSONL) (007-knowledge-graph-viz)
+- Go 1.25.5 (matches existing codebase) + spf13/cobra (CLI), modernc.org/sqlite (storage), os/exec (git integration) (008-shared-repo-workflow)
+- JSONL (refs.jsonl) + ephemeral SQLite (rebuilt on `bip rebuild`) - no schema changes needed (008-shared-repo-workflow)
 
 ## Project Structure
 
@@ -36,7 +38,21 @@ go build -o bip ./cmd/bip && ./bip --help
 ./bip semantic <query>                        # Semantic similarity search
 ./bip get <id>                                # Get reference by ID
 ./bip list                                    # List all references
-./bip export                                  # Export to BibTeX
+./bip export --bibtex                          # Export all to BibTeX
+./bip export --bibtex <id>...                  # Export specific papers
+./bip export --bibtex --append refs.bib <id>   # Append with deduplication
+
+# Open commands (with git integration)
+./bip open <id>                               # Open single paper PDF
+./bip open <id> <id> ...                      # Open multiple papers
+./bip open --recent 5                         # Open 5 most recently added
+./bip open --since HEAD~3                     # Open papers added since commit
+
+# Diff and tracking commands (git integration)
+./bip diff                                    # Show uncommitted changes to library
+./bip diff --human                            # Human-readable diff output
+./bip new --since <commit>                    # Papers added since commit
+./bip new --days 7                            # Papers added in last N days
 
 # Semantic Scholar (S2) commands
 ./bip s2 add DOI:10.1234/example              # Add paper by DOI
@@ -124,6 +140,6 @@ Before any pull request, ensure the following workflow is completed:
 <!-- MANUAL ADDITIONS END -->
 
 ## Recent Changes
+- 008-shared-repo-workflow: Added Go 1.25.5 (matches existing codebase) + spf13/cobra (CLI), modernc.org/sqlite (storage), os/exec (git integration)
 - 007-knowledge-graph-viz: Added Go 1.25.5 + spf13/cobra (CLI), modernc.org/sqlite (storage), html/template (HTML generation)
 - 006-concept-nodes: Added Go 1.25.5 + spf13/cobra (CLI), modernc.org/sqlite (storage)
-- 005-asta-mcp-integration: Added ASTA MCP commands (bip asta *) for paper search, snippet search, citations, references, and author lookup via Allen AI's Academic Search Tool API

--- a/README.md
+++ b/README.md
@@ -113,8 +113,14 @@ bip open Smith2026-ab
 | `bip search <query>` | Full-text search across titles, abstracts, authors, years |
 | `bip list` | List all references |
 | `bip get <id>` | Get a specific reference by ID |
-| `bip open <id>` | Open PDF in configured viewer |
-| `bip export --bibtex` | Export to BibTeX format |
+| `bip open <id>...` | Open PDFs by ID (supports multiple) |
+| `bip open --recent N` | Open N most recently added papers |
+| `bip open --since <commit>` | Open papers added since commit |
+| `bip export --bibtex [<id>...]` | Export to BibTeX (all or specific papers) |
+| `bip export --bibtex --append <file> <id>...` | Append to .bib with deduplication |
+| `bip diff` | Show papers added/removed since last commit |
+| `bip new --since <commit>` | List papers added since commit |
+| `bip new --days N` | List papers added in last N days |
 | `bip check` | Validate repository integrity |
 | `bip groom` | Detect orphaned edges; use `--fix` to remove |
 

--- a/cmd/bip/diff.go
+++ b/cmd/bip/diff.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/matsen/bipartite/internal/git"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(diffCmd)
+}
+
+var diffCmd = &cobra.Command{
+	Use:   "diff",
+	Short: "Show papers added or removed since last commit",
+	Long: `Show papers added or removed in the working tree compared to the last commit.
+
+Useful for reviewing uncommitted changes before committing.
+
+Examples:
+  bip diff
+  bip diff --human`,
+	RunE: runDiff,
+}
+
+func runDiff(cmd *cobra.Command, args []string) error {
+	repoRoot := mustFindRepository()
+	gitRoot := mustFindGitRepo(repoRoot)
+	mustCheckGitTracking(gitRoot)
+
+	// Get diff between HEAD and working tree
+	diff, err := git.DiffWorkingTree(gitRoot)
+	if err != nil {
+		exitWithError(ExitError, "getting diff: %v", err)
+	}
+
+	// Sort for deterministic output
+	git.SortRefsAlphabetically(diff.Added)
+	git.SortRefsAlphabetically(diff.Removed)
+
+	// Convert to output format
+	added := make([]DiffPaper, 0, len(diff.Added))
+	for _, ref := range diff.Added {
+		added = append(added, refToDiffPaper(ref))
+	}
+
+	removed := make([]DiffPaper, 0, len(diff.Removed))
+	for _, ref := range diff.Removed {
+		removed = append(removed, refToDiffPaper(ref))
+	}
+
+	// Sort output by ID for consistency
+	sort.Slice(added, func(i, j int) bool { return added[i].ID < added[j].ID })
+	sort.Slice(removed, func(i, j int) bool { return removed[i].ID < removed[j].ID })
+
+	result := DiffResult{
+		Added:   added,
+		Removed: removed,
+	}
+
+	if humanOutput {
+		printDiffHuman(result)
+	} else {
+		outputJSON(result)
+	}
+
+	return nil
+}
+
+func printDiffHuman(result DiffResult) {
+	if len(result.Added) == 0 && len(result.Removed) == 0 {
+		fmt.Println("No changes since last commit.")
+		return
+	}
+
+	fmt.Println("Changes since last commit:")
+	fmt.Println()
+
+	if len(result.Added) > 0 {
+		fmt.Printf("Added (%d):\n", len(result.Added))
+		for _, p := range result.Added {
+			title := truncateString(p.Title, 50)
+			fmt.Printf("  + %s: %s (%s, %d)\n", p.ID, title, p.Authors, p.Year)
+		}
+		fmt.Println()
+	}
+
+	if len(result.Removed) > 0 {
+		fmt.Printf("Removed (%d):\n", len(result.Removed))
+		for _, p := range result.Removed {
+			title := truncateString(p.Title, 50)
+			fmt.Printf("  - %s: %s (%s, %d)\n", p.ID, title, p.Authors, p.Year)
+		}
+	}
+}

--- a/cmd/bip/git_helpers.go
+++ b/cmd/bip/git_helpers.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"errors"
+
+	"github.com/matsen/bipartite/internal/git"
+	"github.com/matsen/bipartite/internal/reference"
+)
+
+// mustFindGitRepo finds the git repository root, exits on error.
+func mustFindGitRepo(bipRoot string) string {
+	gitRoot, err := git.FindRepoRoot(bipRoot)
+	if err != nil {
+		if errors.Is(err, git.ErrNotGitRepo) {
+			exitWithError(ExitError, "not in a git repository\n  Hint: Initialize with 'git init' or navigate to a git repository")
+		}
+		exitWithError(ExitError, "finding git repository: %v", err)
+	}
+	return gitRoot
+}
+
+// mustValidateCommit validates a commit reference, exits on error.
+func mustValidateCommit(repoRoot, commitRef string) string {
+	sha, err := git.ValidateCommit(repoRoot, commitRef)
+	if err != nil {
+		if errors.Is(err, git.ErrCommitNotFound) {
+			exitWithError(ExitError, "commit not found: %s\n  Hint: Verify the commit exists with 'git log --oneline'", commitRef)
+		}
+		exitWithError(ExitError, "validating commit: %v", err)
+	}
+	return sha
+}
+
+// mustCheckGitTracking verifies refs.jsonl is tracked, exits on error.
+func mustCheckGitTracking(repoRoot string) {
+	if !git.IsFileTracked(repoRoot) {
+		exitWithError(ExitError, "refs.jsonl not tracked by git\n  Hint: Run 'git add .bipartite/refs.jsonl' to track the file")
+	}
+}
+
+// refToDiffPaper converts a reference to a DiffPaper for output.
+func refToDiffPaper(ref reference.Reference) DiffPaper {
+	return DiffPaper{
+		ID:      ref.ID,
+		Title:   ref.Title,
+		Authors: formatAuthorsLastNames(ref.Authors),
+		Year:    ref.Published.Year,
+	}
+}
+
+// refToNewPaper converts a reference and commit info to a NewPaper for output.
+func refToNewPaper(ref reference.Reference, commitSHA string) NewPaper {
+	return NewPaper{
+		ID:        ref.ID,
+		Title:     ref.Title,
+		Authors:   formatAuthorsLastNames(ref.Authors),
+		Year:      ref.Published.Year,
+		CommitSHA: commitSHA,
+	}
+}
+
+// formatAuthorsLastNames formats authors as "Last1, Last2, ..."
+func formatAuthorsLastNames(authors []reference.Author) string {
+	if len(authors) == 0 {
+		return ""
+	}
+	names := make([]string, 0, len(authors))
+	for _, a := range authors {
+		names = append(names, a.Last)
+	}
+	result := ""
+	for i, name := range names {
+		if i > 0 {
+			result += ", "
+		}
+		result += name
+	}
+	return result
+}

--- a/cmd/bip/new.go
+++ b/cmd/bip/new.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/matsen/bipartite/internal/git"
+	"github.com/spf13/cobra"
+)
+
+var (
+	newSince string
+	newDays  int
+)
+
+func init() {
+	newCmd.Flags().StringVar(&newSince, "since", "", "List papers added after this git commit")
+	newCmd.Flags().IntVar(&newDays, "days", 0, "List papers added within last N days (UTC)")
+	rootCmd.AddCommand(newCmd)
+}
+
+var newCmd = &cobra.Command{
+	Use:   "new",
+	Short: "List papers added since a commit or within N days",
+	Long: `List papers added to the repository since a specific commit or within the last N days.
+
+Useful for tracking new additions from collaborators after pulling updates.
+
+Examples:
+  bip new --since abc123f
+  bip new --since HEAD~3
+  bip new --days 7
+  bip new --days 7 --human`,
+	RunE: runNew,
+}
+
+func runNew(cmd *cobra.Command, args []string) error {
+	repoRoot := mustFindRepository()
+	gitRoot := mustFindGitRepo(repoRoot)
+
+	// Validate mutual exclusivity
+	hasSince := newSince != ""
+	hasDays := newDays > 0
+
+	if hasSince && hasDays {
+		exitWithError(ExitError, "--since and --days are mutually exclusive")
+	}
+
+	if !hasSince && !hasDays {
+		exitWithError(ExitError, "--since or --days flag required\n  Hint: Use 'bip new --since <commit>' or 'bip new --days N'")
+	}
+
+	var papers []NewPaper
+	var sinceRef string
+
+	if hasSince {
+		// Validate commit
+		sha := mustValidateCommit(gitRoot, newSince)
+		sinceRef = sha[:8] // Short SHA
+
+		// Get papers added since commit
+		recentPapers, err := git.GetPapersAddedSince(gitRoot, newSince)
+		if err != nil {
+			exitWithError(ExitError, "getting papers since %s: %v", newSince, err)
+		}
+
+		for _, rp := range recentPapers {
+			papers = append(papers, refToNewPaper(rp.Reference, rp.CommitSHA))
+		}
+	} else if hasDays {
+		sinceRef = fmt.Sprintf("%d days ago", newDays)
+
+		// Get papers added in last N days
+		recentPapers, err := git.GetPapersAddedInDays(gitRoot, newDays)
+		if err != nil {
+			exitWithError(ExitError, "getting papers from last %d days: %v", newDays, err)
+		}
+
+		for _, rp := range recentPapers {
+			papers = append(papers, refToNewPaper(rp.Reference, rp.CommitSHA))
+		}
+	}
+
+	// Sort by ID for deterministic output
+	sort.Slice(papers, func(i, j int) bool { return papers[i].ID < papers[j].ID })
+
+	result := NewPapersResult{
+		Papers:     papers,
+		SinceRef:   sinceRef,
+		TotalCount: len(papers),
+	}
+
+	if humanOutput {
+		printNewPapersHuman(result)
+	} else {
+		outputJSON(result)
+	}
+
+	return nil
+}
+
+func printNewPapersHuman(result NewPapersResult) {
+	if len(result.Papers) == 0 {
+		fmt.Printf("No papers added since %s.\n", result.SinceRef)
+		return
+	}
+
+	fmt.Printf("Papers added since %s:\n\n", result.SinceRef)
+
+	for _, p := range result.Papers {
+		fmt.Printf("  %s: %s\n", p.ID, truncateString(p.Title, 50))
+		fmt.Printf("    %s (%d)\n", p.Authors, p.Year)
+		if p.CommitSHA != "" {
+			fmt.Printf("    Added in commit %s\n", p.CommitSHA)
+		}
+		fmt.Println()
+	}
+
+	fmt.Printf("%d paper(s) added\n", result.TotalCount)
+}

--- a/cmd/bip/open.go
+++ b/cmd/bip/open.go
@@ -3,33 +3,39 @@ package main
 import (
 	"fmt"
 
+	"github.com/matsen/bipartite/internal/git"
 	"github.com/matsen/bipartite/internal/pdf"
 	"github.com/spf13/cobra"
 )
 
-var openSupplement int
+var (
+	openSupplement int
+	openRecent     int
+	openSince      string
+)
 
 func init() {
 	openCmd.Flags().IntVar(&openSupplement, "supplement", 0, "Open Nth supplementary PDF (1-indexed)")
+	openCmd.Flags().IntVar(&openRecent, "recent", 0, "Open the N most recently added papers")
+	openCmd.Flags().StringVar(&openSince, "since", "", "Open papers added after this git commit")
 	rootCmd.AddCommand(openCmd)
 }
 
 var openCmd = &cobra.Command{
-	Use:   "open <id>",
-	Short: "Open a paper's PDF in the configured viewer",
-	Long: `Open a paper's PDF in the configured viewer.
+	Use:   "open [<id>...] [flags]",
+	Short: "Open papers' PDFs in the configured viewer",
+	Long: `Open papers' PDFs in the configured viewer.
+
+Supports opening multiple papers by ID, the N most recently added papers,
+or papers added since a specific git commit.
 
 Examples:
   bip open Ahn2026-rs
-  bip open Ahn2026-rs --supplement 1`,
-	Args: cobra.ExactArgs(1),
+  bip open Ahn2026-rs Smith2024-ab Lee2024-cd
+  bip open --recent 5
+  bip open --since HEAD~3
+  bip open --since abc123f`,
 	RunE: runOpen,
-}
-
-// OpenResult is the response for the open command.
-type OpenResult struct {
-	Status string `json:"status"`
-	Path   string `json:"path"`
 }
 
 func runOpen(cmd *cobra.Command, args []string) error {
@@ -38,58 +44,165 @@ func runOpen(cmd *cobra.Command, args []string) error {
 
 	// Check PDF root is configured
 	if cfg.PDFRoot == "" {
-		exitWithError(ExitConfigError, "pdf_root not configured (use 'bip config pdf-root /path/to/pdfs')")
+		exitWithError(ExitConfigError, "pdf_root not configured\n  Hint: Use 'bip config pdf-root /path/to/pdfs' to set the PDF directory")
 	}
 
 	db := mustOpenDatabase(repoRoot)
 	defer db.Close()
 
-	// Get reference
-	id := args[0]
-	ref, err := db.GetByID(id)
-	if err != nil {
-		exitWithError(ExitError, "getting reference: %v", err)
+	// Validate mutual exclusivity
+	hasIDs := len(args) > 0
+	hasRecent := openRecent > 0
+	hasSince := openSince != ""
+
+	exclusiveCount := 0
+	if hasIDs {
+		exclusiveCount++
 	}
-	if ref == nil {
-		exitWithError(ExitError, "reference not found: %s", id)
+	if hasRecent {
+		exclusiveCount++
+	}
+	if hasSince {
+		exclusiveCount++
 	}
 
-	// Determine which PDF to open
-	var pdfPath string
-	if openSupplement > 0 {
-		idx := openSupplement - 1 // Convert to 0-indexed
-		if idx >= len(ref.SupplementPaths) {
-			exitWithError(ExitError, "no supplement at index %d (have %d supplements)", openSupplement, len(ref.SupplementPaths))
+	if exclusiveCount > 1 {
+		exitWithError(ExitError, "positional IDs, --recent, and --since are mutually exclusive")
+	}
+
+	if exclusiveCount == 0 {
+		exitWithError(ExitError, "specify paper IDs, --recent N, or --since <commit>")
+	}
+
+	// Validate --supplement only valid with single ID
+	if openSupplement > 0 && (hasRecent || hasSince || len(args) > 1) {
+		exitWithError(ExitError, "--supplement is only valid with a single paper ID")
+	}
+
+	// Collect paper IDs to open
+	var paperIDs []string
+
+	if hasIDs {
+		paperIDs = args
+	} else if hasRecent {
+		// Get N most recently added papers
+		gitRoot := mustFindGitRepo(repoRoot)
+		recentPapers, err := git.GetRecentlyAddedPapers(gitRoot, openRecent)
+		if err != nil {
+			exitWithError(ExitError, "getting recent papers: %v", err)
 		}
-		pdfPath = ref.SupplementPaths[idx]
-	} else {
-		pdfPath = ref.PDFPath
-		if pdfPath == "" {
-			exitWithError(ExitError, "no PDF path for reference: %s", id)
+		for _, rp := range recentPapers {
+			paperIDs = append(paperIDs, rp.Reference.ID)
+		}
+		if len(paperIDs) == 0 {
+			exitWithError(ExitError, "no recently added papers found")
+		}
+	} else if hasSince {
+		// Get papers added since commit
+		gitRoot := mustFindGitRepo(repoRoot)
+		mustValidateCommit(gitRoot, openSince)
+		addedPapers, err := git.GetPapersAddedSince(gitRoot, openSince)
+		if err != nil {
+			exitWithError(ExitError, "getting papers since %s: %v", openSince, err)
+		}
+		for _, rp := range addedPapers {
+			paperIDs = append(paperIDs, rp.Reference.ID)
+		}
+		if len(paperIDs) == 0 {
+			exitWithError(ExitError, "no papers added since %s", openSince)
 		}
 	}
 
-	// Create opener and resolve path
+	// Open papers
 	opener := pdf.NewOpener(cfg.PDFRoot, cfg.PDFReader)
-	fullPath, err := opener.ResolvePath(pdfPath)
-	if err != nil {
-		exitWithError(ExitError, "%v", err)
+	var opened []OpenedPaper
+	var errors []OpenError
+
+	for _, id := range paperIDs {
+		ref, err := db.GetByID(id)
+		if err != nil {
+			errors = append(errors, OpenError{ID: id, Error: fmt.Sprintf("getting reference: %v", err)})
+			continue
+		}
+		if ref == nil {
+			errors = append(errors, OpenError{ID: id, Error: "reference not found"})
+			continue
+		}
+
+		// Determine which PDF to open
+		var pdfPath string
+		if openSupplement > 0 {
+			idx := openSupplement - 1 // Convert to 0-indexed
+			if idx >= len(ref.SupplementPaths) {
+				errors = append(errors, OpenError{ID: id, Error: fmt.Sprintf("no supplement at index %d (have %d supplements)", openSupplement, len(ref.SupplementPaths))})
+				continue
+			}
+			pdfPath = ref.SupplementPaths[idx]
+		} else {
+			pdfPath = ref.PDFPath
+			if pdfPath == "" {
+				errors = append(errors, OpenError{ID: id, Error: "no PDF path"})
+				continue
+			}
+		}
+
+		// Resolve and open
+		fullPath, err := opener.ResolvePath(pdfPath)
+		if err != nil {
+			errors = append(errors, OpenError{ID: id, Error: fmt.Sprintf("PDF not found: %s", pdfPath)})
+			continue
+		}
+
+		if err := opener.Open(fullPath); err != nil {
+			errors = append(errors, OpenError{ID: id, Error: fmt.Sprintf("opening PDF: %v", err)})
+			continue
+		}
+
+		opened = append(opened, OpenedPaper{ID: id, Path: fullPath})
 	}
 
-	// Open the PDF
-	if err := opener.Open(fullPath); err != nil {
-		exitWithError(ExitError, "opening PDF: %v", err)
+	// Check if at least one paper was opened
+	if len(opened) == 0 {
+		// All failed
+		if humanOutput {
+			fmt.Fprintf(cmd.ErrOrStderr(), "Failed to open any papers:\n")
+			for _, e := range errors {
+				fmt.Fprintf(cmd.ErrOrStderr(), "  %s: %s\n", e.ID, e.Error)
+			}
+		} else {
+			outputJSON(OpenMultipleResult{Errors: errors})
+		}
+		return exitErrorSilent(ExitError)
 	}
 
-	// Output success
+	// Output results
 	if humanOutput {
-		fmt.Printf("Opening: %s\n", pdfPath)
+		fmt.Printf("Opening %d paper(s):\n", len(opened))
+		for _, o := range opened {
+			fmt.Printf("  \u2713 %s: %s\n", o.ID, o.Path)
+		}
+		for _, e := range errors {
+			fmt.Printf("  \u2717 %s: %s\n", e.ID, e.Error)
+		}
 	} else {
-		outputJSON(OpenResult{
-			Status: "opened",
-			Path:   fullPath,
+		outputJSON(OpenMultipleResult{
+			Opened: opened,
+			Errors: errors,
 		})
 	}
 
 	return nil
+}
+
+// exitErrorSilent returns an error that signals the exit code without printing a message.
+type silentExitError struct {
+	code int
+}
+
+func (e silentExitError) Error() string {
+	return ""
+}
+
+func exitErrorSilent(code int) error {
+	return silentExitError{code: code}
 }

--- a/cmd/bip/types.go
+++ b/cmd/bip/types.go
@@ -1,0 +1,57 @@
+package main
+
+// OpenMultipleResult is the JSON response for opening multiple papers.
+type OpenMultipleResult struct {
+	Opened []OpenedPaper `json:"opened"`
+	Errors []OpenError   `json:"errors,omitempty"`
+}
+
+// OpenedPaper represents a successfully opened paper.
+type OpenedPaper struct {
+	ID   string `json:"id"`
+	Path string `json:"path"`
+}
+
+// OpenError represents an error opening a specific paper.
+type OpenError struct {
+	ID    string `json:"id"`
+	Error string `json:"error"`
+}
+
+// DiffResult is the JSON response for bip diff.
+type DiffResult struct {
+	Added   []DiffPaper `json:"added"`
+	Removed []DiffPaper `json:"removed"`
+}
+
+// DiffPaper represents a paper in diff output.
+type DiffPaper struct {
+	ID      string `json:"id"`
+	Title   string `json:"title"`
+	Authors string `json:"authors"` // Formatted as "Last1, Last2, ..."
+	Year    int    `json:"year"`
+}
+
+// NewPapersResult is the JSON response for bip new.
+type NewPapersResult struct {
+	Papers     []NewPaper `json:"papers"`
+	SinceRef   string     `json:"since_ref,omitempty"` // Commit SHA or "N days ago"
+	TotalCount int        `json:"total_count"`
+}
+
+// NewPaper represents a paper in the new papers output.
+type NewPaper struct {
+	ID        string `json:"id"`
+	Title     string `json:"title"`
+	Authors   string `json:"authors"`
+	Year      int    `json:"year"`
+	CommitSHA string `json:"commit_sha,omitempty"` // When paper was added
+}
+
+// ExportResult is the JSON response for bip export with --append.
+type ExportResult struct {
+	Exported   int      `json:"exported"`              // Number of entries written
+	Skipped    int      `json:"skipped"`               // Number of duplicates skipped
+	SkippedIDs []string `json:"skipped_ids,omitempty"` // IDs that were duplicates
+	OutputPath string   `json:"output_path,omitempty"` // When --append used
+}

--- a/internal/export/bibtex_parse.go
+++ b/internal/export/bibtex_parse.go
@@ -1,0 +1,107 @@
+package export
+
+import (
+	"bufio"
+	"os"
+	"regexp"
+	"strings"
+)
+
+// BibTeXIndex indexes existing BibTeX entries for deduplication.
+type BibTeXIndex struct {
+	// Keys maps citation keys to true for existence check
+	Keys map[string]bool
+	// DOIs maps DOI values to citation keys
+	DOIs map[string]string
+}
+
+// NewBibTeXIndex creates an empty BibTeX index.
+func NewBibTeXIndex() *BibTeXIndex {
+	return &BibTeXIndex{
+		Keys: make(map[string]bool),
+		DOIs: make(map[string]string),
+	}
+}
+
+// HasEntry returns true if the entry already exists (by DOI or key).
+// DOI is the primary match; citation key is the fallback if no DOI.
+func (idx *BibTeXIndex) HasEntry(key, doi string) bool {
+	// Primary: match by DOI if available
+	if doi != "" {
+		if _, exists := idx.DOIs[normalizeDOI(doi)]; exists {
+			return true
+		}
+	}
+
+	// Fallback: match by citation key
+	return idx.Keys[key]
+}
+
+// ParseBibTeXFile builds an index from an existing .bib file.
+// Returns an empty index if the file doesn't exist or is empty.
+func ParseBibTeXFile(path string) (*BibTeXIndex, error) {
+	idx := NewBibTeXIndex()
+
+	file, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return idx, nil
+		}
+		return nil, err
+	}
+	defer file.Close()
+
+	// Regex patterns
+	// Match entry start: @type{key,
+	entryStartRegex := regexp.MustCompile(`@\w+\{([^,]+),`)
+	// Match DOI field: doi = {value} or doi = "value"
+	doiFieldRegex := regexp.MustCompile(`(?i)^\s*doi\s*=\s*[\{"]([^\}"]+)[\}"]`)
+
+	scanner := bufio.NewScanner(file)
+	var currentKey string
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// Check for entry start
+		if matches := entryStartRegex.FindStringSubmatch(line); len(matches) > 1 {
+			currentKey = strings.TrimSpace(matches[1])
+			idx.Keys[currentKey] = true
+		}
+
+		// Check for DOI field
+		if matches := doiFieldRegex.FindStringSubmatch(line); len(matches) > 1 {
+			doi := normalizeDOI(matches[1])
+			if doi != "" && currentKey != "" {
+				idx.DOIs[doi] = currentKey
+			}
+		}
+	}
+
+	return idx, scanner.Err()
+}
+
+// normalizeDOI normalizes a DOI for comparison.
+// Removes common prefixes like "https://doi.org/" and lowercases.
+func normalizeDOI(doi string) string {
+	doi = strings.TrimSpace(doi)
+	doi = strings.TrimPrefix(doi, "https://doi.org/")
+	doi = strings.TrimPrefix(doi, "http://doi.org/")
+	doi = strings.TrimPrefix(doi, "doi.org/")
+	doi = strings.TrimPrefix(doi, "DOI:")
+	doi = strings.TrimPrefix(doi, "doi:")
+	return strings.ToLower(doi)
+}
+
+// AppendToBibFile appends BibTeX content to a file.
+func AppendToBibFile(path, content string) error {
+	file, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	// Ensure we start on a new line
+	_, err = file.WriteString("\n" + content)
+	return err
+}

--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -1,0 +1,77 @@
+package git
+
+import (
+	"github.com/matsen/bipartite/internal/reference"
+)
+
+// DiffWorkingTree compares the working tree refs.jsonl to HEAD.
+// Returns papers added and removed since the last commit.
+func DiffWorkingTree(repoRoot string) (*GitDiff, error) {
+	// Get refs at HEAD
+	headRefs, err := GetRefsJSONLAtCommit(repoRoot, "HEAD")
+	if err != nil {
+		return nil, err
+	}
+
+	// Get current working tree refs
+	currentRefs, err := GetCurrentRefs(repoRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	return diffRefs(headRefs, currentRefs), nil
+}
+
+// DiffSince compares current refs.jsonl to a specific commit.
+// Returns papers added and removed since that commit.
+func DiffSince(repoRoot, commitRef string) (*GitDiff, error) {
+	// Get refs at the specified commit
+	oldRefs, err := GetRefsJSONLAtCommit(repoRoot, commitRef)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get current working tree refs
+	currentRefs, err := GetCurrentRefs(repoRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	return diffRefs(oldRefs, currentRefs), nil
+}
+
+// diffRefs computes the difference between two sets of references.
+// Returns papers in current but not old (added), and papers in old but not current (removed).
+func diffRefs(oldRefs, currentRefs []reference.Reference) *GitDiff {
+	// Build maps keyed by ID for efficient lookup
+	oldMap := make(map[string]reference.Reference, len(oldRefs))
+	for _, ref := range oldRefs {
+		oldMap[ref.ID] = ref
+	}
+
+	currentMap := make(map[string]reference.Reference, len(currentRefs))
+	for _, ref := range currentRefs {
+		currentMap[ref.ID] = ref
+	}
+
+	// Find added papers (in current but not old)
+	var added []reference.Reference
+	for id, ref := range currentMap {
+		if _, exists := oldMap[id]; !exists {
+			added = append(added, ref)
+		}
+	}
+
+	// Find removed papers (in old but not current)
+	var removed []reference.Reference
+	for id, ref := range oldMap {
+		if _, exists := currentMap[id]; !exists {
+			removed = append(removed, ref)
+		}
+	}
+
+	return &GitDiff{
+		Added:   added,
+		Removed: removed,
+	}
+}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1,0 +1,131 @@
+package git
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/matsen/bipartite/internal/reference"
+)
+
+// ErrNotGitRepo indicates the directory is not a git repository.
+var ErrNotGitRepo = errors.New("not a git repository")
+
+// ErrCommitNotFound indicates the specified commit does not exist.
+var ErrCommitNotFound = errors.New("commit not found")
+
+// ErrFileNotTracked indicates refs.jsonl is not tracked by git.
+var ErrFileNotTracked = errors.New("refs.jsonl not tracked by git")
+
+// FindRepoRoot finds the root of the git repository containing the given path.
+// Returns ErrNotGitRepo if not in a git repository.
+func FindRepoRoot(path string) (string, error) {
+	cmd := exec.Command("git", "-C", path, "rev-parse", "--show-toplevel")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", ErrNotGitRepo
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+// IsGitRepo checks if the given path is inside a git repository.
+func IsGitRepo(path string) bool {
+	_, err := FindRepoRoot(path)
+	return err == nil
+}
+
+// ValidateCommit verifies that a commit reference exists.
+// Supports SHA, HEAD, HEAD~N, branch names, tags, etc.
+// Returns the resolved full SHA or ErrCommitNotFound.
+func ValidateCommit(repoRoot, commitRef string) (string, error) {
+	cmd := exec.Command("git", "-C", repoRoot, "rev-parse", "--verify", commitRef+"^{commit}")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", ErrCommitNotFound
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+// GetRefsJSONLPath returns the path to refs.jsonl relative to repo root.
+func GetRefsJSONLPath() string {
+	return ".bipartite/refs.jsonl"
+}
+
+// GetRefsJSONLAtCommit retrieves the contents of refs.jsonl at a specific commit.
+// Returns ErrCommitNotFound if commit doesn't exist, or empty slice if file didn't exist at that commit.
+func GetRefsJSONLAtCommit(repoRoot, commitRef string) ([]reference.Reference, error) {
+	// First validate the commit exists
+	sha, err := ValidateCommit(repoRoot, commitRef)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get file contents at that commit
+	refsPath := GetRefsJSONLPath()
+	cmd := exec.Command("git", "-C", repoRoot, "show", sha+":"+refsPath)
+	output, err := cmd.Output()
+	if err != nil {
+		// File might not exist at that commit - return empty slice
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return []reference.Reference{}, nil
+		}
+		return nil, fmt.Errorf("getting refs.jsonl at %s: %w", commitRef, err)
+	}
+
+	return parseRefsJSONL(output)
+}
+
+// GetCurrentRefs reads the current refs.jsonl from the working tree.
+func GetCurrentRefs(repoRoot string) ([]reference.Reference, error) {
+	refsPath := filepath.Join(repoRoot, GetRefsJSONLPath())
+	data, err := os.ReadFile(refsPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []reference.Reference{}, nil
+		}
+		return nil, fmt.Errorf("reading refs.jsonl: %w", err)
+	}
+
+	return parseRefsJSONL(data)
+}
+
+// parseRefsJSONL parses JSONL content into a slice of references.
+func parseRefsJSONL(data []byte) ([]reference.Reference, error) {
+	var refs []reference.Reference
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	lineNum := 0
+	for scanner.Scan() {
+		lineNum++
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var ref reference.Reference
+		if err := json.Unmarshal([]byte(line), &ref); err != nil {
+			return nil, fmt.Errorf("parsing line %d: %w", lineNum, err)
+		}
+		refs = append(refs, ref)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scanning refs: %w", err)
+	}
+	return refs, nil
+}
+
+// IsFileTracked checks if refs.jsonl is tracked by git.
+func IsFileTracked(repoRoot string) bool {
+	refsPath := GetRefsJSONLPath()
+	cmd := exec.Command("git", "-C", repoRoot, "ls-files", refsPath)
+	output, err := cmd.Output()
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(output)) != ""
+}

--- a/internal/git/log.go
+++ b/internal/git/log.go
@@ -1,0 +1,310 @@
+package git
+
+import (
+	"bufio"
+	"bytes"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/matsen/bipartite/internal/reference"
+)
+
+// RecentPaper represents a recently added paper with its commit info.
+type RecentPaper struct {
+	Reference reference.Reference
+	CommitSHA string
+	CommitMsg string
+}
+
+// GetRecentlyAddedPapers returns the N most recently added papers.
+// "Recently added" is determined by git commit history on refs.jsonl.
+func GetRecentlyAddedPapers(repoRoot string, n int) ([]RecentPaper, error) {
+	// Get commits that touched refs.jsonl
+	commits, err := getCommitsTouchingRefs(repoRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(commits) == 0 {
+		return nil, nil
+	}
+
+	// Track papers we've seen and their commit info
+	seen := make(map[string]RecentPaper)
+	var result []RecentPaper
+
+	// Walk through commits from newest to oldest
+	for i := 0; i < len(commits); i++ {
+		commit := commits[i]
+
+		// Get refs at this commit
+		refsAtCommit, err := GetRefsJSONLAtCommit(repoRoot, commit.SHA)
+		if err != nil {
+			continue
+		}
+
+		// Get refs at parent commit (if any)
+		var refsAtParent []reference.Reference
+		if i+1 < len(commits) {
+			refsAtParent, _ = GetRefsJSONLAtCommit(repoRoot, commits[i+1].SHA)
+		}
+
+		// Build parent map for efficient lookup
+		parentMap := make(map[string]bool, len(refsAtParent))
+		for _, ref := range refsAtParent {
+			parentMap[ref.ID] = true
+		}
+
+		// Find papers added in this commit
+		for _, ref := range refsAtCommit {
+			if _, wasSeen := seen[ref.ID]; !wasSeen {
+				if !parentMap[ref.ID] {
+					// This paper was added in this commit
+					rp := RecentPaper{
+						Reference: ref,
+						CommitSHA: shortSHA(commit.SHA),
+						CommitMsg: commit.Message,
+					}
+					seen[ref.ID] = rp
+					result = append(result, rp)
+					if len(result) >= n {
+						return result, nil
+					}
+				}
+			}
+		}
+	}
+
+	return result, nil
+}
+
+// GetPapersAddedSince returns papers added since a specific commit.
+func GetPapersAddedSince(repoRoot, commitRef string) ([]RecentPaper, error) {
+	// Validate commit
+	_, err := ValidateCommit(repoRoot, commitRef)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get commits between commitRef and HEAD that touched refs.jsonl
+	commits, err := getCommitsSince(repoRoot, commitRef)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(commits) == 0 {
+		return nil, nil
+	}
+
+	// Get refs at the starting commit
+	refsAtStart, err := GetRefsJSONLAtCommit(repoRoot, commitRef)
+	if err != nil {
+		return nil, err
+	}
+	startMap := make(map[string]bool, len(refsAtStart))
+	for _, ref := range refsAtStart {
+		startMap[ref.ID] = true
+	}
+
+	// Get current refs
+	currentRefs, err := GetCurrentRefs(repoRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	// Find papers added since the starting commit
+	var result []RecentPaper
+	seen := make(map[string]bool)
+
+	for _, ref := range currentRefs {
+		if !startMap[ref.ID] && !seen[ref.ID] {
+			seen[ref.ID] = true
+			// Find which commit added this paper
+			commitSHA := findCommitThatAdded(repoRoot, ref.ID, commits)
+			result = append(result, RecentPaper{
+				Reference: ref,
+				CommitSHA: commitSHA,
+			})
+		}
+	}
+
+	return result, nil
+}
+
+// GetPapersAddedInDays returns papers that exist in the current refs
+// and were added to the repository within the last N days.
+func GetPapersAddedInDays(repoRoot string, days int) ([]RecentPaper, error) {
+	// Calculate the cutoff time
+	cutoff := time.Now().UTC().AddDate(0, 0, -days)
+
+	// Get commits since cutoff that touched refs.jsonl
+	commits, err := getCommitsSinceTime(repoRoot, cutoff)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(commits) == 0 {
+		return nil, nil
+	}
+
+	// Get refs at the earliest commit in our range (or empty if none before)
+	var refsAtStart []reference.Reference
+	// Find earliest commit before our range
+	earliestCommit, err := getEarliestCommitBefore(repoRoot, cutoff)
+	if err == nil && earliestCommit != "" {
+		refsAtStart, _ = GetRefsJSONLAtCommit(repoRoot, earliestCommit)
+	}
+
+	startMap := make(map[string]bool, len(refsAtStart))
+	for _, ref := range refsAtStart {
+		startMap[ref.ID] = true
+	}
+
+	// Get current refs
+	currentRefs, err := GetCurrentRefs(repoRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	// Find papers added since the cutoff
+	var result []RecentPaper
+	seen := make(map[string]bool)
+
+	for _, ref := range currentRefs {
+		if !startMap[ref.ID] && !seen[ref.ID] {
+			seen[ref.ID] = true
+			commitSHA := findCommitThatAdded(repoRoot, ref.ID, commits)
+			result = append(result, RecentPaper{
+				Reference: ref,
+				CommitSHA: commitSHA,
+			})
+		}
+	}
+
+	return result, nil
+}
+
+// getCommitsTouchingRefs returns commits that touched refs.jsonl, newest first.
+func getCommitsTouchingRefs(repoRoot string) ([]CommitInfo, error) {
+	refsPath := GetRefsJSONLPath()
+	cmd := exec.Command("git", "-C", repoRoot, "log", "--oneline", "--follow", "--", refsPath)
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, nil // No commits or file not tracked
+	}
+
+	return parseGitLogOneline(output), nil
+}
+
+// getCommitsSince returns commits between commitRef and HEAD that touched refs.jsonl.
+func getCommitsSince(repoRoot, commitRef string) ([]CommitInfo, error) {
+	refsPath := GetRefsJSONLPath()
+	cmd := exec.Command("git", "-C", repoRoot, "log", "--oneline", commitRef+"..HEAD", "--", refsPath)
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, nil
+	}
+	return parseGitLogOneline(output), nil
+}
+
+// getCommitsSinceTime returns commits since a specific time that touched refs.jsonl.
+func getCommitsSinceTime(repoRoot string, since time.Time) ([]CommitInfo, error) {
+	refsPath := GetRefsJSONLPath()
+	sinceStr := since.Format("2006-01-02")
+	cmd := exec.Command("git", "-C", repoRoot, "log", "--oneline", "--since="+sinceStr, "--", refsPath)
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, nil
+	}
+	return parseGitLogOneline(output), nil
+}
+
+// getEarliestCommitBefore returns the earliest commit touching refs.jsonl before the given time.
+func getEarliestCommitBefore(repoRoot string, before time.Time) (string, error) {
+	refsPath := GetRefsJSONLPath()
+	beforeStr := before.Format("2006-01-02")
+	cmd := exec.Command("git", "-C", repoRoot, "log", "--oneline", "--until="+beforeStr, "-1", "--", refsPath)
+	output, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	commits := parseGitLogOneline(output)
+	if len(commits) == 0 {
+		return "", nil
+	}
+	return commits[0].SHA, nil
+}
+
+// findCommitThatAdded finds the commit that added a specific paper ID.
+func findCommitThatAdded(repoRoot, paperID string, commits []CommitInfo) string {
+	// Walk commits from newest to oldest
+	for i := 0; i < len(commits); i++ {
+		commit := commits[i]
+		refsAtCommit, err := GetRefsJSONLAtCommit(repoRoot, commit.SHA)
+		if err != nil {
+			continue
+		}
+
+		// Check if paper exists at this commit
+		hasAtCommit := false
+		for _, ref := range refsAtCommit {
+			if ref.ID == paperID {
+				hasAtCommit = true
+				break
+			}
+		}
+
+		if !hasAtCommit {
+			// Paper doesn't exist at this commit, so it was added after
+			if i > 0 {
+				return shortSHA(commits[i-1].SHA)
+			}
+			return ""
+		}
+	}
+
+	// Paper existed at earliest commit in range
+	if len(commits) > 0 {
+		return shortSHA(commits[len(commits)-1].SHA)
+	}
+	return ""
+}
+
+// shortSHA returns a short version of a SHA (up to 8 chars).
+func shortSHA(sha string) string {
+	if len(sha) > 8 {
+		return sha[:8]
+	}
+	return sha
+}
+
+// parseGitLogOneline parses git log --oneline output.
+func parseGitLogOneline(data []byte) []CommitInfo {
+	var commits []CommitInfo
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, " ", 2)
+		if len(parts) < 1 {
+			continue
+		}
+		ci := CommitInfo{SHA: parts[0]}
+		if len(parts) > 1 {
+			ci.Message = parts[1]
+		}
+		commits = append(commits, ci)
+	}
+	return commits
+}
+
+// SortRefsAlphabetically sorts references by ID for deterministic output.
+func SortRefsAlphabetically(refs []reference.Reference) {
+	sort.Slice(refs, func(i, j int) bool {
+		return refs[i].ID < refs[j].ID
+	})
+}

--- a/internal/git/types.go
+++ b/internal/git/types.go
@@ -1,0 +1,16 @@
+// Package git provides git integration for tracking repository history.
+package git
+
+import "github.com/matsen/bipartite/internal/reference"
+
+// GitDiff represents changes to refs.jsonl between two git states.
+type GitDiff struct {
+	Added   []reference.Reference
+	Removed []reference.Reference
+}
+
+// CommitInfo represents information about a git commit.
+type CommitInfo struct {
+	SHA     string
+	Message string
+}

--- a/specs/008-shared-repo-workflow/checklists/requirements.md
+++ b/specs/008-shared-repo-workflow/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Shared Repository Workflow Commands
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-01-21
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Spec is ready for `/speckit.clarify` or `/speckit.plan`
+- All 19 functional requirements are testable
+- 6 edge cases identified for consideration during implementation
+- Clear out-of-scope boundaries defined (references issue #18 for conflict resolution)

--- a/specs/008-shared-repo-workflow/contracts/cli.md
+++ b/specs/008-shared-repo-workflow/contracts/cli.md
@@ -1,0 +1,339 @@
+# CLI Contract: Shared Repository Workflow Commands
+
+## Overview
+
+This document specifies the CLI interface for the shared repository workflow commands. All commands follow existing bip conventions:
+- JSON output by default
+- `--human` flag for readable output
+- Exit codes per `cmd/bip/exitcodes.go`
+
+---
+
+## bip open (Enhanced)
+
+### Synopsis
+```
+bip open <id>... [flags]
+bip open --recent N [flags]
+bip open --since <commit> [flags]
+```
+
+### Description
+Open one or more papers' PDFs in the configured viewer. Supports opening multiple papers by ID, the N most recently added papers, or papers added since a specific git commit.
+
+### Arguments
+| Argument | Type | Required | Description |
+|----------|------|----------|-------------|
+| `<id>...` | string | Conditional | One or more paper IDs (mutually exclusive with --recent/--since) |
+
+### Flags
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--recent` | int | 0 | Open the N most recently added papers |
+| `--since` | string | "" | Open papers added after this git commit |
+| `--supplement` | int | 0 | Open Nth supplementary PDF (1-indexed) |
+| `--human` | bool | false | Human-readable output |
+
+### Mutual Exclusivity
+- Positional IDs, `--recent`, and `--since` are mutually exclusive
+- `--supplement` only valid with single ID
+
+### Exit Codes
+| Code | Condition |
+|------|-----------|
+| 0 | At least one PDF opened successfully |
+| 1 | No papers found, all PDFs missing, or other error |
+| 2 | Configuration error (pdf_root not set) |
+
+### JSON Output
+```json
+{
+  "opened": [
+    {"id": "Smith2024-ab", "path": "/full/path/to/paper.pdf"}
+  ],
+  "errors": [
+    {"id": "Jones2023-xy", "error": "PDF not found: papers/jones2023.pdf"}
+  ]
+}
+```
+
+### Human Output
+```
+Opening 3 papers:
+  ✓ Smith2024-ab: papers/smith2024.pdf
+  ✓ Lee2024-cd: papers/lee2024.pdf
+  ✗ Jones2023-xy: PDF not found
+```
+
+### Examples
+```bash
+# Open specific papers
+bip open Smith2024-ab Jones2023-xy Lee2024-cd
+
+# Open 5 most recent papers
+bip open --recent 5
+
+# Open papers added since last pull
+bip open --since HEAD~3
+
+# Open papers since a specific commit
+bip open --since abc123f
+```
+
+---
+
+## bip diff
+
+### Synopsis
+```
+bip diff [flags]
+```
+
+### Description
+Show papers added or removed in the working tree compared to the last commit. Useful for reviewing uncommitted changes before committing.
+
+### Flags
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--human` | bool | false | Human-readable output |
+
+### Exit Codes
+| Code | Condition |
+|------|-----------|
+| 0 | Success (even if no changes) |
+| 1 | Error reading refs or git state |
+
+### JSON Output
+```json
+{
+  "added": [
+    {"id": "Smith2024-ab", "title": "A New Method...", "authors": "Smith, Jones", "year": 2024}
+  ],
+  "removed": [
+    {"id": "Old2020-xy", "title": "Deprecated Paper", "authors": "Old", "year": 2020}
+  ]
+}
+```
+
+### Human Output
+```
+Changes since last commit:
+
+Added (2):
+  + Smith2024-ab: A New Method for... (Smith, Jones, 2024)
+  + Lee2024-cd: Deep Learning in... (Lee et al., 2024)
+
+Removed (1):
+  - Old2020-xy: Deprecated Paper (Old, 2020)
+```
+
+### Examples
+```bash
+# Show uncommitted changes (JSON)
+bip diff
+
+# Show uncommitted changes (human-readable)
+bip diff --human
+```
+
+---
+
+## bip new
+
+### Synopsis
+```
+bip new --since <commit> [flags]
+bip new --days N [flags]
+```
+
+### Description
+List papers added to the repository since a specific commit or within the last N days. Useful for tracking new additions from collaborators after pulling updates.
+
+### Flags
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--since` | string | "" | List papers added after this git commit |
+| `--days` | int | 0 | List papers added within last N days (UTC) |
+| `--human` | bool | false | Human-readable output |
+
+### Mutual Exclusivity
+- `--since` and `--days` are mutually exclusive
+- One of them must be provided
+
+### Exit Codes
+| Code | Condition |
+|------|-----------|
+| 0 | Success (even if no new papers) |
+| 1 | Invalid commit reference or other error |
+
+### JSON Output
+```json
+{
+  "papers": [
+    {
+      "id": "Smith2024-ab",
+      "title": "A New Method for Phylogenetic Analysis",
+      "authors": "Smith, Jones",
+      "year": 2024,
+      "commit_sha": "abc123f"
+    }
+  ],
+  "since_ref": "def456a",
+  "total_count": 1
+}
+```
+
+### Human Output
+```
+Papers added since def456a:
+
+  Smith2024-ab: A New Method for Phylogenetic Analysis
+    Smith, Jones (2024)
+    Added in commit abc123f
+
+  Lee2024-cd: Deep Learning Approaches to...
+    Lee, Kim, Park (2024)
+    Added in commit abc123f
+
+2 papers added
+```
+
+### Examples
+```bash
+# Papers since a specific commit
+bip new --since abc123f
+
+# Papers added in last 7 days
+bip new --days 7
+
+# Papers since last week (human-readable)
+bip new --days 7 --human
+```
+
+---
+
+## bip export --bibtex (Enhanced)
+
+### Synopsis
+```
+bip export --bibtex [<id>...] [flags]
+bip export --bibtex --append <file> [<id>...] [flags]
+```
+
+### Description
+Export papers to BibTeX format. Can export all papers, specific papers by ID, or append to an existing .bib file with automatic deduplication.
+
+### Arguments
+| Argument | Type | Required | Description |
+|----------|------|----------|-------------|
+| `<id>...` | string | No | Paper IDs to export (default: all papers) |
+
+### Flags
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--bibtex` | bool | false | Export to BibTeX format (required) |
+| `--append` | string | "" | Append to existing .bib file (with deduplication) |
+| `--keys` | string | "" | Legacy: comma-separated IDs (deprecated, use positional args) |
+
+### Exit Codes
+| Code | Condition |
+|------|-----------|
+| 0 | Success |
+| 1 | Paper not found, file error, or other error |
+
+### Output Behavior
+- **Without --append**: BibTeX written to stdout (no JSON wrapper)
+- **With --append**: JSON response with statistics
+
+### JSON Output (with --append)
+```json
+{
+  "exported": 3,
+  "skipped": 1,
+  "skipped_ids": ["Smith2024-ab"],
+  "output_path": "/path/to/refs.bib"
+}
+```
+
+### BibTeX Output (without --append)
+```bibtex
+@article{Smith2024-ab,
+  author = {Smith, John and Jones, Jane},
+  title = {A New Method for Phylogenetic Analysis},
+  journal = {Systematic Biology},
+  year = {2024},
+  doi = {10.1093/sysbio/example},
+}
+
+@article{Lee2024-cd,
+  ...
+}
+```
+
+### Deduplication Rules (--append mode)
+1. Match by DOI (primary): Skip if DOI exists in .bib file
+2. Match by citation key (fallback): Skip if key exists and entry has no DOI
+3. Entries without DOI in library are deduplicated by key only
+
+### Examples
+```bash
+# Export all papers to stdout
+bip export --bibtex > refs.bib
+
+# Export specific papers
+bip export --bibtex Smith2024-ab Lee2024-cd
+
+# Append to existing file with deduplication
+bip export --bibtex --append refs.bib Smith2024-ab Lee2024-cd
+
+# Export single paper for citation
+bip export --bibtex Smith2024-ab
+```
+
+---
+
+## Error Messages
+
+All error messages follow FR-019 (actionable with resolution hints).
+
+### bip open
+```
+error: reference not found: Smith2024-ab
+  Hint: Use 'bip list' to see available references
+
+error: pdf_root not configured
+  Hint: Use 'bip config pdf-root /path/to/pdfs' to set the PDF directory
+
+error: commit not found: xyz789
+  Hint: Verify the commit exists with 'git log --oneline'
+```
+
+### bip diff
+```
+error: not in a git repository
+  Hint: Initialize with 'git init' or navigate to a git repository
+
+error: refs.jsonl not tracked by git
+  Hint: Run 'git add .bipartite/refs.jsonl' to track the file
+```
+
+### bip new
+```
+error: commit not found: xyz789
+  Hint: Verify the commit exists with 'git log --oneline'
+
+error: --since or --days flag required
+  Hint: Use 'bip new --since <commit>' or 'bip new --days N'
+```
+
+### bip export
+```
+error: unknown key: Smith2024-ab
+  Hint: Use 'bip list' to see available references
+
+error: cannot read file: refs.bib
+  Hint: Check file exists and has read permissions
+
+error: cannot write to file: refs.bib
+  Hint: Check file has write permissions
+```

--- a/specs/008-shared-repo-workflow/data-model.md
+++ b/specs/008-shared-repo-workflow/data-model.md
@@ -1,0 +1,219 @@
+# Data Model: Shared Repository Workflow Commands
+
+## Overview
+
+This feature primarily uses existing entities (Reference, BibTeX Entry) with new response types for command outputs. No schema changes to persistent storage (refs.jsonl, SQLite) are required.
+
+---
+
+## Existing Entities (No Changes)
+
+### Reference
+Source: `internal/reference/reference.go`
+
+```go
+type Reference struct {
+    ID              string          `json:"id"`
+    DOI             string          `json:"doi"`
+    Title           string          `json:"title"`
+    Authors         []Author        `json:"authors"`
+    Abstract        string          `json:"abstract"`
+    Venue           string          `json:"venue"`
+    Published       PublicationDate `json:"published"`
+    PDFPath         string          `json:"pdf_path"`
+    SupplementPaths []string        `json:"supplement_paths,omitempty"`
+    Source          ImportSource    `json:"source"`
+    Supersedes      string          `json:"supersedes,omitempty"`
+}
+```
+
+Used by: All commands in this feature
+
+### BibTeX Entry (Output Format)
+Source: `internal/export/bibtex.go`
+
+Existing `ToBibTeX()` function produces valid BibTeX. No structural changes needed.
+
+---
+
+## New Response Types
+
+### OpenMultipleResult
+For `bip open` with multiple papers.
+
+```go
+// OpenMultipleResult is the JSON response for opening multiple papers.
+type OpenMultipleResult struct {
+    Opened []OpenedPaper `json:"opened"`
+    Errors []OpenError   `json:"errors,omitempty"`
+}
+
+type OpenedPaper struct {
+    ID   string `json:"id"`
+    Path string `json:"path"`
+}
+
+type OpenError struct {
+    ID    string `json:"id"`
+    Error string `json:"error"`
+}
+```
+
+**Validation Rules**:
+- At least one paper must be opened successfully, or exit with error
+- Errors array populated for papers with missing PDFs (FR-004)
+
+### DiffResult
+For `bip diff` showing uncommitted changes.
+
+```go
+// DiffResult is the JSON response for bip diff.
+type DiffResult struct {
+    Added   []DiffPaper `json:"added"`
+    Removed []DiffPaper `json:"removed"`
+}
+
+type DiffPaper struct {
+    ID      string `json:"id"`
+    Title   string `json:"title"`
+    Authors string `json:"authors"` // Formatted as "Last1, Last2, ..."
+    Year    int    `json:"year"`
+}
+```
+
+**Validation Rules**:
+- Empty arrays (not null) when no changes
+- Papers sorted by ID for deterministic output
+
+### NewPapersResult
+For `bip new --since` and `bip new --days`.
+
+```go
+// NewPapersResult is the JSON response for bip new.
+type NewPapersResult struct {
+    Papers     []NewPaper `json:"papers"`
+    SinceRef   string     `json:"since_ref,omitempty"`   // Commit SHA or "N days ago"
+    TotalCount int        `json:"total_count"`
+}
+
+type NewPaper struct {
+    ID        string `json:"id"`
+    Title     string `json:"title"`
+    Authors   string `json:"authors"`
+    Year      int    `json:"year"`
+    CommitSHA string `json:"commit_sha,omitempty"` // When paper was added
+}
+```
+
+**Validation Rules**:
+- Empty papers array (not null) when no new papers
+- CommitSHA populated when available from git history
+
+### ExportResult
+Extended response for `bip export --bibtex` with `--append`.
+
+```go
+// ExportResult is the JSON response for bip export with --append.
+type ExportResult struct {
+    Exported   int      `json:"exported"`    // Number of entries written
+    Skipped    int      `json:"skipped"`     // Number of duplicates skipped
+    SkippedIDs []string `json:"skipped_ids,omitempty"` // IDs that were duplicates
+    OutputPath string   `json:"output_path,omitempty"` // When --append used
+}
+```
+
+**Validation Rules**:
+- Without --append: BibTeX written to stdout (no JSON response)
+- With --append: JSON response with stats
+
+---
+
+## Internal Types
+
+### BibTeXIndex
+For deduplication during append operations.
+
+```go
+// BibTeXIndex indexes existing BibTeX entries for deduplication.
+type BibTeXIndex struct {
+    // Keys maps citation keys to true for existence check
+    Keys map[string]bool
+    // DOIs maps DOI values to citation keys
+    DOIs map[string]string
+}
+
+// HasEntry returns true if the entry already exists (by DOI or key).
+func (idx *BibTeXIndex) HasEntry(key, doi string) bool
+
+// ParseFile builds an index from an existing .bib file.
+func ParseBibTeXFile(path string) (*BibTeXIndex, error)
+```
+
+### GitDiff
+Internal representation of refs.jsonl changes.
+
+```go
+// GitDiff represents changes to refs.jsonl between two git states.
+type GitDiff struct {
+    Added   []reference.Reference
+    Removed []reference.Reference
+}
+
+// DiffWorkingTree compares working tree to HEAD.
+func DiffWorkingTree(repoRoot string) (*GitDiff, error)
+
+// DiffSince compares current state to a specific commit.
+func DiffSince(repoRoot, commitRef string) (*GitDiff, error)
+```
+
+---
+
+## State Transitions
+
+### Reference Lifecycle (Existing)
+```
+[not in library] --import/s2 add--> [in refs.jsonl] --rebuild--> [in SQLite]
+```
+
+No changes to this lifecycle.
+
+### BibTeX Append Operation
+```
+[Paper ID] --lookup--> [Reference] --ToBibTeX--> [BibTeX Entry]
+                                                      |
+                                                      v
+[Existing .bib] --ParseBibTeXFile--> [BibTeXIndex] --HasEntry?--> [skip/append]
+```
+
+---
+
+## Entity Relationships
+
+```
+┌─────────────────┐
+│   Reference     │
+│   (refs.jsonl)  │
+└────────┬────────┘
+         │
+    ┌────┴────┐
+    │         │
+    v         v
+┌───────┐ ┌──────────┐
+│ open  │ │ export   │
+│ diff  │ │ --bibtex │
+│ new   │ └────┬─────┘
+└───────┘      │
+               v
+         ┌───────────┐
+         │ BibTeXIndex│
+         │ (.bib file)│
+         └───────────┘
+```
+
+---
+
+## Notes
+
+1. **No persistent storage changes**: All new types are response/internal only
+2. **Git is the source of truth for history**: Paper addition times derived from git log, not stored in refs.jsonl
+3. **BibTeX parsing is read-only**: We parse existing .bib files but don't modify their structure, only append

--- a/specs/008-shared-repo-workflow/plan.md
+++ b/specs/008-shared-repo-workflow/plan.md
@@ -1,0 +1,122 @@
+# Implementation Plan: Shared Repository Workflow Commands
+
+**Branch**: `008-shared-repo-workflow` | **Date**: 2026-01-21 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/008-shared-repo-workflow/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/commands/plan.md` for the execution workflow.
+
+## Summary
+
+Add three command groups to support teams sharing a paper library via git:
+1. **bip open** enhancements: Open multiple papers by ID, with `--recent N` and `--since <commit>` flags
+2. **bip diff / bip new**: Track papers added/removed since last commit or a specific commit
+3. **bip export --bibtex** enhancements: Export specific papers with optional `--append` mode and deduplication
+
+Technical approach: Extend existing cobra commands with git integration for commit-based filtering, modify PDF opener to support multiple files, and add BibTeX parsing for deduplication during append operations.
+
+## Technical Context
+
+**Language/Version**: Go 1.25.5 (matches existing codebase)
+**Primary Dependencies**: spf13/cobra (CLI), modernc.org/sqlite (storage), os/exec (git integration)
+**Storage**: JSONL (refs.jsonl) + ephemeral SQLite (rebuilt on `bip rebuild`) - no schema changes needed
+**Testing**: go test with real fixtures from testdata/
+**Target Platform**: macOS, Linux (consistent with existing platform support)
+**Project Type**: Single CLI application
+**Performance Goals**: SC-001: Open 5 papers < 3s, SC-003: Export single paper < 1s
+**Constraints**: CLI startup < 100ms (constitution), git must be available on PATH
+**Scale/Scope**: Commands for typical research library (100-1000 papers)
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Agent-First Design | ✅ PASS | JSON default, --human flag, CLI-only interface |
+| II. Git-Versionable Architecture | ✅ PASS | Reads from JSONL/SQLite, git for commit filtering, no new persistent state |
+| III. Fail-Fast Philosophy | ✅ PASS | FR-019: Actionable error messages, no silent defaults |
+| IV. Real Testing | ✅ PASS | Will use real fixtures, no mocks planned |
+| V. Clean Architecture | ✅ PASS | Single responsibility per command, extend existing packages |
+| VI. Simplicity | ✅ PASS | Minimal new dependencies (git already assumed), no premature abstraction |
+
+**Technology Constraints**:
+- CLI Responsiveness: ✅ Go compiled, instant startup
+- Embeddable Over Client-Server: ✅ No new external services (git is called via exec)
+- Data Portability: ✅ JSONL source of truth preserved, classic BibTeX output (FR-015)
+- Platform Support: ✅ macOS and Linux via existing pdf.Opener
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/008-shared-repo-workflow/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── contracts/           # Phase 1 output (/speckit.plan command)
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+
+```text
+cmd/bip/
+├── open.go              # MODIFY: Multi-paper open, --recent, --since
+├── export.go            # MODIFY: Positional IDs, --append mode
+├── diff.go              # NEW: bip diff command
+├── new.go               # NEW: bip new command
+└── git_helpers.go       # NEW: Shared git operations
+
+internal/
+├── export/
+│   ├── bibtex.go        # MODIFY: Add BibTeX parsing for deduplication
+│   └── bibtex_test.go   # MODIFY: Add parse/dedupe tests
+├── git/
+│   └── git.go           # NEW: Git operations package (refs diff, commit lookup)
+├── pdf/
+│   └── opener.go        # No changes needed (already supports single file open)
+└── storage/
+    └── sqlite.go        # MODIFY: Add query for papers by commit timestamp (if needed)
+
+tests/
+└── testdata/            # Add fixtures for git diff scenarios, .bib files
+```
+
+**Structure Decision**: Follows existing Go CLI structure. New commands in `cmd/bip/`, shared git logic in new `internal/git/` package (consistent with `internal/s2/`, `internal/asta/` pattern). Minimal changes to existing packages.
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+No violations. All design decisions align with constitution principles.
+
+---
+
+## Post-Design Constitution Re-Check
+
+*Verified after Phase 1 design artifacts completed.*
+
+| Principle | Status | Post-Design Notes |
+|-----------|--------|-------------------|
+| I. Agent-First Design | ✅ PASS | All commands output JSON by default per contracts/cli.md |
+| II. Git-Versionable Architecture | ✅ PASS | No new persistent state; git used read-only for history queries |
+| III. Fail-Fast Philosophy | ✅ PASS | Error messages defined in contracts/cli.md with actionable hints |
+| IV. Real Testing | ✅ PASS | quickstart.md includes test scenarios with real commands |
+| V. Clean Architecture | ✅ PASS | New `internal/git/` package has single responsibility; data-model.md defines clear types |
+| VI. Simplicity | ✅ PASS | BibTeX parsing is minimal regex (research.md); no new dependencies added |
+
+**Gate Status**: ✅ PASSED - Ready for Phase 2 task generation
+
+---
+
+## Generated Artifacts
+
+| Artifact | Path | Status |
+|----------|------|--------|
+| Research | [research.md](research.md) | ✅ Complete |
+| Data Model | [data-model.md](data-model.md) | ✅ Complete |
+| CLI Contract | [contracts/cli.md](contracts/cli.md) | ✅ Complete |
+| Quickstart | [quickstart.md](quickstart.md) | ✅ Complete |
+| Tasks | tasks.md | ⏳ Pending (use `/speckit.tasks`) |

--- a/specs/008-shared-repo-workflow/quickstart.md
+++ b/specs/008-shared-repo-workflow/quickstart.md
@@ -1,0 +1,144 @@
+# Quickstart: Shared Repository Workflow Commands
+
+## Prerequisites
+
+- Go 1.25.5+ installed
+- Git available on PATH
+- Existing bipartite repository with papers
+- PDF root configured (`bip config pdf-root`)
+
+## Build
+
+```bash
+go build -o bip ./cmd/bip
+```
+
+## Common Workflows
+
+### 1. Review Papers After Pulling Updates
+
+After `git pull` from a shared repository, see what's new:
+
+```bash
+# See what changed (uncommitted)
+./bip diff --human
+
+# See papers added since your last commit
+./bip new --since HEAD~1 --human
+
+# Open all new papers to review
+./bip open --since HEAD~1
+```
+
+### 2. Quick-Review Recently Added Papers
+
+Your agent added papers overnight. Open the most recent ones:
+
+```bash
+# Open 5 most recent papers
+./bip open --recent 5
+
+# Or see what was added in last 3 days
+./bip new --days 3 --human
+```
+
+### 3. Export Paper for Manuscript Citation
+
+Your agent identified a paper to cite. Export it to your .bib file:
+
+```bash
+# Export single paper to stdout
+./bip export --bibtex Smith2024-ab
+
+# Append to existing .bib file (won't duplicate)
+./bip export --bibtex --append ~/paper/refs.bib Smith2024-ab Lee2024-cd
+```
+
+### 4. Check Uncommitted Changes Before Commit
+
+Before committing changes to the shared repository:
+
+```bash
+# See what will be committed
+./bip diff --human
+
+# Review the papers being added
+./bip open Smith2024-ab Lee2024-cd
+```
+
+## Testing Commands
+
+### Test `bip open` with Multiple Papers
+
+```bash
+# Requires: at least 2 papers in library with PDFs
+./bip open $(./bip list | jq -r '.[0:2][].id')
+
+# Expected: 2 PDF viewers open
+```
+
+### Test `bip diff`
+
+```bash
+# Add a paper, don't commit
+./bip s2 add DOI:10.1234/example
+
+# Show uncommitted changes
+./bip diff --human
+
+# Expected: Shows 1 paper added
+```
+
+### Test `bip new --since`
+
+```bash
+# Get current commit
+BEFORE=$(git rev-parse HEAD)
+
+# Add and commit a paper
+./bip s2 add DOI:10.1234/example
+git add .bipartite/refs.jsonl
+git commit -m "Add test paper"
+
+# Show papers since before
+./bip new --since $BEFORE --human
+
+# Expected: Shows 1 paper added
+```
+
+### Test `bip export --bibtex --append`
+
+```bash
+# Create empty .bib file
+echo "" > /tmp/test.bib
+
+# Export a paper
+./bip export --bibtex --append /tmp/test.bib Smith2024-ab
+
+# Export same paper again (should skip)
+./bip export --bibtex --append /tmp/test.bib Smith2024-ab
+
+# Expected: Second call shows skipped=1
+```
+
+## Edge Cases to Test
+
+1. **Missing PDF**: `bip open` with paper that has no PDF
+2. **Non-existent commit**: `bip new --since xyz789` (should error)
+3. **Empty diff**: `bip diff` when no changes (should show empty arrays)
+4. **Duplicate detection**: `bip export --append` with existing DOI
+
+## JSON vs Human Output
+
+All commands default to JSON for agent integration:
+
+```bash
+# JSON (default)
+./bip diff
+# {"added": [...], "removed": [...]}
+
+# Human-readable
+./bip diff --human
+# Added (2):
+#   + Smith2024-ab: ...
+```

--- a/specs/008-shared-repo-workflow/research.md
+++ b/specs/008-shared-repo-workflow/research.md
@@ -1,0 +1,140 @@
+# Research: Shared Repository Workflow Commands
+
+## Research Tasks
+
+Based on Technical Context unknowns and dependency best practices:
+
+1. Git integration patterns for JSONL diff detection
+2. BibTeX parsing for append deduplication
+3. Concurrent PDF opening across platforms
+4. Commit-based timestamp filtering
+
+---
+
+## 1. Git Integration for JSONL Diff Detection
+
+### Decision: Use `git diff` and `git show` via os/exec
+
+### Rationale
+The codebase already uses `os/exec` for external tools (see `internal/pdf/opener.go`). Go has no standard git library, and CGO-based libgit2 bindings would violate constitution principle VI (Simplicity) by adding heavyweight dependencies.
+
+### Approach
+- **For `bip diff`**: Compare working tree vs HEAD using `git diff --name-status`
+- **For `bip new --since <commit>`**: Use `git log --oneline --since-commit` combined with `git show <commit>:.bipartite/refs.jsonl` to get historical state
+- **For `--recent N`**: Parse git log to find commits that touched refs.jsonl, extract paper IDs from diffs
+
+### Key Commands
+```bash
+# Check if commit exists
+git rev-parse --verify <commit>^{commit}
+
+# Get refs.jsonl at specific commit
+git show <commit>:.bipartite/refs.jsonl
+
+# Get commits touching refs.jsonl since a commit
+git log --oneline <commit>..HEAD -- .bipartite/refs.jsonl
+
+# Get unified diff of refs.jsonl
+git diff HEAD -- .bipartite/refs.jsonl
+```
+
+### Alternatives Considered
+- **go-git (pure Go)**: Large dependency, overkill for simple diff operations
+- **libgit2/git2go**: CGO dependency, complicates builds
+- **Direct JSONL comparison**: Would miss uncommitted changes for `bip diff`
+
+---
+
+## 2. BibTeX Parsing for Append Deduplication
+
+### Decision: Implement minimal regex-based parser for citation key and DOI extraction
+
+### Rationale
+Full BibTeX parsing is complex (nested braces, string concatenation, etc.). For deduplication, we only need:
+1. Extract citation keys (`@article{key123,`)
+2. Extract DOI field values (`doi = {10.1234/example},`)
+
+### Approach
+- Parse existing .bib file line-by-line with regex
+- Build a set of existing citation keys and DOIs
+- Skip entries where DOI matches (primary) or key matches (fallback)
+
+### Key Patterns
+```go
+// Match entry start: @type{key,
+entryStartRegex := regexp.MustCompile(`@\w+\{([^,]+),`)
+
+// Match DOI field: doi = {value} or doi = "value"
+doiFieldRegex := regexp.MustCompile(`(?i)doi\s*=\s*[\{"]([^\}"]+)[\}"]`)
+```
+
+### Alternatives Considered
+- **Full BibTeX parser library**: Overkill for deduplication, adds dependency
+- **String contains search**: Unreliable for field extraction
+- **Parse entire BibTeX AST**: Constitution VI violation (YAGNI)
+
+---
+
+## 3. Concurrent PDF Opening
+
+### Decision: Sequential open calls with small delay, reuse existing pdf.Opener
+
+### Rationale
+Opening PDFs in parallel can overwhelm the PDF viewer. The existing `pdf.Opener.Open()` method uses `cmd.Start()` which doesn't block. Sequential calls with the existing implementation will open multiple PDFs.
+
+### Approach
+- Loop through paper IDs, call `opener.Open()` for each
+- Collect errors for papers with missing PDFs (FR-004: continue with available)
+- No artificial delay needed - `cmd.Start()` returns immediately
+
+### Platform Behavior
+- **macOS**: `open` command queues files for the same app
+- **Linux**: Each `xdg-open` or reader call spawns independently
+
+### Alternatives Considered
+- **Single command with multiple files**: Not portable across readers
+- **Parallel goroutines**: Unnecessary complexity, no benefit
+- **Batching**: Platform-dependent, unpredictable behavior
+
+---
+
+## 4. Commit-Based Timestamp Filtering
+
+### Decision: Compare JSONL snapshots at different commits
+
+### Rationale
+The `--since <commit>` flag needs to identify papers added after a commit. Since refs.jsonl is the source of truth, comparing the file at two points in git history provides accurate results.
+
+### Approach for `bip new --since <commit>`
+1. Validate commit exists: `git rev-parse --verify <commit>`
+2. Get refs.jsonl at commit: `git show <commit>:.bipartite/refs.jsonl`
+3. Parse both historical and current JSONL into maps keyed by ID
+4. Papers in current but not historical are "new"
+
+### Approach for `--recent N`
+1. Query git log for recent commits touching refs.jsonl
+2. For each commit, diff against parent to find added IDs
+3. Return up to N most recent additions
+
+### Edge Cases
+- Non-existent commit: Exit with error per spec
+- Merge commits: Use first-parent history for simplicity
+- Rebased history: Works correctly (compares snapshots, not commit parents)
+
+### Alternatives Considered
+- **Track add timestamps in JSONL**: Requires schema change, breaks existing data
+- **Use commit timestamps as proxy**: Doesn't account for force-push/rebase
+- **SQLite triggers**: Would require persistent tracking, violates constitution II
+
+---
+
+## Summary of Decisions
+
+| Topic | Decision | Key Rationale |
+|-------|----------|---------------|
+| Git integration | os/exec with git CLI | Simplicity, no CGO |
+| BibTeX parsing | Regex for key/DOI only | Minimal for deduplication |
+| PDF opening | Sequential, existing Opener | cmd.Start() is non-blocking |
+| Commit filtering | JSONL snapshot comparison | Accurate, works with rebase |
+
+All decisions align with constitution principles, particularly VI (Simplicity) and II (Git-Versionable Architecture).

--- a/specs/008-shared-repo-workflow/spec.md
+++ b/specs/008-shared-repo-workflow/spec.md
@@ -1,0 +1,142 @@
+# Feature Specification: Shared Repository Workflow Commands
+
+**Feature Branch**: `008-shared-repo-workflow`
+**Created**: 2026-01-21
+**Status**: Draft
+**Input**: User description: "Commands needed to support teams sharing a paper library via git. With matsengrp/bip-papers set up as a shared repository, several command enhancements would streamline the collaborative workflow."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Open Multiple Papers for Review (Priority: P1)
+
+Alice's agent adds papers to the shared repository. Alice wants to quickly open and verify that the papers are relevant to her research before committing time to read them in detail.
+
+**Why this priority**: This is the most common collaborative workflow - reviewing papers added by others (or agents) requires quick multi-paper access. Without this, users must manually look up and open each paper one by one.
+
+**Independent Test**: Can be fully tested by running `bip open` with multiple paper IDs and verifying all PDFs open in the default viewer. Delivers immediate value for paper review workflows.
+
+**Acceptance Scenarios**:
+
+1. **Given** a repository with papers P1, P2, P3, **When** user runs `bip open P1 P2 P3`, **Then** all three papers open in the default PDF viewer
+2. **Given** a repository with 10 papers, **When** user runs `bip open --recent 3`, **Then** the 3 most recently added papers open
+3. **Given** a repository with papers added across commits, **When** user runs `bip open --since abc123`, **Then** all papers added after commit abc123 open
+
+---
+
+### User Story 2 - Track New Papers from Collaborators (Priority: P1)
+
+Bernadetta pulls updates from the shared repository and wants to see what papers were added by her collaborators since she last checked, so she can stay current with the team's literature collection.
+
+**Why this priority**: Equally critical to multi-paper open - this is the entry point for the collaborative workflow. Users need to discover what changed before they can act on it.
+
+**Independent Test**: Can be fully tested by running `bip new` or `bip diff` commands and verifying the output lists the correct papers. Delivers immediate value for staying synchronized with collaborators.
+
+**Acceptance Scenarios**:
+
+1. **Given** uncommitted changes in refs.jsonl, **When** user runs `bip diff`, **Then** output shows papers added and removed since last commit
+2. **Given** a repository with history, **When** user runs `bip new --since abc123`, **Then** output lists papers added after that commit with metadata
+3. **Given** papers added over the past week, **When** user runs `bip new --days 7`, **Then** output lists papers added within the last 7 days
+
+---
+
+### User Story 3 - Export Specific Papers to BibTeX (Priority: P2)
+
+An agent determines that a specific paper should be cited in a manuscript. The agent needs to export just that paper's BibTeX entry and optionally append it to an existing .bib file without duplicating entries.
+
+**Why this priority**: Important for manuscript writing workflow but depends on users first being able to discover and review papers (P1 features). Single-paper export is more targeted than batch export.
+
+**Independent Test**: Can be fully tested by running `bip export --bibtex <id>` and verifying correct BibTeX output. Append mode can be tested by checking the .bib file contains the entry without duplicates.
+
+**Acceptance Scenarios**:
+
+1. **Given** a paper with ID "abc123" in the library, **When** user runs `bip export --bibtex abc123`, **Then** BibTeX entry for that paper is output
+2. **Given** multiple papers, **When** user runs `bip export --bibtex id1 id2 id3`, **Then** BibTeX entries for all specified papers are output
+3. **Given** an existing .bib file with entries, **When** user runs `bip export --bibtex --append refs.bib newpaper`, **Then** the new entry is appended and duplicates are not created
+
+---
+
+### Edge Cases
+
+- What happens when `bip open` is called with an ID that has no associated PDF file? → Covered by FR-004: show error, continue opening available PDFs
+- How does `bip diff` handle merge commits or rebased history?
+- What happens when `bip new --since` references a non-existent commit? → Exit with error message indicating commit not found
+- How does `bip export --bibtex --append` handle a paper that already exists in the .bib file (deduplication)? → Match by DOI (primary), fall back to citation key
+- What happens when `bip open --recent N` is called but fewer than N papers exist? → Open all available papers (no error)
+- How does `bip new --days` handle timezones and papers added at midnight boundaries? → Use UTC for all date calculations
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+#### Open Multiple Papers (bip open)
+
+- **FR-001**: System MUST support opening multiple papers by ID in a single command (`bip open <id1> <id2> ...`)
+- **FR-002**: System MUST support `--recent N` flag to open the N most recently added papers (recency determined by git commit timestamp)
+- **FR-003**: System MUST support `--since <commit>` flag to open papers added after a specific git commit
+- **FR-004**: System MUST gracefully handle missing PDF files with a clear error message while still opening available PDFs
+- **FR-005**: System MUST open PDFs using the system default PDF viewer
+
+#### Track What's New (bip diff, bip new)
+
+- **FR-006**: System MUST provide `bip diff` command showing papers added/removed since last commit
+- **FR-007**: System MUST provide `bip new --since <commit>` to list papers added after a git commit
+- **FR-008**: System MUST provide `bip new --days N` to list papers added within the last N days
+- **FR-009**: System MUST output JSON by default with `--human` flag for readable output (consistent with existing commands)
+- **FR-010**: System MUST display paper metadata (title, authors, year, ID) in the output
+
+#### BibTeX Export (bip export --bibtex)
+
+- **FR-011**: System MUST support `bip export --bibtex <id>` to export a single paper's BibTeX entry
+- **FR-012**: System MUST support multiple IDs (`bip export --bibtex <id1> <id2> ...`)
+- **FR-013**: System MUST support `--append <file>` flag to append entries to an existing .bib file
+- **FR-014**: System MUST deduplicate entries when appending (match by DOI if present, fall back to citation key match for entries without DOI)
+- **FR-015**: System MUST generate valid BibTeX with appropriate entry types (@article, @inproceedings, etc.)
+
+#### Cross-Cutting Requirements
+
+- **FR-016**: All commands MUST follow existing CLI patterns (JSON default, `--human` for readable output)
+- **FR-017**: Multi-ID arguments MUST use consistent parsing across all commands
+- **FR-018**: `--since <commit>` MUST accept any valid git commit reference (SHA, branch name, tag, HEAD~N)
+- **FR-019**: Error messages MUST be actionable and indicate how to resolve the issue
+
+### Key Entities
+
+- **Paper Reference**: Existing entity from refs.jsonl - contains ID, title, authors, year, DOI, PDF path
+- **Git Commit**: External entity - represents a point in repository history for `--since` filtering
+- **BibTeX Entry**: Output format - contains citation key, entry type, and bibliographic fields
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Users can open 5 papers simultaneously in under 3 seconds
+- **SC-002**: Users can identify new papers from collaborators within 10 seconds of pulling updates
+- **SC-003**: Exporting a single paper's BibTeX completes in under 1 second
+- **SC-004**: 100% of exported BibTeX entries are valid and parseable by standard tools
+- **SC-005**: Append mode correctly deduplicates 100% of existing entries
+- **SC-006**: All commands produce consistent output format (JSON default, human-readable with flag)
+
+## Assumptions
+
+- The repository uses git for version control and refs.jsonl is tracked in git
+- Papers have associated PDF files stored locally (path in refs.jsonl)
+- The system's default PDF viewer can handle multiple files opened in sequence
+- BibTeX citation keys can be derived from paper metadata (author-year or DOI-based)
+- Git is available on the system PATH for commit-based filtering
+
+## Out of Scope
+
+- Remote PDF fetching (papers must already have local PDFs)
+- BibTeX style customization (uses standard format)
+- Conflict resolution for shared repository merges (see separate issue #18)
+- Real-time synchronization or push notifications for new papers
+
+## Clarifications
+
+### Session 2026-01-21
+
+- Q: How is "recently added" determined for `--recent N` flag? → A: Based on git commit timestamp (when the paper's entry was committed)
+- Q: How are BibTeX entries matched for deduplication when appending? → A: Match by DOI (primary), fall back to citation key match for entries without DOI
+- Q: What happens when `--since` references a non-existent commit? → A: Exit with error message indicating commit not found
+- Q: What happens when `--recent N` requests more papers than exist? → A: Open all available papers (no error)
+- Q: How does `--days N` handle timezones? → A: Use UTC for all date calculations

--- a/specs/008-shared-repo-workflow/tasks.md
+++ b/specs/008-shared-repo-workflow/tasks.md
@@ -1,0 +1,215 @@
+# Tasks: Shared Repository Workflow Commands
+
+**Input**: Design documents from `/specs/008-shared-repo-workflow/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/cli.md, quickstart.md
+
+**Tests**: No test tasks included (tests not explicitly requested in specification).
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- **CLI commands**: `cmd/bip/`
+- **Internal packages**: `internal/`
+- **Test fixtures**: `testdata/`
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Create the git integration package and response types that all commands will use
+
+- [X] T001 Create internal/git/ package directory structure
+- [X] T002 [P] Define response types (OpenMultipleResult, DiffResult, NewPapersResult, ExportResult) in cmd/bip/types.go
+- [X] T003 [P] Define internal types (BibTeXIndex, GitDiff) in internal/git/types.go
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core git integration infrastructure that MUST be complete before ANY user story can be implemented
+
+**CRITICAL**: No user story work can begin until this phase is complete
+
+- [X] T004 Implement git repository detection (find repo root, check if in git repo) in internal/git/git.go
+- [X] T005 Implement commit validation (verify commit exists, resolve refs like HEAD~N) in internal/git/git.go
+- [X] T006 Implement JSONL snapshot retrieval from git (git show <commit>:.bipartite/refs.jsonl) in internal/git/git.go
+- [X] T007 Implement GitDiff functions (DiffWorkingTree, DiffSince) in internal/git/diff.go
+- [X] T008 Implement git log parsing for commit history (commits touching refs.jsonl) in internal/git/log.go
+- [X] T009 Create shared git helper functions for CLI commands in cmd/bip/git_helpers.go
+
+**Checkpoint**: Git integration ready - user story implementation can now begin
+
+---
+
+## Phase 3: User Story 1 - Open Multiple Papers for Review (Priority: P1)
+
+**Goal**: Allow users to open multiple papers by ID, with `--recent N` and `--since <commit>` flags
+
+**Independent Test**: Run `bip open` with multiple paper IDs and verify all PDFs open in the default viewer
+
+### Implementation for User Story 1
+
+- [X] T010 [US1] Modify cmd/bip/open.go to accept multiple positional ID arguments
+- [X] T011 [US1] Add --recent N flag to cmd/bip/open.go (open N most recently added papers)
+- [X] T012 [US1] Add --since <commit> flag to cmd/bip/open.go (open papers added after commit)
+- [X] T013 [US1] Implement mutual exclusivity validation (IDs vs --recent vs --since) in cmd/bip/open.go
+- [X] T014 [US1] Implement multi-paper opening loop with error collection (FR-004: continue on missing PDF) in cmd/bip/open.go
+- [X] T015 [US1] Implement JSON output (OpenMultipleResult) for multi-paper open in cmd/bip/open.go
+- [X] T016 [US1] Implement --human output formatting for multi-paper open in cmd/bip/open.go
+- [X] T017 [US1] Add actionable error messages per contracts/cli.md (commit not found, PDF not found, pdf_root not set) in cmd/bip/open.go
+
+**Checkpoint**: User Story 1 complete - users can open multiple papers by ID, --recent, or --since
+
+---
+
+## Phase 4: User Story 2 - Track New Papers from Collaborators (Priority: P1)
+
+**Goal**: Provide `bip diff` and `bip new` commands to show papers added/removed since commits
+
+**Independent Test**: Run `bip diff` or `bip new --since` and verify output lists correct papers
+
+### Implementation for User Story 2
+
+- [X] T018 [P] [US2] Create cmd/bip/diff.go with cobra command skeleton and --human flag
+- [X] T019 [P] [US2] Create cmd/bip/new.go with cobra command skeleton, --since, --days, --human flags
+- [X] T020 [US2] Implement bip diff logic using DiffWorkingTree() in cmd/bip/diff.go
+- [X] T021 [US2] Implement JSON output (DiffResult) for bip diff in cmd/bip/diff.go
+- [X] T022 [US2] Implement --human output formatting for bip diff in cmd/bip/diff.go
+- [X] T023 [US2] Implement bip new --since logic using DiffSince() in cmd/bip/new.go
+- [X] T024 [US2] Implement bip new --days logic (papers added within N days UTC) in cmd/bip/new.go
+- [X] T025 [US2] Implement mutual exclusivity validation (--since vs --days) in cmd/bip/new.go
+- [X] T026 [US2] Implement JSON output (NewPapersResult) for bip new in cmd/bip/new.go
+- [X] T027 [US2] Implement --human output formatting for bip new in cmd/bip/new.go
+- [X] T028 [US2] Add actionable error messages per contracts/cli.md (commit not found, not in git repo) in cmd/bip/diff.go and cmd/bip/new.go
+- [X] T029 [US2] Register diff and new commands in cmd/bip/root.go
+
+**Checkpoint**: User Story 2 complete - users can track new papers from collaborators
+
+---
+
+## Phase 5: User Story 3 - Export Specific Papers to BibTeX (Priority: P2)
+
+**Goal**: Support `bip export --bibtex <id>...` and `--append` mode with deduplication
+
+**Independent Test**: Run `bip export --bibtex <id>` and verify correct BibTeX output; test append mode for deduplication
+
+### Implementation for User Story 3
+
+- [X] T030 [US3] Implement BibTeXIndex type and ParseBibTeXFile() for deduplication in internal/export/bibtex_parse.go
+- [X] T031 [US3] Add HasEntry() method (match by DOI primary, citation key fallback) to BibTeXIndex in internal/export/bibtex_parse.go
+- [X] T032 [US3] Modify cmd/bip/export.go to accept multiple positional ID arguments
+- [X] T033 [US3] Add --append <file> flag to cmd/bip/export.go
+- [X] T034 [US3] Implement single/multi-paper BibTeX export (IDs to stdout) in cmd/bip/export.go
+- [X] T035 [US3] Implement --append mode with BibTeXIndex deduplication in cmd/bip/export.go
+- [X] T036 [US3] Implement JSON output (ExportResult) for --append mode in cmd/bip/export.go
+- [X] T037 [US3] Add actionable error messages per contracts/cli.md (unknown key, file read/write errors) in cmd/bip/export.go
+
+**Checkpoint**: User Story 3 complete - users can export specific papers to BibTeX with optional append/deduplication
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Validation, documentation, and final quality checks
+
+- [X] T038 Run all quickstart.md test scenarios to validate command behavior
+- [X] T039 [P] Update CLAUDE.md with new commands documentation
+- [X] T040 [P] Update README.md with new command usage examples
+- [X] T041 Verify all commands follow CLI patterns (JSON default, --human flag, exit codes)
+- [X] T042 Run go vet ./... and go fmt ./... for code quality
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion - BLOCKS all user stories
+- **User Stories (Phase 3-5)**: All depend on Foundational phase completion
+  - US1 and US2 are both P1 priority and can proceed in parallel
+  - US3 (P2) can proceed in parallel with US1/US2 or after them
+- **Polish (Phase 6)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Can start after Foundational (Phase 2) - Uses git log parsing for --recent
+- **User Story 2 (P1)**: Can start after Foundational (Phase 2) - Uses DiffWorkingTree and DiffSince
+- **User Story 3 (P2)**: Can start after Foundational (Phase 2) - Independent of US1/US2, only needs existing export infrastructure
+
+### Within Each User Story
+
+- Command skeleton before implementation logic
+- Core implementation before output formatting
+- JSON output before --human output
+- Error messages after main implementation
+
+### Parallel Opportunities
+
+- T002 and T003 (Setup) can run in parallel (different files)
+- T018 and T019 (US2 command skeletons) can run in parallel (different files)
+- T039 and T040 (Polish docs) can run in parallel (different files)
+- All three user stories can be worked on in parallel after Foundational phase
+
+---
+
+## Parallel Example: User Story 2
+
+```bash
+# Launch command skeletons together:
+Task: "Create cmd/bip/diff.go with cobra command skeleton and --human flag"
+Task: "Create cmd/bip/new.go with cobra command skeleton, --since, --days, --human flags"
+
+# Then proceed with implementation sequentially within each command
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Stories 1 + 2)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational (CRITICAL - blocks all stories)
+3. Complete Phase 3: User Story 1 (Open Multiple Papers)
+4. Complete Phase 4: User Story 2 (Track New Papers)
+5. **STOP and VALIDATE**: Test both P1 stories independently
+6. Deploy/demo collaborative workflow (open + track new papers)
+
+### Incremental Delivery
+
+1. Complete Setup + Foundational -> Git integration ready
+2. Add User Story 1 -> Test independently -> Multi-paper open works
+3. Add User Story 2 -> Test independently -> Diff/new commands work
+4. Add User Story 3 -> Test independently -> BibTeX export enhanced
+5. Each story adds value without breaking previous stories
+
+### Parallel Team Strategy
+
+With multiple developers:
+
+1. Team completes Setup + Foundational together
+2. Once Foundational is done:
+   - Developer A: User Story 1 (open.go modifications)
+   - Developer B: User Story 2 (new diff.go and new.go)
+   - Developer C: User Story 3 (export.go modifications + bibtex_parse.go)
+3. Stories complete and integrate independently
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- Each user story should be independently completable and testable
+- Commit after each task or logical group
+- Stop at any checkpoint to validate story independently
+- FR references map to spec.md functional requirements
+- Avoid: vague tasks, same file conflicts, cross-story dependencies that break independence


### PR DESCRIPTION
## Summary

- Adds commands for teams sharing a paper library via git
- `bip open` now supports multiple IDs, `--recent N`, and `--since <commit>`
- New `bip diff` command shows papers added/removed since last commit
- New `bip new` command lists papers added since commit or in last N days
- `bip export --bibtex` now supports specific IDs and `--append` with deduplication

## New Commands

| Command | Description |
|---------|-------------|
| `bip open <id>...` | Open multiple papers by ID |
| `bip open --recent N` | Open N most recently added papers |
| `bip open --since <commit>` | Open papers added after commit |
| `bip diff` | Show papers added/removed since last commit |
| `bip new --since <commit>` | List papers added since commit |
| `bip new --days N` | List papers added in last N days |
| `bip export --bibtex <id>...` | Export specific papers |
| `bip export --bibtex --append <file>` | Append with deduplication |

## Implementation

- New `internal/git` package for git integration (repo detection, commit validation, JSONL history)
- New `internal/export/bibtex_parse.go` for BibTeX deduplication (by DOI primary, citation key fallback)
- All commands follow existing CLI patterns (JSON default, `--human` flag)

## Test plan

- [x] `go fmt ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes
- [x] Tested against bip-papers repo:
  - [x] `bip diff --human` works
  - [x] `bip new --since HEAD~1 --human` works
  - [x] `bip new --days 30 --human` works
  - [x] `bip export --bibtex <id> <id>` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)