### PR TITLE
Fix viz missing papers/edges and add project/repo support

### DIFF
--- a/internal/viz/graph.go
+++ b/internal/viz/graph.go
@@ -6,15 +6,33 @@ import (
 
 	"github.com/matsen/bipartite/internal/concept"
 	"github.com/matsen/bipartite/internal/edge"
+	"github.com/matsen/bipartite/internal/project"
 	"github.com/matsen/bipartite/internal/reference"
+	"github.com/matsen/bipartite/internal/repo"
 	"github.com/matsen/bipartite/internal/storage"
 )
 
+// ID prefixes used in edge source/target IDs.
+const (
+	conceptPrefix = "concept:"
+	projectPrefix = "project:"
+)
+
 // BuildGraphFromDatabase queries the database and constructs a complete GraphData
-// structure for visualization, including filtered edges, connection counts, and
-// type-specific nodes.
+// structure for visualization, including papers, concepts, projects, repos, and edges.
 func BuildGraphFromDatabase(db *storage.DB) (*GraphData, error) {
+	// Load all entity types
 	concepts, err := db.GetAllConcepts()
+	if err != nil {
+		return nil, err
+	}
+
+	projects, err := db.GetAllProjects()
+	if err != nil {
+		return nil, err
+	}
+
+	repos, err := db.GetAllRepos()
 	if err != nil {
 		return nil, err
 	}
@@ -24,47 +42,120 @@ func BuildGraphFromDatabase(db *storage.DB) (*GraphData, error) {
 		return nil, err
 	}
 
-	filteredEdges, paperIDs, connectionCounts := filterEdgesToConcepts(allEdges, concepts)
-
-	paperNodes, err := buildPaperNodes(db, paperIDs)
-	if err != nil {
-		return nil, err
-	}
-
-	conceptNodes := buildConceptNodes(concepts, connectionCounts)
-
-	return &GraphData{
-		Nodes: append(paperNodes, conceptNodes...),
-		Edges: filteredEdges,
-	}, nil
-}
-
-// filterEdgesToConcepts filters edges to only paper->concept relationships and
-// tracks which papers are involved and how many connections each concept has.
-func filterEdgesToConcepts(allEdges []edge.Edge, concepts []concept.Concept) ([]Edge, map[string]bool, map[string]int) {
+	// Build ID lookup maps
 	conceptIDs := make(map[string]bool, len(concepts))
 	for _, c := range concepts {
 		conceptIDs[c.ID] = true
 	}
 
+	projectIDs := make(map[string]bool, len(projects))
+	for _, p := range projects {
+		projectIDs[p.ID] = true
+	}
+
+	// Process edges and collect connected node IDs
+	vizEdges, paperIDs, conceptConnectionCounts, projectConnectionCounts := processEdges(allEdges, conceptIDs, projectIDs)
+
+	// Build paper nodes (only those connected via edges)
+	paperNodes, err := buildPaperNodes(db, paperIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build concept nodes with connection counts
+	conceptNodes := buildConceptNodes(concepts, conceptConnectionCounts)
+
+	// Build project nodes with connection counts
+	projectNodes := buildProjectNodes(projects, projectConnectionCounts)
+
+	// Build repo nodes (grouped under their projects)
+	repoNodes := buildRepoNodes(repos)
+
+	// Combine all nodes
+	var allNodes []Node
+	allNodes = append(allNodes, paperNodes...)
+	allNodes = append(allNodes, conceptNodes...)
+	allNodes = append(allNodes, projectNodes...)
+	allNodes = append(allNodes, repoNodes...)
+
+	return &GraphData{
+		Nodes: allNodes,
+		Edges: vizEdges,
+	}, nil
+}
+
+// processEdges processes all edges, normalizing prefixed IDs and tracking connections.
+// Returns visualization edges, paper IDs to fetch, and connection counts for concepts and projects.
+func processEdges(allEdges []edge.Edge, conceptIDs, projectIDs map[string]bool) ([]Edge, map[string]bool, map[string]int, map[string]int) {
 	paperIDs := make(map[string]bool)
-	connectionCounts := make(map[string]int)
-	var filteredEdges []Edge
+	conceptConnectionCounts := make(map[string]int)
+	projectConnectionCounts := make(map[string]int)
+	var vizEdges []Edge
 
 	for _, e := range allEdges {
-		if conceptIDs[e.TargetID] {
-			paperIDs[e.SourceID] = true
-			connectionCounts[e.TargetID]++
-			filteredEdges = append(filteredEdges, Edge{
-				Source:           e.SourceID,
-				Target:           e.TargetID,
+		sourceID := normalizeID(e.SourceID)
+		targetID := normalizeID(e.TargetID)
+
+		// Determine edge type and validate endpoints
+		sourceIsConcept := conceptIDs[sourceID]
+		targetIsConcept := conceptIDs[targetID]
+		sourceIsProject := projectIDs[sourceID]
+		targetIsProject := projectIDs[targetID]
+
+		// Paper → Concept edges
+		if targetIsConcept && !sourceIsConcept && !sourceIsProject {
+			paperIDs[sourceID] = true
+			conceptConnectionCounts[targetID]++
+			vizEdges = append(vizEdges, Edge{
+				Source:           sourceID,
+				Target:           targetID,
 				RelationshipType: e.RelationshipType,
 				Summary:          e.Summary,
 			})
+			continue
 		}
+
+		// Concept → Project edges
+		if sourceIsConcept && targetIsProject {
+			conceptConnectionCounts[sourceID]++
+			projectConnectionCounts[targetID]++
+			vizEdges = append(vizEdges, Edge{
+				Source:           sourceID,
+				Target:           targetID,
+				RelationshipType: e.RelationshipType,
+				Summary:          e.Summary,
+			})
+			continue
+		}
+
+		// Project → Concept edges (reverse direction)
+		if sourceIsProject && targetIsConcept {
+			projectConnectionCounts[sourceID]++
+			conceptConnectionCounts[targetID]++
+			vizEdges = append(vizEdges, Edge{
+				Source:           sourceID,
+				Target:           targetID,
+				RelationshipType: e.RelationshipType,
+				Summary:          e.Summary,
+			})
+			continue
+		}
+
+		// Skip other edge types (e.g., paper-paper, invalid edges)
 	}
 
-	return filteredEdges, paperIDs, connectionCounts
+	return vizEdges, paperIDs, conceptConnectionCounts, projectConnectionCounts
+}
+
+// normalizeID strips type prefixes from IDs for matching against node IDs.
+func normalizeID(id string) string {
+	if strings.HasPrefix(id, conceptPrefix) {
+		return strings.TrimPrefix(id, conceptPrefix)
+	}
+	if strings.HasPrefix(id, projectPrefix) {
+		return strings.TrimPrefix(id, projectPrefix)
+	}
+	return id
 }
 
 // buildPaperNodes fetches paper details and constructs nodes for papers with concept edges.
@@ -96,6 +187,28 @@ func buildConceptNodes(concepts []concept.Concept, connectionCounts map[string]i
 	return nodes
 }
 
+// buildProjectNodes constructs nodes for all projects with their connection counts.
+func buildProjectNodes(projects []project.Project, connectionCounts map[string]int) []Node {
+	nodes := make([]Node, 0, len(projects))
+
+	for _, p := range projects {
+		nodes = append(nodes, newProjectNode(p, connectionCounts[p.ID]))
+	}
+
+	return nodes
+}
+
+// buildRepoNodes constructs nodes for all repos.
+func buildRepoNodes(repos []repo.Repo) []Node {
+	nodes := make([]Node, 0, len(repos))
+
+	for _, r := range repos {
+		nodes = append(nodes, newRepoNode(r))
+	}
+
+	return nodes
+}
+
 // newPaperNode creates a visualization node from a paper reference.
 func newPaperNode(ref *reference.Reference) Node {
 	return Node{
@@ -118,6 +231,34 @@ func newConceptNode(c concept.Concept, connectionCount int) Node {
 		Aliases:         c.Aliases,
 		Description:     c.Description,
 		ConnectionCount: connectionCount,
+	}
+}
+
+// newProjectNode creates a visualization node from a project with its connection count.
+func newProjectNode(p project.Project, connectionCount int) Node {
+	return Node{
+		ID:              p.ID,
+		Type:            NodeTypeProject,
+		Label:           p.Name,
+		Name:            p.Name,
+		Description:     p.Description,
+		ConnectionCount: connectionCount,
+	}
+}
+
+// newRepoNode creates a visualization node from a repo.
+func newRepoNode(r repo.Repo) Node {
+	return Node{
+		ID:          r.ID,
+		Type:        NodeTypeRepo,
+		Label:       r.Name,
+		Name:        r.Name,
+		Description: r.Description,
+		ProjectID:   r.Project,
+		RepoType:    r.Type,
+		GitHubURL:   r.GitHubURL,
+		Language:    r.Language,
+		Topics:      r.Topics,
 	}
 }
 

--- a/internal/viz/graph_test.go
+++ b/internal/viz/graph_test.go
@@ -1,0 +1,290 @@
+package viz
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/matsen/bipartite/internal/edge"
+)
+
+func TestProcessEdges_PaperToConcept(t *testing.T) {
+	conceptIDs := map[string]bool{
+		"somatic-hypermutation": true,
+		"affinity-maturation":   true,
+	}
+	projectIDs := map[string]bool{}
+
+	tests := []struct {
+		name                     string
+		edges                    []edge.Edge
+		wantEdgeCount            int
+		wantPaperIDs             []string
+		wantConceptConnCounts    map[string]int
+		wantEdgeTargetUnprefixed bool
+	}{
+		{
+			name: "edges with concept: prefix are matched",
+			edges: []edge.Edge{
+				{
+					SourceID:         "Paper2023-ab",
+					TargetID:         "concept:somatic-hypermutation",
+					RelationshipType: "models",
+					Summary:          "Models SHM targeting",
+				},
+			},
+			wantEdgeCount:            1,
+			wantPaperIDs:             []string{"Paper2023-ab"},
+			wantConceptConnCounts:    map[string]int{"somatic-hypermutation": 1},
+			wantEdgeTargetUnprefixed: true,
+		},
+		{
+			name: "edges without prefix are matched",
+			edges: []edge.Edge{
+				{
+					SourceID:         "Paper2023-cd",
+					TargetID:         "affinity-maturation",
+					RelationshipType: "applies",
+					Summary:          "Applies AM",
+				},
+			},
+			wantEdgeCount:            1,
+			wantPaperIDs:             []string{"Paper2023-cd"},
+			wantConceptConnCounts:    map[string]int{"affinity-maturation": 1},
+			wantEdgeTargetUnprefixed: true,
+		},
+		{
+			name: "edges to non-existent concepts are filtered out",
+			edges: []edge.Edge{
+				{
+					SourceID:         "Paper2023-ef",
+					TargetID:         "concept:unknown-concept",
+					RelationshipType: "introduces",
+					Summary:          "Introduces something",
+				},
+			},
+			wantEdgeCount:         0,
+			wantPaperIDs:          nil,
+			wantConceptConnCounts: map[string]int{},
+		},
+		{
+			name: "multiple edges from same paper to different concepts",
+			edges: []edge.Edge{
+				{
+					SourceID:         "Paper2023-gh",
+					TargetID:         "concept:somatic-hypermutation",
+					RelationshipType: "models",
+					Summary:          "Models SHM",
+				},
+				{
+					SourceID:         "Paper2023-gh",
+					TargetID:         "concept:affinity-maturation",
+					RelationshipType: "applies",
+					Summary:          "Studies AM",
+				},
+			},
+			wantEdgeCount: 2,
+			wantPaperIDs:  []string{"Paper2023-gh"},
+			wantConceptConnCounts: map[string]int{
+				"somatic-hypermutation": 1,
+				"affinity-maturation":   1,
+			},
+			wantEdgeTargetUnprefixed: true,
+		},
+		{
+			name: "multiple papers to same concept",
+			edges: []edge.Edge{
+				{
+					SourceID:         "Paper2023-ij",
+					TargetID:         "concept:somatic-hypermutation",
+					RelationshipType: "models",
+					Summary:          "First paper",
+				},
+				{
+					SourceID:         "Paper2023-kl",
+					TargetID:         "concept:somatic-hypermutation",
+					RelationshipType: "applies",
+					Summary:          "Second paper",
+				},
+			},
+			wantEdgeCount:            2,
+			wantPaperIDs:             []string{"Paper2023-ij", "Paper2023-kl"},
+			wantConceptConnCounts:    map[string]int{"somatic-hypermutation": 2},
+			wantEdgeTargetUnprefixed: true,
+		},
+		{
+			name:                  "empty edges list",
+			edges:                 []edge.Edge{},
+			wantEdgeCount:         0,
+			wantPaperIDs:          nil,
+			wantConceptConnCounts: map[string]int{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotEdges, gotPaperIDs, gotConceptConnCounts, _ := processEdges(tt.edges, conceptIDs, projectIDs)
+
+			// Check edge count
+			if len(gotEdges) != tt.wantEdgeCount {
+				t.Errorf("got %d edges, want %d", len(gotEdges), tt.wantEdgeCount)
+			}
+
+			// Check paper IDs
+			for _, wantPaperID := range tt.wantPaperIDs {
+				if !gotPaperIDs[wantPaperID] {
+					t.Errorf("missing paper ID %q in result", wantPaperID)
+				}
+			}
+			if len(gotPaperIDs) != len(tt.wantPaperIDs) {
+				t.Errorf("got %d paper IDs, want %d", len(gotPaperIDs), len(tt.wantPaperIDs))
+			}
+
+			// Check concept connection counts
+			for conceptID, wantCount := range tt.wantConceptConnCounts {
+				if gotConceptConnCounts[conceptID] != wantCount {
+					t.Errorf("concept %q: got connection count %d, want %d",
+						conceptID, gotConceptConnCounts[conceptID], wantCount)
+				}
+			}
+
+			// Check that edge targets are unprefixed (matching concept node IDs)
+			if tt.wantEdgeTargetUnprefixed {
+				for _, e := range gotEdges {
+					if strings.HasPrefix(e.Target, "concept:") {
+						t.Errorf("edge target should be unprefixed, got %q", e.Target)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestProcessEdges_ConceptToProject(t *testing.T) {
+	conceptIDs := map[string]bool{
+		"variational-inference": true,
+		"somatic-hypermutation": true,
+	}
+	projectIDs := map[string]bool{
+		"dasm2": true,
+		"netam": true,
+	}
+
+	tests := []struct {
+		name                  string
+		edges                 []edge.Edge
+		wantEdgeCount         int
+		wantConceptConnCounts map[string]int
+		wantProjectConnCounts map[string]int
+	}{
+		{
+			name: "concept to project edge with prefixes",
+			edges: []edge.Edge{
+				{
+					SourceID:         "concept:variational-inference",
+					TargetID:         "project:dasm2",
+					RelationshipType: "implemented-in",
+					Summary:          "DASM2 uses VI",
+				},
+			},
+			wantEdgeCount:         1,
+			wantConceptConnCounts: map[string]int{"variational-inference": 1},
+			wantProjectConnCounts: map[string]int{"dasm2": 1},
+		},
+		{
+			name: "project to concept edge (reverse direction)",
+			edges: []edge.Edge{
+				{
+					SourceID:         "project:netam",
+					TargetID:         "concept:somatic-hypermutation",
+					RelationshipType: "studied-by",
+					Summary:          "Netam studies SHM",
+				},
+			},
+			wantEdgeCount:         1,
+			wantConceptConnCounts: map[string]int{"somatic-hypermutation": 1},
+			wantProjectConnCounts: map[string]int{"netam": 1},
+		},
+		{
+			name: "multiple concepts to same project",
+			edges: []edge.Edge{
+				{
+					SourceID:         "concept:variational-inference",
+					TargetID:         "project:dasm2",
+					RelationshipType: "implemented-in",
+					Summary:          "VI in DASM2",
+				},
+				{
+					SourceID:         "concept:somatic-hypermutation",
+					TargetID:         "project:dasm2",
+					RelationshipType: "applied-in",
+					Summary:          "SHM in DASM2",
+				},
+			},
+			wantEdgeCount: 2,
+			wantConceptConnCounts: map[string]int{
+				"variational-inference": 1,
+				"somatic-hypermutation": 1,
+			},
+			wantProjectConnCounts: map[string]int{"dasm2": 2},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotEdges, _, gotConceptConnCounts, gotProjectConnCounts := processEdges(tt.edges, conceptIDs, projectIDs)
+
+			// Check edge count
+			if len(gotEdges) != tt.wantEdgeCount {
+				t.Errorf("got %d edges, want %d", len(gotEdges), tt.wantEdgeCount)
+			}
+
+			// Check concept connection counts
+			for conceptID, wantCount := range tt.wantConceptConnCounts {
+				if gotConceptConnCounts[conceptID] != wantCount {
+					t.Errorf("concept %q: got connection count %d, want %d",
+						conceptID, gotConceptConnCounts[conceptID], wantCount)
+				}
+			}
+
+			// Check project connection counts
+			for projectID, wantCount := range tt.wantProjectConnCounts {
+				if gotProjectConnCounts[projectID] != wantCount {
+					t.Errorf("project %q: got connection count %d, want %d",
+						projectID, gotProjectConnCounts[projectID], wantCount)
+				}
+			}
+
+			// Check that edge endpoints are unprefixed
+			for _, e := range gotEdges {
+				if strings.HasPrefix(e.Source, "concept:") || strings.HasPrefix(e.Source, "project:") {
+					t.Errorf("edge source should be unprefixed, got %q", e.Source)
+				}
+				if strings.HasPrefix(e.Target, "concept:") || strings.HasPrefix(e.Target, "project:") {
+					t.Errorf("edge target should be unprefixed, got %q", e.Target)
+				}
+			}
+		})
+	}
+}
+
+func TestNormalizeID(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"concept:somatic-hypermutation", "somatic-hypermutation"},
+		{"project:dasm2", "dasm2"},
+		{"Paper2023-ab", "Paper2023-ab"},
+		{"no-prefix", "no-prefix"},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := normalizeID(tt.input)
+			if got != tt.want {
+				t.Errorf("normalizeID(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/viz/html.go
+++ b/internal/viz/html.go
@@ -250,6 +250,37 @@ const htmlTemplate = `<!DOCTYPE html>
               'height': 'mapData(connectionCount, 0, 10, 25, 50)'
             }
           },
+          // Project nodes - green hexagons
+          {
+            selector: 'node[type="project"]',
+            style: {
+              'background-color': '#27AE60',
+              'shape': 'hexagon',
+              'label': 'data(label)',
+              'color': '#333',
+              'font-size': '11px',
+              'font-weight': 'bold',
+              'text-valign': 'bottom',
+              'text-margin-y': '5px',
+              'width': 'mapData(connectionCount, 0, 10, 35, 60)',
+              'height': 'mapData(connectionCount, 0, 10, 35, 60)'
+            }
+          },
+          // Repo nodes - small gray squares
+          {
+            selector: 'node[type="repo"]',
+            style: {
+              'background-color': '#7F8C8D',
+              'shape': 'rectangle',
+              'label': 'data(label)',
+              'color': '#555',
+              'font-size': '8px',
+              'text-valign': 'bottom',
+              'text-margin-y': '3px',
+              'width': '20px',
+              'height': '20px'
+            }
+          },
           // Edge styling by relationship type
           {
             selector: 'edge[relationshipType="introduces"]',
@@ -276,6 +307,37 @@ const htmlTemplate = `<!DOCTYPE html>
             style: {
               'line-color': '#9B59B6',
               'target-arrow-color': '#9B59B6',
+              'target-arrow-shape': 'triangle',
+              'curve-style': 'bezier',
+              'width': 2
+            }
+          },
+          // Concept-project edges - teal
+          {
+            selector: 'edge[relationshipType="implemented-in"]',
+            style: {
+              'line-color': '#1ABC9C',
+              'target-arrow-color': '#1ABC9C',
+              'target-arrow-shape': 'triangle',
+              'curve-style': 'bezier',
+              'width': 2
+            }
+          },
+          {
+            selector: 'edge[relationshipType="applied-in"]',
+            style: {
+              'line-color': '#16A085',
+              'target-arrow-color': '#16A085',
+              'target-arrow-shape': 'triangle',
+              'curve-style': 'bezier',
+              'width': 2
+            }
+          },
+          {
+            selector: 'edge[relationshipType="studied-by"]',
+            style: {
+              'line-color': '#2ECC71',
+              'target-arrow-color': '#2ECC71',
               'target-arrow-shape': 'triangle',
               'curve-style': 'bezier',
               'width': 2
@@ -353,6 +415,17 @@ const htmlTemplate = `<!DOCTYPE html>
             html += '<div class="detail">Aliases: ' + data.aliases.map(escapeHtml).join(', ') + '</div>';
           }
           html += '<div class="detail">Connections: ' + data.connectionCount + '</div>';
+        } else if (data.type === 'project') {
+          if (data.description) html += '<div class="detail">' + escapeHtml(data.description) + '</div>';
+          html += '<div class="detail">Connections: ' + data.connectionCount + '</div>';
+        } else if (data.type === 'repo') {
+          if (data.description) html += '<div class="detail">' + escapeHtml(data.description) + '</div>';
+          if (data.projectId) html += '<div class="detail">Project: ' + escapeHtml(data.projectId) + '</div>';
+          if (data.language) html += '<div class="detail">Language: ' + escapeHtml(data.language) + '</div>';
+          if (data.topics && data.topics.length > 0) {
+            html += '<div class="detail">Topics: ' + data.topics.map(escapeHtml).join(', ') + '</div>';
+          }
+          if (data.githubUrl) html += '<div class="detail"><a href="' + escapeHtml(data.githubUrl) + '" target="_blank">GitHub</a></div>';
         }
 
         return html;

--- a/internal/viz/types.go
+++ b/internal/viz/types.go
@@ -5,6 +5,8 @@ package viz
 const (
 	NodeTypePaper   = "paper"
 	NodeTypeConcept = "concept"
+	NodeTypeProject = "project"
+	NodeTypeRepo    = "repo"
 )
 
 // GraphData contains all data needed to render the visualization.
@@ -13,10 +15,10 @@ type GraphData struct {
 	Edges []Edge `json:"edges"`
 }
 
-// Node represents a paper or concept in the graph.
+// Node represents a paper, concept, project, or repo in the graph.
 type Node struct {
 	ID    string `json:"id"`
-	Type  string `json:"type"` // NodeTypePaper or NodeTypeConcept
+	Type  string `json:"type"` // NodeTypePaper, NodeTypeConcept, NodeTypeProject, or NodeTypeRepo
 	Label string `json:"label"`
 
 	// Paper-specific fields (for tooltips)
@@ -29,7 +31,17 @@ type Node struct {
 	Aliases     []string `json:"aliases,omitempty"`
 	Description string   `json:"description,omitempty"`
 
-	// Sizing (for concept nodes)
+	// Project-specific fields (for tooltips)
+	// Uses Name and Description (shared with concept)
+
+	// Repo-specific fields (for tooltips)
+	ProjectID string   `json:"projectId,omitempty"` // Parent project ID
+	RepoType  string   `json:"repoType,omitempty"`  // "github" or "manual"
+	GitHubURL string   `json:"githubUrl,omitempty"`
+	Language  string   `json:"language,omitempty"`
+	Topics    []string `json:"topics,omitempty"`
+
+	// Sizing (for concept and project nodes)
 	ConnectionCount int `json:"connectionCount"`
 }
 


### PR DESCRIPTION
## Summary

- **Fixes the core bug**: `bip viz` was showing only concept nodes because edges use `concept:id` prefix while concept IDs are stored without prefix. Now normalizes IDs when matching.
- **Extends viz for projects/repos**: Adds support for the three-layer graph structure (papers ↔ concepts ↔ projects) per spec 011-repo-nodes
- **Adds comprehensive tests** for edge processing logic

## Changes

### Bug fix (issue #55)
- `processEdges()` now strips `concept:` and `project:` prefixes when matching against node IDs
- Paper↔concept edges are now correctly included in the visualization

### Project/repo visualization (prepares for issue #56)
- New node types: `project` (green hexagons) and `repo` (gray squares)
- Handles concept↔project edges in both directions
- New edge colors for project relationship types (`implemented-in`, `applied-in`, `studied-by`)
- Updated tooltips to show project and repo metadata (description, language, topics, GitHub URL)

### Testing
- `TestProcessEdges_PaperToConcept` - verifies paper→concept edge handling with prefix normalization
- `TestProcessEdges_ConceptToProject` - verifies concept↔project edge handling
- `TestNormalizeID` - unit tests for ID normalization

## Test plan

- [x] Run `go test ./...` - all tests pass
- [x] Run `go vet ./...` - no issues
- [x] Test with nexus: `bip viz -o test.html` now shows 45 papers, 16 concepts, 59 edges
- [x] Verify visualization renders correctly in browser

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)