### PR TITLE
Print Cobra errors when required flags are missing

### DIFF
--- a/cmd/bip/main.go
+++ b/cmd/bip/main.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	"github.com/matsen/bipartite/internal/config"
@@ -20,6 +21,9 @@ var humanOutput bool
 
 func main() {
 	if err := rootCmd.Execute(); err != nil {
+		// Print the error since we have SilenceErrors: true
+		// This ensures Cobra errors (like missing required flags) are visible
+		fmt.Fprintf(os.Stderr, "Error: %s\n", err)
 		os.Exit(ExitError)
 	}
 }


### PR DESCRIPTION
## Summary
- Fix silent failure when required flags are missing from CLI commands (e.g., `bip edge add` without `--summary`)
- Print Cobra errors to stderr before exiting, so users see messages like `Error: required flag(s) "summary" not set`

The root command has `SilenceErrors: true` which suppresses Cobra's automatic error printing. This change ensures errors returned from `Execute()` are still visible to users.

## Test plan
- [x] Verify `bip edge add -s concept:foo -t project:bar -r relevant-to` now prints `Error: required flag(s) "summary" not set` instead of failing silently
- [x] Run `go test ./...` to verify no regressions

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)