### PR TITLE
Add /land skill, fix bip.import and pre-merge-check

### DIFF
--- a/skills/bip.import/SKILL.md
+++ b/skills/bip.import/SKILL.md
@@ -31,7 +31,6 @@ If multiple files match, ask the user which one.
 Always dry-run first to show what will change:
 
 ```bash
-cd ~/re/nexus
 bip import --format paperpile "<file>" --dry-run --human
 ```
 

--- a/skills/land/SKILL.md
+++ b/skills/land/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: land
+description: Land a PR branch — squash merge, clean up local and remote branches, return to main.
+---
+
+# /land
+
+Squash-merge the current branch's PR and clean up.
+
+## Usage
+
+```
+/land           # Land the current branch's PR
+/land #42       # Land PR #42 (if not on that branch)
+```
+
+## Workflow
+
+### Step 1: Identify the PR
+
+```bash
+# Get current branch
+BRANCH=$(git branch --show-current)
+
+# Find the PR for this branch
+gh pr view "$BRANCH" --json number,title,state,baseRefName
+```
+
+If no PR found, abort: "No PR found for branch `$BRANCH`."
+If PR is not open, abort: "PR is already `$STATE`."
+
+Save the base branch name (usually `main` or `master`) from `baseRefName`.
+
+### Step 2: Confirm with user
+
+Show the PR title and number, and ask for confirmation before proceeding:
+
+```
+About to land: #42 "Add feature X" (branch: my-feature → main)
+Proceed?
+```
+
+**STOP and wait for user confirmation.**
+
+### Step 3: Update base branch and rebase
+
+```bash
+git fetch origin
+git rebase origin/<base>
+```
+
+If rebase has conflicts, stop and report. Do not force-push or auto-resolve.
+
+### Step 4: Force-push rebased branch
+
+```bash
+git push --force-with-lease
+```
+
+### Step 5: Squash merge via gh
+
+```bash
+# If PR closes an issue (check PR body for "closes #N" or "fixes #N"):
+gh pr merge --squash --body "closes #N"
+
+# Otherwise:
+gh pr merge --squash --body ""
+```
+
+Follow the squash merge conventions from global CLAUDE.md — PR title becomes the commit message, body is minimal.
+
+### Step 6: Return to base branch and pull
+
+```bash
+git checkout <base>
+git pull
+```
+
+### Step 7: Delete local branch
+
+```bash
+git branch -d <branch>
+```
+
+The remote branch is already deleted by `gh pr merge` (GitHub default).
+If not, also run: `git push origin --delete <branch>`
+
+### Step 8: Confirm
+
+Report: "Landed #42. On `<base>`, up to date. Branch `<branch>` deleted."

--- a/skills/pre-merge-check/SKILL.md
+++ b/skills/pre-merge-check/SKILL.md
@@ -33,10 +33,26 @@ Examine the repository to determine what checks apply:
 
 Multiple types can apply (e.g., Snakemake + Python).
 
+### Step 1.5: Fetch and determine base branch
+
+Always fetch first so comparisons are against the true remote state, not a stale local branch:
+
+```bash
+git fetch origin
+```
+
+Determine the base branch from the PR (if one exists), otherwise default to `main` or `master`:
+
+```bash
+gh pr view --json baseRefName -q .baseRefName 2>/dev/null || echo "main"
+```
+
+Use `origin/<base>` (not local `<base>`) for all diffs below. This avoids false positives from a stale local main.
+
 ### Step 2: Identify Changed Files
 
 ```bash
-git diff main...HEAD --name-only
+git diff origin/<base>...HEAD --name-only
 ```
 
 Focus review on changed files, not the entire codebase.
@@ -59,7 +75,7 @@ Scan changed files for artifacts that typically shouldn't be committed:
 
 **Check file sizes:**
 ```bash
-git diff main...HEAD --name-only | xargs -I{} sh -c 'test -f "{}" && stat -f "%z %N" "{}" 2>/dev/null || stat --format="%s %n" "{}" 2>/dev/null' | awk '$1 > 102400 {print}'
+git diff origin/<base>...HEAD --name-only | xargs -I{} sh -c 'test -f "{}" && stat -f "%z %N" "{}" 2>/dev/null || stat --format="%s %n" "{}" 2>/dev/null' | awk '$1 > 102400 {print}'
 ```
 
 Flag anything suspicious for user confirmation before proceeding.


### PR DESCRIPTION
🤖

## Summary
- **`/land`**: New skill for squash-merging PRs and cleaning up local/remote branches
- **`/bip.import`**: Remove unnecessary `cd ~/re/nexus` — bip works from any directory
- **`/pre-merge-check`**: Fetch origin and diff against `origin/<base>` instead of local `main` to avoid stale delta issues

## Test plan
- [ ] Run `/bip.import` from a non-nexus directory
- [ ] Run `/pre-merge-check` on a branch where local main is behind remote
- [ ] Run `/land` on a branch with an open PR