### PR TITLE
Fix ball-in-court filter missing comments outside since window

### DIFF
--- a/cmd/bip/checkin.go
+++ b/cmd/bip/checkin.go
@@ -170,14 +170,16 @@ func runCheckin(cmd *cobra.Command, args []string) {
 		// Apply ball-in-my-court filtering if enabled
 		if githubUser != "" {
 			// Include ALL PR reviews (not just since-filtered) for ball-in-court,
-			// since a review predating the window is still relevant.
+			// since a review predating the window is still relevant. This may
+			// duplicate since-window reviews already in allActions; duplicates
+			// are harmless since only the last actor per item matters.
 			allActions = append(allActions, flow.CommentsToActions(allReviewComments)...)
 
 			// Enrich actions: for items with no actions at all, fetch their
 			// last comment so ball-in-court doesn't fall through to the default.
 			// This fixes the bug where the user's comment predates the since window.
-			allItems := append(append([]flow.GitHubItem{}, issues...), prs...)
-			enriched := flow.EnrichActionsWithLastComments(repo, allItems, allActions)
+			itemsForEnrich := append(append([]flow.GitHubItem{}, issues...), prs...)
+			enriched := flow.EnrichActionsWithLastComments(repo, itemsForEnrich, allActions)
 			allActions = append(allActions, enriched...)
 
 			issues = flow.FilterByBallInCourt(issues, allActions, githubUser)

--- a/internal/flow/ballcourt.go
+++ b/internal/flow/ballcourt.go
@@ -142,10 +142,14 @@ func FilterByBallInCourt(items []GitHubItem, actions []ItemAction, githubUser st
 	return filtered
 }
 
-// EnrichActionsWithLastComments fetches the last comment for items that have
-// no actions in the current window. This prevents ball-in-court from falling
-// through to the author-based default when the user's last comment predates
-// the since window.
+// EnrichActionsWithLastComments fetches the last issue-thread comment for items
+// that have no actions in the current window. This prevents ball-in-court from
+// falling through to the author-based default when the user's last comment
+// predates the since window.
+//
+// Note: only issue-thread comments (/issues/{n}/comments) are considered here.
+// PR review submissions and inline review comments are handled separately
+// via FetchPRReviewsAsComments.
 func EnrichActionsWithLastComments(repo string, items []GitHubItem, existingActions []ItemAction) []ItemAction {
 	// Build set of item numbers that already have actions
 	hasActions := make(map[int]bool)
@@ -173,7 +177,8 @@ func EnrichActionsWithLastComments(repo string, items []GitHubItem, existingActi
 
 		itemNum := getCommentItemNumber(*comment)
 		if itemNum == 0 {
-			// Fallback: use the item number directly since we fetched for this specific item
+			// Should not occur unless the API returns a comment without issue_url;
+			// fall back to the known item number.
 			itemNum = item.Number
 		}
 		enriched = append(enriched, ItemAction{

--- a/internal/flow/gh.go
+++ b/internal/flow/gh.go
@@ -439,7 +439,8 @@ func fetchPRReviewsBatch(repo string, prNumbers []int) (map[int][]rawPRReview, e
 
 // FetchPRReviewsAsComments fetches PR reviews for a set of PRs and returns
 // them as GitHubComment entries so they participate in ball-in-court filtering.
-// Only reviews submitted since the given time are included.
+// Only reviews submitted at or after since are included; pass time.Time{} to
+// fetch all reviews regardless of age.
 // Uses a single batched GraphQL call, falling back to per-PR REST calls on failure.
 //
 // All errors are logged to stderr (never silently swallowed). A nil return
@@ -489,7 +490,6 @@ func FetchPRReviewsAsComments(repo string, prNumbers []int, since time.Time) []G
 			})
 		}
 	}
-	fmt.Fprintf(os.Stderr, "Fetched %d review comment(s) across %d PR(s) for %s\n", len(comments), len(prNumbers), repo)
 	return comments
 }
 


### PR DESCRIPTION
🤖

## Summary
- For items with no actions in the `since` window, fetch the last comment per-item via `GET /repos/{owner}/{repo}/issues/{number}/comments?per_page=1&direction=desc` so ball-in-court doesn't fall through to the author-based default
- Fetch ALL PR reviews (not just since-filtered) for accurate ball-in-court determination, reusing the single batch GraphQL call
- Fix silent error swallowing on comment fetch failures (now logs warnings to stderr)

## Test plan
- [x] All existing ball-in-court tests pass
- [x] `go vet ./...` clean
- [ ] Manual test: comment on someone's PR, wait, run `bip checkin` — PR should not appear

Closes #102