### PR TITLE
Document GitHub authentication setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ See the [Getting Started guide](https://matsen.github.io/bipartite/guides/gettin
 
 ## Configuration
 
-For full functionality, add API keys ([Semantic Scholar](https://www.semanticscholar.org/product/api#api-key), [Asta](https://allenai.org/asta/resources/mcp), [GitHub](https://github.com/settings/tokens), [Slack](https://api.slack.com/apps)) to your config:
+For full functionality, add API keys ([Semantic Scholar](https://www.semanticscholar.org/product/api#api-key), [Asta](https://allenai.org/asta/resources/mcp), [GitHub](https://matsen.github.io/bipartite/guides/configuration/#github-authentication), [Slack](https://api.slack.com/apps)) to your config:
 
 ```yaml
 nexus_path: ~/re/nexus


### PR DESCRIPTION
## Summary

🤖

- Adds a comprehensive GitHub Authentication section to the configuration guide covering both `gh` CLI auth and personal access tokens
- Documents fine-grained vs classic token setup with required scopes
- Includes command-to-auth-method table and troubleshooting tips
- Updates README to link to the new guide instead of the raw tokens page

## Test plan

- [ ] Verify docs site renders the new section correctly
- [ ] Confirm anchor link from README (`#github-authentication`) resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)