### PR TITLE
Add skill files and rename bip-extract-refs to dot convention

### DIFF
--- a/skills/bip.extract-refs/SKILL.md
+++ b/skills/bip.extract-refs/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: bip-extract-refs
+name: bip.extract-refs
 description: Extract paper references and concepts from a LaTeX repository for the bipartite knowledge graph.
 ---
 
@@ -10,7 +10,7 @@ Analyze a LaTeX repository to extract papers and concepts for the bipartite know
 ## Usage
 
 ```
-/bip-extract-refs <path-to-tex-repo>
+/bip.extract-refs <path-to-tex-repo>
 ```
 
 ## What This Skill Does
@@ -108,7 +108,7 @@ bip edge add -s Smith2026-ab -t x-model -r introduces -m "Foundational paper"
 ## Example Session
 
 ```
-User: /bip-extract-refs ../dasm-tex-1
+User: /bip.extract-refs ../dasm-tex-1
 
 Claude: I'll analyze the LaTeX repository to extract references and concepts.
 

--- a/skills/bip.import/SKILL.md
+++ b/skills/bip.import/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: bip.import
+description: Import Paperpile JSON export into bip library, rebuild database, and clean up.
+---
+
+# Import Paperpile Library
+
+Import a Paperpile JSON export from `~/Downloads/` into the bip reference library.
+
+## Usage
+
+```bash
+/bip.import              # Auto-detect latest Paperpile JSON in ~/Downloads
+/bip.import ~/path.json  # Explicit file path
+```
+
+## Workflow
+
+### 1. Find the export file
+
+If no path argument given, look for `~/Downloads/Paperpile*.json` or `~/Downloads/*.json`:
+
+```bash
+ls -lt ~/Downloads/Paperpile*.json 2>/dev/null || ls -lt ~/Downloads/*.json
+```
+
+If multiple files match, ask the user which one.
+
+### 2. Dry-run import
+
+Always dry-run first to show what will change:
+
+```bash
+cd ~/re/nexus
+bip import --format paperpile "<file>" --dry-run --human
+```
+
+Report the counts (new, updated, skipped) to the user. The skipped entries are typically old Paperpile records missing year or author — expected and not actionable.
+
+### 3. Import
+
+```bash
+bip import --format paperpile "<file>" --human
+```
+
+### 4. Rebuild database
+
+```bash
+bip rebuild --human
+```
+
+### 5. Delete the export file
+
+```bash
+rm "<file>"
+```
+
+### 6. Report
+
+Summarize: new refs added, total count, file deleted.

--- a/skills/issue-file/SKILL.md
+++ b/skills/issue-file/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: issue-file
+description: Create or update GitHub issue from markdown file using --body-file
+allowed-tools: Bash, Read
+---
+
+# /issue-file
+
+Create or update a GitHub issue using a markdown file as the body.
+
+## Usage
+
+```
+/issue-file ISSUE-feature-name.md
+```
+
+**CRITICAL: Use the `--body-file` flag to ensure the ENTIRE contents of the file become the issue body verbatim.**
+
+## Workflow
+
+### Step 1: Determine the file path
+
+- If `$ARGUMENTS` is provided, use that as the file path
+- Otherwise, check if the file path is clearly determinable from the current conversation context
+- If unclear, ask the user which file to use
+
+### Step 2: Check for existing issue context
+
+Search the recent conversation history for:
+- Issue numbers mentioned in previous `/work-issue` commands
+- Issue numbers referenced in discussion (e.g., "#123", "issue 123")
+- Any clear indication we're discussing a specific issue
+
+If found, this is an UPDATE operation. Otherwise, CREATE.
+
+### Step 3: Check for assignee context
+
+Look for explicit mentions like:
+- "this is an issue for [username]"
+- "assign this to [username]"
+
+**Do NOT auto-assign without explicit context.**
+
+### Step 4: Extract title from file
+
+For CREATE operations, extract the title from the file:
+1. Read the first line of the file
+2. If it starts with `# ` (markdown h1 heading), strip the `# ` prefix and use as title
+3. If no markdown heading, use the filename (without extension) as the title
+
+### Step 5: Execute
+
+**Update** (issue number found in context):
+```bash
+gh issue edit <number> --body-file <file>
+```
+
+**Create** (no issue number):
+```bash
+gh issue create --title "<extracted title>" --body-file <file>
+```
+
+**Create with assignee** (if explicitly mentioned):
+```bash
+gh issue create --title "<extracted title>" --body-file <file> --assignee <username>
+```
+
+**IMPORTANT:**
+- NEVER use `--label` flags
+- NEVER ask the user for the title — extract it from the file or filename
+- Use `--body-file` (or `-F`) flag exclusively for the body
+- Only add `--assignee` if explicitly mentioned in conversation context
+
+### Step 6: Report results
+
+After running the command, report:
+- Success/failure status
+- Issue number and URL
+- Whether it was a create or update operation

--- a/skills/work-issue/SKILL.md
+++ b/skills/work-issue/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: work-issue
+description: Read a GitHub issue and implement the work described in it
+allowed-tools: Bash, Read, Edit, Write, Glob, Grep, Task
+---
+
+# /work-issue
+
+Read a GitHub issue and do the work described in it.
+
+## Usage
+
+```
+/work-issue 123
+```
+
+The argument `$ARGUMENTS` is the issue number.
+
+## Workflow
+
+### Step 1: Read the issue
+
+```bash
+gh issue view $ARGUMENTS
+gh issue view $ARGUMENTS --comments
+```
+
+Read both the issue body and any comments for full context.
+
+### Step 2: Brainstorm clarifying questions
+
+Think hard about the issue requirements. If you have any clarifying questions, **STOP and ask them before writing any code**.
+
+Once everything is clear, proceed.
+
+### Step 3: Create a feature branch
+
+```bash
+git pull origin main
+git checkout -b $ARGUMENTS-<short-description>
+```
+
+Use the issue number as a branch prefix for traceability.
+
+### Step 4: Implement
+
+- Use code from the issue as a starting point when provided
+- Follow CLAUDE.md guidelines for the project
+- If you start deviating significantly from the issue, **STOP and discuss**
+- Continue until the issue is done and all tests pass
+
+### Step 5: Verify
+
+Before creating a PR, run quality checks. Most projects use:
+
+```bash
+make format   # Apply consistent formatting
+make check    # Static analysis / linting
+make test     # Run test suite
+```
+
+Not all projects define all of these — check the Makefile or CLAUDE.md for what's available.
+
+### Step 6: Create the PR
+
+```bash
+gh pr create --title "<concise title>" --body "Closes #$ARGUMENTS"
+```
+
+- Include `Closes #$ARGUMENTS` to auto-close the issue on merge
+- Do NOT manually close the issue — GitHub handles it when the PR merges


### PR DESCRIPTION
🤖

## Summary
- Rename `bip-extract-refs` → `bip.extract-refs` for dot-namespace consistency, fix stale `/bip-extract-refs` references in usage examples
- Add new skill files: `bip.import`, `issue-file`, `work-issue`

## Test plan
- [ ] Verify `/bip.extract-refs`, `/bip.import`, `/issue-file`, `/work-issue` skills load correctly in Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)