### PR TITLE
Fix flowc board sync to match P0 beads with GitHub references

### DIFF
--- a/flowc/board/sync.py
+++ b/flowc/board/sync.py
@@ -8,7 +8,6 @@ from flowc.board.api import add_issue_to_board, list_board_items
 from flowc.shared.config import load_beads
 
 GITHUB_REF_PATTERN = re.compile(r"GitHub:\s*([^#\s]+)#(\d+)")
-PRIORITY_PATTERN = re.compile(r"\bP([0-4])\b")
 
 
 def get_p0_beads_with_github_refs() -> list[dict]:
@@ -20,29 +19,22 @@ def get_p0_beads_with_github_refs() -> list[dict]:
     p0_beads = []
 
     for bead in beads:
-        bead_id = bead.get("id", "")
-        title = bead.get("title", "")
-        desc = bead.get("description", "")
-
-        # Check if P0
-        priority_match = PRIORITY_PATTERN.search(title) or PRIORITY_PATTERN.search(desc)
-        if not priority_match or priority_match.group(1) != "0":
+        # Check if P0 (priority stored as integer field)
+        if bead.get("priority") != 0:
             continue
 
-        # Extract GitHub reference
+        # Extract GitHub reference from description
+        desc = bead.get("description", "")
         github_match = GITHUB_REF_PATTERN.search(desc)
         if not github_match:
             continue
 
-        repo = github_match.group(1)
-        issue_number = int(github_match.group(2))
-
         p0_beads.append(
             {
-                "bead_id": bead_id,
-                "title": title,
-                "repo": repo,
-                "issue_number": issue_number,
+                "bead_id": bead.get("id", ""),
+                "title": bead.get("title", ""),
+                "repo": github_match.group(1),
+                "issue_number": int(github_match.group(2)),
             }
         )
 

--- a/flowc/main.py
+++ b/flowc/main.py
@@ -61,9 +61,7 @@ def main():
     add_parser.add_argument("issue", type=int, help="Issue number to add")
     add_parser.add_argument("--status", help="Initial status (blocked, next, active)")
     add_parser.add_argument("--label", help="Label to apply")
-    add_parser.add_argument(
-        "--repo", help="Repository (org/repo format, required)"
-    )
+    add_parser.add_argument("--repo", help="Repository (org/repo format, required)")
     add_parser.add_argument(
         "--board",
         help="Board to use (owner/number). Defaults to first in sources.json",
@@ -75,9 +73,7 @@ def main():
     )
     move_parser.add_argument("issue", type=int, help="Issue number to move")
     move_parser.add_argument("--status", required=True, help="New status")
-    move_parser.add_argument(
-        "--repo", help="Repository (org/repo format, required)"
-    )
+    move_parser.add_argument("--repo", help="Repository (org/repo format, required)")
     move_parser.add_argument(
         "--board",
         help="Board to use (owner/number). Defaults to first in sources.json",
@@ -88,9 +84,7 @@ def main():
         "remove", help="Remove issue from board"
     )
     remove_parser.add_argument("issue", type=int, help="Issue number to remove")
-    remove_parser.add_argument(
-        "--repo", help="Repository (org/repo format, required)"
-    )
+    remove_parser.add_argument("--repo", help="Repository (org/repo format, required)")
     remove_parser.add_argument(
         "--board",
         help="Board to use (owner/number). Defaults to first in sources.json",
@@ -170,7 +164,8 @@ def main():
         help="Highlight beads created after this date (YYYY-MM-DD or ISO format)",
     )
     tree_parser.add_argument(
-        "-o", "--output",
+        "-o",
+        "--output",
         help="Output file path (default: stdout)",
     )
     tree_parser.add_argument(

--- a/flowc/shared/config.py
+++ b/flowc/shared/config.py
@@ -9,7 +9,7 @@ from pathlib import Path
 # Paths relative to current working directory (nexus)
 ROOT = Path.cwd()
 SOURCES_FILE = ROOT / "sources.json"
-BEADS_FILE = ROOT / "issues.jsonl"
+BEADS_FILE = ROOT / ".beads" / "issues.jsonl"
 STATE_FILE = ROOT / ".last-checkin.json"
 CACHE_FILE = ROOT / ".flow-cache.json"
 

--- a/flowc/tree/cli.py
+++ b/flowc/tree/cli.py
@@ -173,7 +173,7 @@ def render_node(
             class_attr = f' class="{" ".join(css_classes)}"' if css_classes else ""
             id_span = f'<span class="id">{key}</span>'
             title_span = f'<span class="title">{title}</span>'
-            inner = f'<summary{desc_attr}>{id_span}{title_span}</summary>'
+            inner = f"<summary{desc_attr}>{id_span}{title_span}</summary>"
             inner += render_node(children, since=since)
             html.append(f"<details{class_attr} open>{inner}</details>")
         else:
@@ -255,9 +255,7 @@ def run_tree(args: argparse.Namespace) -> int:
             webbrowser.open(f"file://{output_path.absolute()}")
     elif args.open:
         # Write to temp file and open
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".html", delete=False
-        ) as f:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".html", delete=False) as f:
             f.write(html)
             temp_path = f.name
         webbrowser.open(f"file://{temp_path}")

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -1,6 +1,5 @@
 """Tests for ball-in-my-court filtering logic."""
 
-
 from flowc.checkin.activity import (
     ball_in_my_court,
     filter_by_ball_in_court,


### PR DESCRIPTION
## Summary

- Fixed `BEADS_FILE` path to point to `.beads/issues.jsonl` (was incorrectly pointing to `issues.jsonl`)
- Updated priority detection to use the integer `priority` field instead of regex pattern matching for "P0" text

## Problem

`flowc board sync` reported board issues as "without P0 bead" even when a matching P0 bead existed with the correct `GitHub:` reference in its description. This was caused by:

1. The beads file path was wrong - beads are stored in `.beads/issues.jsonl`, not `issues.jsonl`
2. The priority check searched for "P0" text pattern, but beads store priority as an integer field (`priority: 0`)

## Test plan

- [x] All Python tests pass (110 tests)
- [x] All Go tests pass
- [x] Verified `flowc board sync` now correctly matches `matsengrp/data-central#8` to `flow-dasm.2.1.2.1` and `matsengrp/dasm2-experiments#173` to `flow-dasm.2.11`
- [x] Linting passes (`ruff check`, `go vet`)

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)