### PR TITLE
kaizen: verify PR/issue state before presenting checkin action items

### DIFF
--- a/skills/bip.checkin/SKILL.md
+++ b/skills/bip.checkin/SKILL.md
@@ -88,6 +88,13 @@ Skip issues that are:
 - Pure questions/discussions without actionable work
 - Already closed
 
+## Action item verification
+
+Before presenting any item as an action item (e.g., "ready to merge", "needs review"):
+- Verify current state with `gh pr view --repo <owner>/<repo> <number> --json state` or `gh api`
+- Do NOT infer state from comment content alone — checkin shows *activity*, not *status*
+- Only label items as actionable if they are confirmed OPEN and awaiting the user's input
+
 ## Output guidelines
 
 When summarizing checkin results:


### PR DESCRIPTION
## Summary
- Adds an "Action item verification" section to the `bip.checkin` skill
- Requires the agent to confirm open/merged/closed state via `gh pr view` before labeling items as action items
- Prevents false action items caused by inferring state from comment activity alone

## Context
During a checkin, data-central#99 was presented as "ready to merge" based on an LGTM comment, but it had already been merged 5 days earlier. This wasted the user's time.

## Test plan
- [ ] Run `/bip.checkin` and verify action items are confirmed open before being presented

🤖 Generated with [Claude Code](https://claude.com/claude-code)