### PR TITLE
Fix author search to use exact last name matching

### DIFF
--- a/.claude/skills/bip/SKILL.md
+++ b/.claude/skills/bip/SKILL.md
@@ -62,7 +62,7 @@ Suggest creating concepts when you notice:
 | Task | Command |
 |------|---------|
 | Search local library | `bip search "query"` |
-| Search by author | `bip search -a "Name"` (repeatable, AND logic) |
+| Search by author | `bip search -a "LastName"` (exact last name, AND logic) |
 | Search by title | `bip search -t "keywords"` or `--title` |
 | Search by year | `bip search --year 2024` or `--year 2020:` |
 | Search by venue | `bip search --venue "Nature"` (partial match) |
@@ -88,9 +88,10 @@ Suggest creating concepts when you notice:
 Use `--author` and `--year` flags for precise filtering:
 
 ```bash
-# Search by author (supports prefix matching: "Tim" matches "Timothy")
-bip search --author "Yu" --author "Bloom"
-bip search -a "Matsen" -a "Suchard"
+# Search by author (exact last name matching to avoid false positives)
+bip search --author "Yu" --author "Bloom"    # Last names only
+bip search -a "Tim Yu" -a "Bloom"            # First + last name
+bip search -a "Yu, Timothy"                  # Last, First format
 
 # Filter by year
 bip search --year 2024           # exact year
@@ -104,15 +105,21 @@ bip search "deep mutational scanning" --author "Bloom" --year 2023:
 
 **Multiple authors use AND logic** - all must appear in the paper.
 
+**Author matching rules:**
+- Single word (e.g., `-a "Yu"`) → exact last name match (won't match "Yujia")
+- Two+ words (e.g., `-a "Tim Yu"`) → exact last name + first name prefix
+- Comma format (e.g., `-a "Yu, Tim"`) → same as above
+
 ### Query Formulation Tips
 
 **Keep queries short and specific** - Long conceptual queries perform poorly:
 - Bad: `"correlation between BME criterion and Felsenstein likelihood around correct tree"`
 - Good: `"BME Felsenstein likelihood phylogeny"` or `"Bruno WEIGHBOR likelihood"`
 
-**Use --author flag instead of embedding names in query** - More reliable matching:
-- Good: `bip search -a "Yu" -a "Bloom" --year 2022:` (finds papers by Yu AND Bloom)
-- Less reliable: `bip search "Tim Yu Bloom"` (may miss "Timothy C Yu")
+**Use --author flag instead of embedding names in query** - Precise last name matching:
+- Good: `bip search -a "Yu" -a "Bloom" --year 2022:` (exact last name match)
+- Good: `bip search -a "Tim Yu" -a "Bloom"` (first prefix + exact last name)
+- Bad: `bip search "Tim Yu Bloom"` (keyword search is substring-based)
 
 **Use specific method/algorithm names**:
 - `"WEIGHBOR"`, `"FASTME"`, `"neighbor joining"` rather than general descriptions

--- a/cmd/bip/search.go
+++ b/cmd/bip/search.go
@@ -50,13 +50,17 @@ Query Syntax (positional argument):
   title:text     - Search title only
 
 Flags:
-  --author, -a   - Search by author (repeatable, AND logic, prefix matching)
+  --author, -a   - Search by author (repeatable, AND logic, exact last name)
   --title, -t    - Search in title only
   --year         - Filter by year (exact, range, or open-ended)
   --venue        - Filter by venue/journal (partial match)
   --doi          - Lookup by exact DOI
 
-Author matching supports prefix matching, so "Tim" matches "Timothy".
+Author matching uses exact last name matching to avoid false positives:
+  -a "Yu"           - Matches last name "Yu" exactly (not "Yujia")
+  -a "Timothy Yu"   - Last name "Yu" + first name starts with "Timothy"
+  -a "Yu, Timothy"  - Same as above (Last, First format)
+
 When multiple authors are specified, all must match (AND logic).
 
 Year syntax:

--- a/internal/author/query.go
+++ b/internal/author/query.go
@@ -1,0 +1,97 @@
+// Package author provides author name parsing and matching for search queries.
+package author
+
+import (
+	"strings"
+
+	"github.com/matsen/bipartite/internal/reference"
+)
+
+// Query represents a parsed author search query.
+type Query struct {
+	First string // First name (may be empty for last-name-only queries)
+	Last  string // Last name (required)
+}
+
+// ParseQuery parses an author search string into a structured Query.
+//
+// Supported formats:
+//   - "Yu"           → last="Yu" (single word = last name only)
+//   - "Timothy Yu"   → first="Timothy", last="Yu" (space-separated = First Last)
+//   - "Yu, Timothy"  → first="Timothy", last="Yu" (comma = Last, First)
+//
+// Names are trimmed but case is preserved (matching is case-insensitive).
+func ParseQuery(input string) Query {
+	input = strings.TrimSpace(input)
+	if input == "" {
+		return Query{}
+	}
+
+	// Check for comma format: "Last, First"
+	if idx := strings.Index(input, ","); idx > 0 {
+		last := strings.TrimSpace(input[:idx])
+		first := strings.TrimSpace(input[idx+1:])
+		return Query{First: first, Last: last}
+	}
+
+	// Check for space format: "First Last"
+	parts := strings.Fields(input)
+	if len(parts) == 1 {
+		// Single word = last name only
+		return Query{Last: parts[0]}
+	}
+
+	// Multiple words: last word is last name, rest is first name
+	// e.g., "Timothy C Yu" → first="Timothy C", last="Yu"
+	last := parts[len(parts)-1]
+	first := strings.Join(parts[:len(parts)-1], " ")
+	return Query{First: first, Last: last}
+}
+
+// Matches checks if the query matches a given author.
+//
+// Matching rules:
+//   - Last name: case-insensitive exact match (required)
+//   - First name: case-insensitive prefix match (if query has first name)
+//
+// This enables "Tim Yu" to match "Timothy C Yu" while preventing
+// "Yu" from matching "Yujia" (since "Yu" is not Yujia's last name).
+func (q Query) Matches(a reference.Author) bool {
+	// Last name must match exactly (case-insensitive)
+	if !strings.EqualFold(q.Last, a.Last) {
+		return false
+	}
+
+	// If no first name in query, we're done
+	if q.First == "" {
+		return true
+	}
+
+	// First name uses prefix matching (case-insensitive)
+	// "Tim" matches "Timothy", "Timothy C", etc.
+	return strings.HasPrefix(
+		strings.ToLower(a.First),
+		strings.ToLower(q.First),
+	)
+}
+
+// MatchesAny checks if the query matches any author in the list.
+func (q Query) MatchesAny(authors []reference.Author) bool {
+	for _, a := range authors {
+		if q.Matches(a) {
+			return true
+		}
+	}
+	return false
+}
+
+// AllMatch checks if all queries match at least one author each.
+// This implements AND logic for multiple author filters.
+func AllMatch(queries []Query, authors []reference.Author) bool {
+	for _, q := range queries {
+		if !q.MatchesAny(authors) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/author/query_test.go
+++ b/internal/author/query_test.go
@@ -1,0 +1,295 @@
+package author
+
+import (
+	"testing"
+
+	"github.com/matsen/bipartite/internal/reference"
+)
+
+func TestParseQuery(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  Query
+	}{
+		{
+			name:  "single word is last name",
+			input: "Yu",
+			want:  Query{Last: "Yu"},
+		},
+		{
+			name:  "two words is First Last",
+			input: "Timothy Yu",
+			want:  Query{First: "Timothy", Last: "Yu"},
+		},
+		{
+			name:  "three words: first two are first name",
+			input: "Timothy C Yu",
+			want:  Query{First: "Timothy C", Last: "Yu"},
+		},
+		{
+			name:  "comma format: Last, First",
+			input: "Yu, Timothy",
+			want:  Query{First: "Timothy", Last: "Yu"},
+		},
+		{
+			name:  "comma format with spaces",
+			input: "Yu,  Timothy C",
+			want:  Query{First: "Timothy C", Last: "Yu"},
+		},
+		{
+			name:  "leading/trailing whitespace",
+			input: "  Bloom  ",
+			want:  Query{Last: "Bloom"},
+		},
+		{
+			name:  "empty string",
+			input: "",
+			want:  Query{},
+		},
+		{
+			name:  "whitespace only",
+			input: "   ",
+			want:  Query{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseQuery(tt.input)
+			if got != tt.want {
+				t.Errorf("ParseQuery(%q) = %+v, want %+v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestQueryMatches(t *testing.T) {
+	tests := []struct {
+		name   string
+		query  Query
+		author reference.Author
+		want   bool
+	}{
+		{
+			name:   "exact last name match",
+			query:  Query{Last: "Yu"},
+			author: reference.Author{First: "Timothy C", Last: "Yu"},
+			want:   true,
+		},
+		{
+			name:   "last name case insensitive",
+			query:  Query{Last: "yu"},
+			author: reference.Author{First: "Timothy", Last: "Yu"},
+			want:   true,
+		},
+		{
+			name:   "last name no partial match",
+			query:  Query{Last: "Yu"},
+			author: reference.Author{First: "Yujia Alina", Last: "Chan"},
+			want:   false,
+		},
+		{
+			name:   "first and last match",
+			query:  Query{First: "Timothy", Last: "Yu"},
+			author: reference.Author{First: "Timothy C", Last: "Yu"},
+			want:   true,
+		},
+		{
+			name:   "first name prefix match",
+			query:  Query{First: "Tim", Last: "Yu"},
+			author: reference.Author{First: "Timothy C", Last: "Yu"},
+			want:   true,
+		},
+		{
+			name:   "first name case insensitive",
+			query:  Query{First: "timothy", Last: "Yu"},
+			author: reference.Author{First: "Timothy", Last: "Yu"},
+			want:   true,
+		},
+		{
+			name:   "first name mismatch",
+			query:  Query{First: "John", Last: "Yu"},
+			author: reference.Author{First: "Timothy", Last: "Yu"},
+			want:   false,
+		},
+		{
+			name:   "last name mismatch",
+			query:  Query{First: "Timothy", Last: "Chan"},
+			author: reference.Author{First: "Timothy", Last: "Yu"},
+			want:   false,
+		},
+		{
+			name:   "full first name with middle initial",
+			query:  Query{First: "Timothy C", Last: "Yu"},
+			author: reference.Author{First: "Timothy C", Last: "Yu"},
+			want:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.query.Matches(tt.author)
+			if got != tt.want {
+				t.Errorf("Query%+v.Matches(%+v) = %v, want %v", tt.query, tt.author, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestQueryMatchesAny(t *testing.T) {
+	authors := []reference.Author{
+		{First: "Jesse D", Last: "Bloom"},
+		{First: "Yujia Alina", Last: "Chan"},
+		{First: "Timothy C", Last: "Yu"},
+	}
+
+	tests := []struct {
+		name  string
+		query Query
+		want  bool
+	}{
+		{
+			name:  "matches first author",
+			query: Query{Last: "Bloom"},
+			want:  true,
+		},
+		{
+			name:  "matches last author",
+			query: Query{Last: "Yu"},
+			want:  true,
+		},
+		{
+			name:  "no match - Yu is not a last name here",
+			query: Query{First: "Yu", Last: "Something"},
+			want:  false,
+		},
+		{
+			name:  "matches with first name",
+			query: Query{First: "Jesse", Last: "Bloom"},
+			want:  true,
+		},
+		{
+			name:  "no match for nonexistent author",
+			query: Query{Last: "Smith"},
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.query.MatchesAny(authors)
+			if got != tt.want {
+				t.Errorf("Query%+v.MatchesAny() = %v, want %v", tt.query, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAllMatch(t *testing.T) {
+	authors := []reference.Author{
+		{First: "Jesse D", Last: "Bloom"},
+		{First: "Timothy C", Last: "Yu"},
+	}
+
+	tests := []struct {
+		name    string
+		queries []Query
+		want    bool
+	}{
+		{
+			name:    "both authors match",
+			queries: []Query{{Last: "Bloom"}, {Last: "Yu"}},
+			want:    true,
+		},
+		{
+			name:    "one author missing",
+			queries: []Query{{Last: "Bloom"}, {Last: "Chan"}},
+			want:    false,
+		},
+		{
+			name:    "empty queries matches all",
+			queries: []Query{},
+			want:    true,
+		},
+		{
+			name:    "single query matches",
+			queries: []Query{{Last: "Bloom"}},
+			want:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := AllMatch(tt.queries, authors)
+			if got != tt.want {
+				t.Errorf("AllMatch(%+v, authors) = %v, want %v", tt.queries, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestIssue81 tests the specific cases from GitHub issue #81.
+func TestIssue81(t *testing.T) {
+	// Paper: "Investigate the origins of COVID-19"
+	// Authors: Jesse D Bloom, Yujia Alina Chan, Ralph S Baric, ...
+	bloom2021Authors := []reference.Author{
+		{First: "Jesse D", Last: "Bloom"},
+		{First: "Yujia Alina", Last: "Chan"},
+		{First: "Ralph S", Last: "Baric"},
+	}
+
+	t.Run("Yu should not match Yujia", func(t *testing.T) {
+		query := ParseQuery("Yu")
+		if query.MatchesAny(bloom2021Authors) {
+			t.Error("Query 'Yu' should NOT match paper with Yujia Alina Chan")
+		}
+	})
+
+	t.Run("Bloom should match Jesse D Bloom", func(t *testing.T) {
+		query := ParseQuery("Bloom")
+		if !query.MatchesAny(bloom2021Authors) {
+			t.Error("Query 'Bloom' should match paper with Jesse D Bloom")
+		}
+	})
+
+	// Paper with actual Timothy Yu
+	yuPaperAuthors := []reference.Author{
+		{First: "Timothy C", Last: "Yu"},
+		{First: "Jesse D", Last: "Bloom"},
+	}
+
+	t.Run("Yu should match Timothy C Yu", func(t *testing.T) {
+		query := ParseQuery("Yu")
+		if !query.MatchesAny(yuPaperAuthors) {
+			t.Error("Query 'Yu' should match paper with Timothy C Yu")
+		}
+	})
+
+	t.Run("Timothy Yu should match Timothy C Yu", func(t *testing.T) {
+		query := ParseQuery("Timothy Yu")
+		if !query.MatchesAny(yuPaperAuthors) {
+			t.Error("Query 'Timothy Yu' should match paper with Timothy C Yu")
+		}
+	})
+
+	t.Run("Yu, Timothy should match Timothy C Yu", func(t *testing.T) {
+		query := ParseQuery("Yu, Timothy")
+		if !query.MatchesAny(yuPaperAuthors) {
+			t.Error("Query 'Yu, Timothy' should match paper with Timothy C Yu")
+		}
+	})
+
+	// Hodcroft2021-xj case: Timothy G Vaughan and Jesse D Bloom
+	hodcroftAuthors := []reference.Author{
+		{First: "Timothy G", Last: "Vaughan"},
+		{First: "Jesse D", Last: "Bloom"},
+	}
+
+	t.Run("Timothy Yu should not match Timothy Vaughan", func(t *testing.T) {
+		queries := []Query{ParseQuery("Timothy Yu"), ParseQuery("Bloom")}
+		if AllMatch(queries, hodcroftAuthors) {
+			t.Error("Queries 'Timothy Yu' + 'Bloom' should NOT match Hodcroft paper")
+		}
+	})
+}

--- a/internal/storage/sqlite_test.go
+++ b/internal/storage/sqlite_test.go
@@ -343,10 +343,31 @@ func TestDB_SearchWithFilters(t *testing.T) {
 			wantMin: 1,
 		},
 		{
-			name:    "single author prefix matching",
-			filters: SearchFilters{Authors: []string{"Jo"}}, // Should match John and Jones
+			name:    "author last name exact match",
+			filters: SearchFilters{Authors: []string{"Jones"}}, // Exact last name match
 			limit:   10,
-			wantMin: 2,
+			wantIDs: []string{"Jones2025-cd"},
+			wantMin: 1,
+		},
+		{
+			name:    "author first+last name",
+			filters: SearchFilters{Authors: []string{"John Smith"}}, // First Last format
+			limit:   10,
+			wantIDs: []string{"Smith2026-ab"},
+			wantMin: 1,
+		},
+		{
+			name:    "author first name prefix match",
+			filters: SearchFilters{Authors: []string{"Al Jones"}}, // "Al" prefix matches "Alice"
+			limit:   10,
+			wantIDs: []string{"Jones2025-cd"},
+			wantMin: 1,
+		},
+		{
+			name:    "partial last name no match",
+			filters: SearchFilters{Authors: []string{"Jo"}}, // "Jo" is not an exact last name
+			limit:   10,
+			wantMin: 0,
 		},
 		{
 			name:    "multiple authors (AND logic)",


### PR DESCRIPTION
## Summary
- Fixes false positives where `-a "Yu"` matched "Yujia" (substring in first name)
- Add `internal/author` package with query parsing supporting three formats:
  - `"Yu"` → exact last name match
  - `"Timothy Yu"` → exact last + first prefix
  - `"Yu, Timothy"` → Last, First format
- Move author filtering from FTS to Go post-processing for precision

## Test plan
- [x] Unit tests for query parsing (TestParseQuery)
- [x] Unit tests for matching logic (TestQueryMatches, TestQueryMatchesAny, TestAllMatch)
- [x] Specific issue #81 test cases (TestIssue81)
- [x] Integration tests pass (TestDB_SearchWithFilters)
- [x] Manual verification: `-a "Yu" -a "Bloom"` no longer returns Bloom2021-ej

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)