### PR TITLE
Add Zotero integration (import, sync, add)

### DIFF
--- a/cmd/bip/import.go
+++ b/cmd/bip/import.go
@@ -12,13 +12,15 @@ import (
 )
 
 var (
-	importFormat string
-	importDryRun bool
+	importFormat   string
+	importDryRun   bool
+	importZoteroDB string
 )
 
 func init() {
-	importCmd.Flags().StringVar(&importFormat, "format", "", "Import format (paperpile)")
+	importCmd.Flags().StringVar(&importFormat, "format", "", "Import format (paperpile, zotero)")
 	importCmd.Flags().BoolVar(&importDryRun, "dry-run", false, "Show what would be imported without writing")
+	importCmd.Flags().StringVar(&importZoteroDB, "zotero-db", "", "Path to Zotero SQLite database for PDF resolution (e.g., ~/Zotero/zotero.sqlite)")
 	importCmd.MarkFlagRequired("format")
 	rootCmd.AddCommand(importCmd)
 }
@@ -30,10 +32,12 @@ var importCmd = &cobra.Command{
 
 Usage:
   bip import --format paperpile export.json
+  bip import --format zotero export.json
   bip import --format paperpile export.json --dry-run
 
 Supported formats:
-  paperpile  - Paperpile JSON export`,
+  paperpile  - Paperpile JSON export
+  zotero     - Zotero CSL-JSON export`,
 	Args: cobra.ExactArgs(1),
 	RunE: runImport,
 }
@@ -73,12 +77,26 @@ func runImport(cmd *cobra.Command, args []string) error {
 	repoRoot := mustFindRepository()
 
 	// Validate format
-	if importFormat != "paperpile" {
-		exitWithError(ExitError, "unknown format: %s", importFormat)
+	switch importFormat {
+	case "paperpile", "zotero":
+		// valid
+	default:
+		exitWithError(ExitError, "unknown format: %s (supported: paperpile, zotero)", importFormat)
 	}
 
 	// Parse input file
 	newRefs, parseErrors := parseImportFile(args[0])
+
+	// Resolve Zotero PDF paths if database provided
+	if importZoteroDB != "" && importFormat == "zotero" {
+		dbPath := config.ExpandTilde(importZoteroDB)
+		resolved, err := importer.ResolveZoteroPDFs(newRefs, dbPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: PDF resolution failed: %v\n", err)
+		} else if humanOutput {
+			fmt.Printf("Resolved %d PDF paths from Zotero database\n", resolved)
+		}
+	}
 
 	// Load existing references
 	refsPath := config.RefsPath(repoRoot)
@@ -116,7 +134,16 @@ func parseImportFile(path string) ([]reference.Reference, []error) {
 		exitWithError(ExitError, "reading file: %v", err)
 	}
 
-	newRefs, parseErrors := importer.ParsePaperpile(data)
+	var newRefs []reference.Reference
+	var parseErrors []error
+
+	switch importFormat {
+	case "paperpile":
+		newRefs, parseErrors = importer.ParsePaperpile(data)
+	case "zotero":
+		newRefs, parseErrors = importer.ParseZotero(data)
+	}
+
 	if len(parseErrors) > 0 && len(newRefs) == 0 {
 		exitWithError(ExitDataError, "failed to parse any references: %v", parseErrors[0])
 	}
@@ -184,7 +211,7 @@ func errorsToStrings(errs []error) []string {
 // reportDryRun outputs the dry-run results.
 func reportDryRun(stats importStats, details []ImportDetail, errStrs []string) {
 	if humanOutput {
-		fmt.Println("Dry run - would import from Paperpile export...")
+		fmt.Printf("Dry run - would import from %s export...\n", importFormat)
 		fmt.Printf("  Would add:    %d new references\n", stats.newCount)
 		fmt.Printf("  Would update: %d existing references (matched by DOI or ID)\n", stats.updated)
 		fmt.Printf("  Would skip:   %d (errors or duplicates)\n", stats.skipped)
@@ -207,7 +234,7 @@ func reportDryRun(stats importStats, details []ImportDetail, errStrs []string) {
 // reportImportResults outputs the actual import results.
 func reportImportResults(stats importStats, errStrs []string) {
 	if humanOutput {
-		fmt.Println("Imported from Paperpile export:")
+		fmt.Printf("Imported from %s export:\n", importFormat)
 		fmt.Printf("  Added:   %d new references\n", stats.newCount)
 		fmt.Printf("  Updated: %d existing references (matched by DOI or ID)\n", stats.updated)
 		fmt.Printf("  Skipped: %d (errors or duplicates)\n", stats.skipped)

--- a/cmd/bip/zotero.go
+++ b/cmd/bip/zotero.go
@@ -4,13 +4,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Exit codes specific to zotero commands.
-const (
-	ExitZoteroNotConfigured = 1 // API key or user ID not set
-	ExitZoteroAPIError      = 2 // API error (rate limit, network)
-	ExitZoteroDuplicate     = 3 // Item already exists
-)
-
 var zoteroCmd = &cobra.Command{
 	Use:   "zotero",
 	Short: "Zotero library integration commands",

--- a/cmd/bip/zotero.go
+++ b/cmd/bip/zotero.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// Exit codes specific to zotero commands.
+const (
+	ExitZoteroNotConfigured = 1 // API key or user ID not set
+	ExitZoteroAPIError      = 2 // API error (rate limit, network)
+	ExitZoteroDuplicate     = 3 // Item already exists
+)
+
+var zoteroCmd = &cobra.Command{
+	Use:   "zotero",
+	Short: "Zotero library integration commands",
+	Long: `Commands for syncing with Zotero's Web API.
+
+Sync papers between your bip library and Zotero, or add new papers
+to both simultaneously.
+
+Requires zotero_api_key and zotero_user_id in ~/.config/bip/config.yml.
+
+All commands output JSON by default for agent consumption.
+Use --human flag for human-readable output.`,
+}
+
+func init() {
+	rootCmd.AddCommand(zoteroCmd)
+}

--- a/cmd/bip/zotero_add.go
+++ b/cmd/bip/zotero_add.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/matsen/bipartite/internal/config"
 	"github.com/matsen/bipartite/internal/reference"
@@ -16,16 +17,16 @@ import (
 var zoteroAddCmd = &cobra.Command{
 	Use:   "add <paper-id>",
 	Short: "Add a paper to both bip and Zotero",
-	Long: `Add a paper by fetching metadata from Semantic Scholar and creating
-it in both your bip library and your Zotero library.
+	Long: `Add a paper by fetching metadata and creating it in both your bip
+library and your Zotero library.
+
+Metadata is fetched from Semantic Scholar first. If S2 is rate-limited
+and the ID is a DOI, falls back to CrossRef (free, no key needed).
 
 Supported paper ID formats:
   DOI:10.1038/nature12373      DOI
   ARXIV:2106.15928             arXiv ID
   PMID:19872477                PubMed ID
-
-The paper metadata is fetched from Semantic Scholar (free, no Zotero
-lookup needed), then pushed to Zotero and saved to bip simultaneously.
 
 Examples:
   bip zotero add DOI:10.1038/nature12373
@@ -40,7 +41,8 @@ func init() {
 
 // ZoteroAddResult is the JSON output for the add command.
 type ZoteroAddResult struct {
-	Action    string             `json:"action"` // added, skipped
+	Action    string             `json:"action"`              // added, skipped
+	Source    string             `json:"source,omitempty"`    // s2, crossref
 	BipPaper  *S2AddPaperSummary `json:"bip_paper,omitempty"`
 	ZoteroKey string             `json:"zotero_key,omitempty"`
 	Error     *S2ErrorResult     `json:"error,omitempty"`
@@ -50,12 +52,11 @@ func runZoteroAdd(cmd *cobra.Command, args []string) error {
 	paperID := args[0]
 	ctx := context.Background()
 
-	// Create clients
+	// Create Zotero client
 	zotClient, err := zotero.NewClient()
 	if err != nil {
 		return outputZoteroError(ExitZoteroNotConfigured, "Zotero not configured", err)
 	}
-	s2Client := s2.NewClient()
 
 	// Find repository
 	repoRoot := mustFindRepository()
@@ -67,25 +68,16 @@ func runZoteroAdd(cmd *cobra.Command, args []string) error {
 		return outputZoteroError(ExitZoteroAPIError, "reading refs", err)
 	}
 
-	// Parse and fetch from S2
-	parsed := s2.ParsePaperID(paperID)
-	s2ID := parsed.String()
-
-	paper, err := s2Client.GetPaper(ctx, s2ID)
+	// Resolve metadata: try S2 first, fall back to CrossRef for DOIs
+	ref, metadataSource, err := resolveMetadata(ctx, paperID)
 	if err != nil {
-		if s2.IsNotFound(err) {
-			return outputGenericNotFound(paperID, "Paper not found in Semantic Scholar")
-		}
-		return outputZoteroError(ExitZoteroAPIError, "fetching from Semantic Scholar", err)
+		return outputZoteroError(ExitZoteroAPIError, "resolving paper metadata", err)
 	}
 
-	// Map to reference
-	ref := s2.MapS2ToReference(*paper)
-
 	// Check for duplicates in bip
-	if paper.ExternalIDs.DOI != "" {
-		if _, found := storage.FindByDOI(refs, paper.ExternalIDs.DOI); found {
-			return outputZoteroDuplicate(ref.ID, paper.ExternalIDs.DOI)
+	if ref.DOI != "" {
+		if _, found := storage.FindByDOI(refs, ref.DOI); found {
+			return outputZoteroDuplicate(ref.ID, ref.DOI)
 		}
 	}
 
@@ -112,6 +104,7 @@ func runZoteroAdd(cmd *cobra.Command, args []string) error {
 	authors := formatAuthors(ref.Authors)
 	result := ZoteroAddResult{
 		Action:    "added",
+		Source:    metadataSource,
 		ZoteroKey: createdItem.Key,
 		BipPaper: &S2AddPaperSummary{
 			ID:      ref.ID,
@@ -124,7 +117,7 @@ func runZoteroAdd(cmd *cobra.Command, args []string) error {
 	}
 
 	if humanOutput {
-		fmt.Printf("Added to both bip and Zotero:\n")
+		fmt.Printf("Added to both bip and Zotero (via %s):\n", metadataSource)
 		fmt.Printf("  bip ID:     %s\n", ref.ID)
 		fmt.Printf("  Zotero key: %s\n", createdItem.Key)
 		fmt.Printf("  Title:      %s\n", ref.Title)
@@ -138,6 +131,41 @@ func runZoteroAdd(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+// resolveMetadata tries S2 first, then CrossRef for DOIs.
+func resolveMetadata(ctx context.Context, paperID string) (reference.Reference, string, error) {
+	parsed := s2.ParsePaperID(paperID)
+	s2ID := parsed.String()
+
+	// Try Semantic Scholar first
+	s2Client := s2.NewClient()
+	paper, err := s2Client.GetPaper(ctx, s2ID)
+	if err == nil {
+		ref := s2.MapS2ToReference(*paper)
+		return ref, "s2", nil
+	}
+
+	// If S2 failed and we have a DOI, try CrossRef
+	if parsed.Type == "DOI" || strings.HasPrefix(paperID, "DOI:") {
+		doi := parsed.Value
+		if humanOutput {
+			fmt.Fprintf(os.Stderr, "S2 unavailable (%v), trying CrossRef...\n", err)
+		}
+
+		ref, crErr := zotero.LookupDOI(ctx, doi)
+		if crErr == nil {
+			return ref, "crossref", nil
+		}
+		// Both failed
+		return reference.Reference{}, "", fmt.Errorf("S2: %v; CrossRef: %v", err, crErr)
+	}
+
+	// Non-DOI identifier and S2 failed
+	if s2.IsNotFound(err) {
+		return reference.Reference{}, "", fmt.Errorf("paper not found in Semantic Scholar: %s", paperID)
+	}
+	return reference.Reference{}, "", fmt.Errorf("Semantic Scholar error: %v", err)
 }
 
 func outputZoteroDuplicate(existingID, doi string) error {

--- a/cmd/bip/zotero_add.go
+++ b/cmd/bip/zotero_add.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/matsen/bipartite/internal/config"
+	"github.com/matsen/bipartite/internal/reference"
+	"github.com/matsen/bipartite/internal/s2"
+	"github.com/matsen/bipartite/internal/storage"
+	"github.com/matsen/bipartite/internal/zotero"
+	"github.com/spf13/cobra"
+)
+
+var zoteroAddCmd = &cobra.Command{
+	Use:   "add <paper-id>",
+	Short: "Add a paper to both bip and Zotero",
+	Long: `Add a paper by fetching metadata from Semantic Scholar and creating
+it in both your bip library and your Zotero library.
+
+Supported paper ID formats:
+  DOI:10.1038/nature12373      DOI
+  ARXIV:2106.15928             arXiv ID
+  PMID:19872477                PubMed ID
+
+The paper metadata is fetched from Semantic Scholar (free, no Zotero
+lookup needed), then pushed to Zotero and saved to bip simultaneously.
+
+Examples:
+  bip zotero add DOI:10.1038/nature12373
+  bip zotero add DOI:10.1093/ve/vead055 --human`,
+	Args: cobra.ExactArgs(1),
+	RunE: runZoteroAdd,
+}
+
+func init() {
+	zoteroCmd.AddCommand(zoteroAddCmd)
+}
+
+// ZoteroAddResult is the JSON output for the add command.
+type ZoteroAddResult struct {
+	Action    string             `json:"action"` // added, skipped
+	BipPaper  *S2AddPaperSummary `json:"bip_paper,omitempty"`
+	ZoteroKey string             `json:"zotero_key,omitempty"`
+	Error     *S2ErrorResult     `json:"error,omitempty"`
+}
+
+func runZoteroAdd(cmd *cobra.Command, args []string) error {
+	paperID := args[0]
+	ctx := context.Background()
+
+	// Create clients
+	zotClient, err := zotero.NewClient()
+	if err != nil {
+		return outputZoteroError(ExitZoteroNotConfigured, "Zotero not configured", err)
+	}
+	s2Client := s2.NewClient()
+
+	// Find repository
+	repoRoot := mustFindRepository()
+	refsPath := config.RefsPath(repoRoot)
+
+	// Load existing refs
+	refs, err := storage.ReadAll(refsPath)
+	if err != nil {
+		return outputZoteroError(ExitZoteroAPIError, "reading refs", err)
+	}
+
+	// Parse and fetch from S2
+	parsed := s2.ParsePaperID(paperID)
+	s2ID := parsed.String()
+
+	paper, err := s2Client.GetPaper(ctx, s2ID)
+	if err != nil {
+		if s2.IsNotFound(err) {
+			return outputGenericNotFound(paperID, "Paper not found in Semantic Scholar")
+		}
+		return outputZoteroError(ExitZoteroAPIError, "fetching from Semantic Scholar", err)
+	}
+
+	// Map to reference
+	ref := s2.MapS2ToReference(*paper)
+
+	// Check for duplicates in bip
+	if paper.ExternalIDs.DOI != "" {
+		if _, found := storage.FindByDOI(refs, paper.ExternalIDs.DOI); found {
+			return outputZoteroDuplicate(ref.ID, paper.ExternalIDs.DOI)
+		}
+	}
+
+	// Add to Zotero
+	zotItem := zotero.MapReferenceToZotero(ref)
+	createdItem, err := zotClient.CreateItem(ctx, zotItem)
+	if err != nil {
+		return outputZoteroError(ExitZoteroAPIError, "creating item in Zotero", err)
+	}
+
+	// Update the ref with the Zotero key
+	ref.Source = reference.ImportSource{
+		Type: "zotero",
+		ID:   createdItem.Key,
+	}
+
+	// Add to bip
+	ref.ID = storage.GenerateUniqueID(refs, ref.ID)
+	if err := storage.Append(refsPath, ref); err != nil {
+		return outputZoteroError(ExitZoteroAPIError, "saving reference", err)
+	}
+
+	// Output
+	authors := formatAuthors(ref.Authors)
+	result := ZoteroAddResult{
+		Action:    "added",
+		ZoteroKey: createdItem.Key,
+		BipPaper: &S2AddPaperSummary{
+			ID:      ref.ID,
+			DOI:     ref.DOI,
+			Title:   ref.Title,
+			Authors: authors,
+			Year:    ref.Published.Year,
+			Venue:   ref.Venue,
+		},
+	}
+
+	if humanOutput {
+		fmt.Printf("Added to both bip and Zotero:\n")
+		fmt.Printf("  bip ID:     %s\n", ref.ID)
+		fmt.Printf("  Zotero key: %s\n", createdItem.Key)
+		fmt.Printf("  Title:      %s\n", ref.Title)
+		fmt.Printf("  Authors:    %s\n", joinAuthorsDisplay(authors))
+		fmt.Printf("  Year:       %d\n", ref.Published.Year)
+		if ref.Venue != "" {
+			fmt.Printf("  Venue:      %s\n", ref.Venue)
+		}
+	} else {
+		outputJSON(result)
+	}
+
+	return nil
+}
+
+func outputZoteroDuplicate(existingID, doi string) error {
+	result := ZoteroAddResult{
+		Action: "skipped",
+		Error: &S2ErrorResult{
+			Code:    "duplicate",
+			Message: "Paper already exists in bip collection",
+			PaperID: existingID,
+		},
+	}
+
+	if humanOutput {
+		fmt.Fprintf(os.Stderr, "Paper already exists: %s\n", existingID)
+		if doi != "" {
+			fmt.Fprintf(os.Stderr, "  DOI: %s\n", doi)
+		}
+	} else {
+		outputJSON(result)
+	}
+	os.Exit(ExitZoteroDuplicate)
+	return nil
+}

--- a/cmd/bip/zotero_add.go
+++ b/cmd/bip/zotero_add.go
@@ -41,8 +41,8 @@ func init() {
 
 // ZoteroAddResult is the JSON output for the add command.
 type ZoteroAddResult struct {
-	Action    string             `json:"action"`              // added, skipped
-	Source    string             `json:"source,omitempty"`    // s2, crossref
+	Action    string             `json:"action"`           // added, skipped
+	Source    string             `json:"source,omitempty"` // s2, crossref
 	BipPaper  *S2AddPaperSummary `json:"bip_paper,omitempty"`
 	ZoteroKey string             `json:"zotero_key,omitempty"`
 	Error     *S2ErrorResult     `json:"error,omitempty"`
@@ -55,7 +55,7 @@ func runZoteroAdd(cmd *cobra.Command, args []string) error {
 	// Create Zotero client
 	zotClient, err := zotero.NewClient()
 	if err != nil {
-		return outputZoteroError(ExitZoteroNotConfigured, "Zotero not configured", err)
+		return outputZoteroError(ExitConfigError, "Zotero not configured", err)
 	}
 
 	// Find repository
@@ -65,18 +65,23 @@ func runZoteroAdd(cmd *cobra.Command, args []string) error {
 	// Load existing refs
 	refs, err := storage.ReadAll(refsPath)
 	if err != nil {
-		return outputZoteroError(ExitZoteroAPIError, "reading refs", err)
+		return outputZoteroError(ExitError, "reading refs", err)
 	}
 
 	// Resolve metadata: try S2 first, fall back to CrossRef for DOIs
 	ref, metadataSource, err := resolveMetadata(ctx, paperID)
 	if err != nil {
-		return outputZoteroError(ExitZoteroAPIError, "resolving paper metadata", err)
+		return outputZoteroError(ExitError, "resolving paper metadata", err)
 	}
 
-	// Check for duplicates in bip
+	// Check for duplicates in bip (by DOI or ID)
 	if ref.DOI != "" {
 		if _, found := storage.FindByDOI(refs, ref.DOI); found {
+			return outputZoteroDuplicate(ref.ID, ref.DOI)
+		}
+	}
+	if ref.ID != "" {
+		if _, found := storage.FindByID(refs, ref.ID); found {
 			return outputZoteroDuplicate(ref.ID, ref.DOI)
 		}
 	}
@@ -85,7 +90,7 @@ func runZoteroAdd(cmd *cobra.Command, args []string) error {
 	zotItem := zotero.MapReferenceToZotero(ref)
 	createdItem, err := zotClient.CreateItem(ctx, zotItem)
 	if err != nil {
-		return outputZoteroError(ExitZoteroAPIError, "creating item in Zotero", err)
+		return outputZoteroError(ExitError, "creating item in Zotero", err)
 	}
 
 	// Update the ref with the Zotero key
@@ -97,7 +102,7 @@ func runZoteroAdd(cmd *cobra.Command, args []string) error {
 	// Add to bip
 	ref.ID = storage.GenerateUniqueID(refs, ref.ID)
 	if err := storage.Append(refsPath, ref); err != nil {
-		return outputZoteroError(ExitZoteroAPIError, "saving reference", err)
+		return outputZoteroError(ExitError, "saving reference", err)
 	}
 
 	// Output
@@ -186,6 +191,6 @@ func outputZoteroDuplicate(existingID, doi string) error {
 	} else {
 		outputJSON(result)
 	}
-	os.Exit(ExitZoteroDuplicate)
+	os.Exit(ExitDataError)
 	return nil
 }

--- a/cmd/bip/zotero_sync.go
+++ b/cmd/bip/zotero_sync.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/matsen/bipartite/internal/config"
+	"github.com/matsen/bipartite/internal/storage"
+	"github.com/matsen/bipartite/internal/zotero"
+	"github.com/spf13/cobra"
+)
+
+var zoteroSyncCmd = &cobra.Command{
+	Use:   "sync",
+	Short: "Sync references from Zotero library into bip",
+	Long: `Pull all items from your Zotero library and import them into bip.
+
+New items are added, existing items (matched by Zotero key, DOI, or ID)
+are updated with the latest metadata.
+
+Examples:
+  bip zotero sync
+  bip zotero sync --human
+  bip zotero sync --dry-run --human`,
+	Args: cobra.NoArgs,
+	RunE: runZoteroSync,
+}
+
+var zoteroSyncDryRun bool
+
+func init() {
+	zoteroCmd.AddCommand(zoteroSyncCmd)
+	zoteroSyncCmd.Flags().BoolVar(&zoteroSyncDryRun, "dry-run", false, "Show what would be synced without writing")
+}
+
+// ZoteroSyncResult is the JSON output for the sync command.
+type ZoteroSyncResult struct {
+	Action  string `json:"action"` // synced, dry_run
+	Fetched int    `json:"fetched"`
+	New     int    `json:"new"`
+	Updated int    `json:"updated"`
+	Skipped int    `json:"skipped"`
+	Errors  int    `json:"errors"`
+}
+
+func runZoteroSync(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	// Create Zotero client
+	client, err := zotero.NewClient()
+	if err != nil {
+		return outputZoteroError(ExitZoteroNotConfigured, "Zotero not configured", err)
+	}
+
+	// Find repository
+	repoRoot := mustFindRepository()
+	refsPath := config.RefsPath(repoRoot)
+
+	// Load existing refs
+	existingRefs, err := storage.ReadAll(refsPath)
+	if err != nil {
+		return outputZoteroError(ExitZoteroAPIError, "reading refs", err)
+	}
+
+	// Fetch items from Zotero
+	if humanOutput {
+		fmt.Println("Fetching items from Zotero...")
+	}
+
+	items, err := client.GetItems(ctx)
+	if err != nil {
+		return outputZoteroError(ExitZoteroAPIError, "fetching items from Zotero", err)
+	}
+
+	if humanOutput {
+		fmt.Printf("Fetched %d items from Zotero\n", len(items))
+	}
+
+	// Convert and classify
+	var newRefs []storage.RefWithAction
+	stats := importStats{}
+	var convertErrors int
+
+	for _, item := range items {
+		ref, err := zotero.MapZoteroToReference(item)
+		if err != nil {
+			convertErrors++
+			continue
+		}
+
+		// Classify against existing refs (reuse import pipeline logic)
+		action := classifyImport(existingRefs, ref)
+
+		switch action.action {
+		case "new":
+			ref.ID = storage.GenerateUniqueID(existingRefs, ref.ID)
+			newRefs = append(newRefs, storage.RefWithAction{Ref: ref, Action: "new"})
+			existingRefs = append(existingRefs, ref)
+			stats.newCount++
+		case "update":
+			newRefs = append(newRefs, storage.RefWithAction{Ref: ref, Action: "update", ExistingIdx: action.existingIdx})
+			stats.updated++
+		case "skip":
+			stats.skipped++
+		}
+	}
+
+	result := ZoteroSyncResult{
+		Fetched: len(items),
+		New:     stats.newCount,
+		Updated: stats.updated,
+		Skipped: stats.skipped,
+		Errors:  convertErrors,
+	}
+
+	if zoteroSyncDryRun {
+		result.Action = "dry_run"
+		if humanOutput {
+			fmt.Printf("\nDry run - would sync from Zotero:\n")
+			fmt.Printf("  Would add:    %d new references\n", stats.newCount)
+			fmt.Printf("  Would update: %d existing references\n", stats.updated)
+			fmt.Printf("  Skipped:      %d (no changes)\n", stats.skipped)
+			if convertErrors > 0 {
+				fmt.Printf("  Errors:       %d (missing required fields)\n", convertErrors)
+			}
+		} else {
+			outputJSON(result)
+		}
+		return nil
+	}
+
+	// Actually persist
+	// Re-read existing refs fresh for the actual write
+	existingRefs, err = storage.ReadAll(refsPath)
+	if err != nil {
+		return outputZoteroError(ExitZoteroAPIError, "reading refs", err)
+	}
+
+	if err := persistImports(refsPath, existingRefs, newRefs); err != nil {
+		return outputZoteroError(ExitZoteroAPIError, "writing refs", err)
+	}
+
+	result.Action = "synced"
+	if humanOutput {
+		fmt.Printf("\nSynced from Zotero:\n")
+		fmt.Printf("  Added:   %d new references\n", stats.newCount)
+		fmt.Printf("  Updated: %d existing references\n", stats.updated)
+		fmt.Printf("  Skipped: %d (no changes)\n", stats.skipped)
+		if convertErrors > 0 {
+			fmt.Printf("  Errors:  %d (missing required fields)\n", convertErrors)
+		}
+		if stats.newCount > 0 || stats.updated > 0 {
+			fmt.Println("\nRun 'bip rebuild' to update the search index.")
+		}
+	} else {
+		outputJSON(result)
+	}
+
+	return nil
+}
+
+func outputZoteroError(exitCode int, context string, err error) error {
+	return outputGenericError(exitCode, "zotero_error", context, err)
+}

--- a/cmd/bip/zotero_sync.go
+++ b/cmd/bip/zotero_sync.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/matsen/bipartite/internal/config"
+	"github.com/matsen/bipartite/internal/reference"
 	"github.com/matsen/bipartite/internal/storage"
 	"github.com/matsen/bipartite/internal/zotero"
 	"github.com/spf13/cobra"
@@ -76,9 +77,8 @@ func runZoteroSync(cmd *cobra.Command, args []string) error {
 		fmt.Printf("Fetched %d items from Zotero\n", len(items))
 	}
 
-	// Convert and classify
-	var newRefs []storage.RefWithAction
-	stats := importStats{}
+	// Convert Zotero items to references
+	var convertedRefs []reference.Reference
 	var convertErrors int
 
 	for _, item := range items {
@@ -87,23 +87,11 @@ func runZoteroSync(cmd *cobra.Command, args []string) error {
 			convertErrors++
 			continue
 		}
-
-		// Classify against existing refs (reuse import pipeline logic)
-		action := classifyImport(existingRefs, ref)
-
-		switch action.action {
-		case "new":
-			ref.ID = storage.GenerateUniqueID(existingRefs, ref.ID)
-			newRefs = append(newRefs, storage.RefWithAction{Ref: ref, Action: "new"})
-			existingRefs = append(existingRefs, ref)
-			stats.newCount++
-		case "update":
-			newRefs = append(newRefs, storage.RefWithAction{Ref: ref, Action: "update", ExistingIdx: action.existingIdx})
-			stats.updated++
-		case "skip":
-			stats.skipped++
-		}
+		convertedRefs = append(convertedRefs, ref)
 	}
+
+	// Classify using the same processImports pipeline as file import
+	stats, _, newRefs := processImports(convertedRefs, existingRefs)
 
 	result := ZoteroSyncResult{
 		Fetched: len(items),
@@ -130,12 +118,6 @@ func runZoteroSync(cmd *cobra.Command, args []string) error {
 	}
 
 	// Actually persist
-	// Re-read existing refs fresh for the actual write
-	existingRefs, err = storage.ReadAll(refsPath)
-	if err != nil {
-		return outputZoteroError(ExitZoteroAPIError, "reading refs", err)
-	}
-
 	if err := persistImports(refsPath, existingRefs, newRefs); err != nil {
 		return outputZoteroError(ExitZoteroAPIError, "writing refs", err)
 	}

--- a/cmd/bip/zotero_sync.go
+++ b/cmd/bip/zotero_sync.go
@@ -50,7 +50,7 @@ func runZoteroSync(cmd *cobra.Command, args []string) error {
 	// Create Zotero client
 	client, err := zotero.NewClient()
 	if err != nil {
-		return outputZoteroError(ExitZoteroNotConfigured, "Zotero not configured", err)
+		return outputZoteroError(ExitConfigError, "Zotero not configured", err)
 	}
 
 	// Find repository
@@ -60,7 +60,7 @@ func runZoteroSync(cmd *cobra.Command, args []string) error {
 	// Load existing refs
 	existingRefs, err := storage.ReadAll(refsPath)
 	if err != nil {
-		return outputZoteroError(ExitZoteroAPIError, "reading refs", err)
+		return outputZoteroError(ExitError, "reading refs", err)
 	}
 
 	// Fetch items from Zotero
@@ -70,7 +70,7 @@ func runZoteroSync(cmd *cobra.Command, args []string) error {
 
 	items, err := client.GetItems(ctx)
 	if err != nil {
-		return outputZoteroError(ExitZoteroAPIError, "fetching items from Zotero", err)
+		return outputZoteroError(ExitError, "fetching items from Zotero", err)
 	}
 
 	if humanOutput {
@@ -148,7 +148,7 @@ func runZoteroSync(cmd *cobra.Command, args []string) error {
 
 	// Actually persist
 	if err := persistImports(refsPath, existingRefs, newRefs); err != nil {
-		return outputZoteroError(ExitZoteroAPIError, "writing refs", err)
+		return outputZoteroError(ExitError, "writing refs", err)
 	}
 
 	result.Action = "synced"

--- a/cmd/bip/zotero_sync.go
+++ b/cmd/bip/zotero_sync.go
@@ -77,9 +77,14 @@ func runZoteroSync(cmd *cobra.Command, args []string) error {
 		fmt.Printf("Fetched %d items from Zotero\n", len(items))
 	}
 
-	// Convert Zotero items to references
-	var convertedRefs []reference.Reference
+	// Convert Zotero items to references and classify
+	var newRefs []storage.RefWithAction
+	var stats importStats
 	var convertErrors int
+
+	// Build working set for deduplication (grows as we add new refs)
+	workingSet := make([]reference.Reference, len(existingRefs))
+	copy(workingSet, existingRefs)
 
 	for _, item := range items {
 		ref, err := zotero.MapZoteroToReference(item)
@@ -87,11 +92,35 @@ func runZoteroSync(cmd *cobra.Command, args []string) error {
 			convertErrors++
 			continue
 		}
-		convertedRefs = append(convertedRefs, ref)
-	}
 
-	// Classify using the same processImports pipeline as file import
-	stats, _, newRefs := processImports(convertedRefs, existingRefs)
+		action := classifyImport(workingSet, ref)
+
+		switch action.action {
+		case "new":
+			ref.ID = storage.GenerateUniqueID(workingSet, ref.ID)
+			newRefs = append(newRefs, storage.RefWithAction{Ref: ref, Action: "new"})
+			workingSet = append(workingSet, ref)
+			stats.newCount++
+		case "update":
+			if action.existingIdx < len(existingRefs) {
+				// Check if anything actually changed before writing
+				existing := existingRefs[action.existingIdx]
+				if refsMetadataEqual(existing, ref) {
+					stats.skipped++
+				} else {
+					// Preserve the existing bip ID
+					ref.ID = existing.ID
+					newRefs = append(newRefs, storage.RefWithAction{Ref: ref, Action: "update", ExistingIdx: action.existingIdx})
+					stats.updated++
+				}
+			} else {
+				// Within-batch duplicate
+				stats.skipped++
+			}
+		case "skip":
+			stats.skipped++
+		}
+	}
 
 	result := ZoteroSyncResult{
 		Fetched: len(items),
@@ -143,4 +172,30 @@ func runZoteroSync(cmd *cobra.Command, args []string) error {
 
 func outputZoteroError(exitCode int, context string, err error) error {
 	return outputGenericError(exitCode, "zotero_error", context, err)
+}
+
+// refsMetadataEqual checks if two references have the same metadata.
+// Used to skip unnecessary updates during sync.
+func refsMetadataEqual(a, b reference.Reference) bool {
+	if a.Title != b.Title || a.DOI != b.DOI || a.Abstract != b.Abstract {
+		return false
+	}
+	if a.Venue != b.Venue || a.Note != b.Note {
+		return false
+	}
+	if a.Published != b.Published {
+		return false
+	}
+	if a.PMID != b.PMID || a.PMCID != b.PMCID || a.ArXivID != b.ArXivID {
+		return false
+	}
+	if len(a.Authors) != len(b.Authors) {
+		return false
+	}
+	for i := range a.Authors {
+		if a.Authors[i].First != b.Authors[i].First || a.Authors[i].Last != b.Authors[i].Last {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -12,12 +12,14 @@ import (
 
 // GlobalConfig represents configuration stored in ~/.config/bip/config.yml.
 type GlobalConfig struct {
-	NexusPath     string            `yaml:"nexus_path,omitempty"`
-	S2APIKey      string            `yaml:"s2_api_key,omitempty"`
-	ASTAAPIKey    string            `yaml:"asta_api_key,omitempty"`
-	SlackBotToken string            `yaml:"slack_bot_token,omitempty"`
-	GitHubToken   string            `yaml:"github_token,omitempty"`
-	SlackWebhooks map[string]string `yaml:"slack_webhooks,omitempty"`
+	NexusPath      string            `yaml:"nexus_path,omitempty"`
+	S2APIKey       string            `yaml:"s2_api_key,omitempty"`
+	ASTAAPIKey     string            `yaml:"asta_api_key,omitempty"`
+	SlackBotToken  string            `yaml:"slack_bot_token,omitempty"`
+	GitHubToken    string            `yaml:"github_token,omitempty"`
+	SlackWebhooks  map[string]string `yaml:"slack_webhooks,omitempty"`
+	ZoteroAPIKey   string            `yaml:"zotero_api_key,omitempty"`
+	ZoteroUserID   string            `yaml:"zotero_user_id,omitempty"`
 }
 
 const (
@@ -158,6 +160,18 @@ func MustGetNexusPath() string {
 		os.Exit(2)
 	}
 	return path
+}
+
+// GetZoteroAPIKey returns the Zotero API key from global config.
+func GetZoteroAPIKey() string {
+	cfg, _ := LoadGlobalConfig()
+	return cfg.ZoteroAPIKey
+}
+
+// GetZoteroUserID returns the Zotero user ID from global config.
+func GetZoteroUserID() string {
+	cfg, _ := LoadGlobalConfig()
+	return cfg.ZoteroUserID
 }
 
 // HelpfulConfigMessage returns a helpful message when nexus_path is not configured.

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -12,14 +12,14 @@ import (
 
 // GlobalConfig represents configuration stored in ~/.config/bip/config.yml.
 type GlobalConfig struct {
-	NexusPath      string            `yaml:"nexus_path,omitempty"`
-	S2APIKey       string            `yaml:"s2_api_key,omitempty"`
-	ASTAAPIKey     string            `yaml:"asta_api_key,omitempty"`
-	SlackBotToken  string            `yaml:"slack_bot_token,omitempty"`
-	GitHubToken    string            `yaml:"github_token,omitempty"`
-	SlackWebhooks  map[string]string `yaml:"slack_webhooks,omitempty"`
-	ZoteroAPIKey   string            `yaml:"zotero_api_key,omitempty"`
-	ZoteroUserID   string            `yaml:"zotero_user_id,omitempty"`
+	NexusPath     string            `yaml:"nexus_path,omitempty"`
+	S2APIKey      string            `yaml:"s2_api_key,omitempty"`
+	ASTAAPIKey    string            `yaml:"asta_api_key,omitempty"`
+	SlackBotToken string            `yaml:"slack_bot_token,omitempty"`
+	GitHubToken   string            `yaml:"github_token,omitempty"`
+	SlackWebhooks map[string]string `yaml:"slack_webhooks,omitempty"`
+	ZoteroAPIKey  string            `yaml:"zotero_api_key,omitempty"`
+	ZoteroUserID  string            `yaml:"zotero_user_id,omitempty"`
 }
 
 const (

--- a/internal/importer/zotero.go
+++ b/internal/importer/zotero.go
@@ -1,0 +1,168 @@
+package importer
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/matsen/bipartite/internal/reference"
+)
+
+// CSLItem represents a single entry from a CSL-JSON export (Zotero's native export format).
+type CSLItem struct {
+	ID             string     `json:"id"`
+	Type           string     `json:"type"`
+	CitationKey    string     `json:"citation-key"`
+	Title          string     `json:"title"`
+	DOI            string     `json:"DOI"`
+	Abstract       string     `json:"abstract"`
+	ContainerTitle string     `json:"container-title"`
+	Note           string     `json:"note"`
+	PMID           string     `json:"PMID"`
+	PMCID          string     `json:"PMCID"`
+	Author         []CSLName  `json:"author"`
+	Issued         CSLDate    `json:"issued"`
+	Volume         string     `json:"volume"`
+	Issue          string     `json:"issue"`
+}
+
+// CSLName represents an author in CSL-JSON format.
+type CSLName struct {
+	Family  string `json:"family"`
+	Given   string `json:"given"`
+	Literal string `json:"literal"` // For institutional authors
+}
+
+// CSLDate represents a date in CSL-JSON format.
+type CSLDate struct {
+	DateParts [][]json.Number `json:"date-parts"`
+}
+
+// ParseZotero parses a CSL-JSON export (as produced by Zotero) and returns references.
+func ParseZotero(data []byte) ([]reference.Reference, []error) {
+	var items []CSLItem
+	if err := json.Unmarshal(data, &items); err != nil {
+		return nil, []error{fmt.Errorf("parsing CSL-JSON: %w", err)}
+	}
+
+	var refs []reference.Reference
+	var errs []error
+
+	for i, item := range items {
+		ref, err := cslItemToReference(item)
+		if err != nil {
+			label := item.CitationKey
+			if label == "" {
+				label = item.ID
+			}
+			errs = append(errs, fmt.Errorf("entry %d (%s): %w", i+1, label, err))
+			continue
+		}
+		refs = append(refs, ref)
+	}
+
+	return refs, errs
+}
+
+// cslItemToReference converts a CSL-JSON item to a Reference.
+func cslItemToReference(item CSLItem) (reference.Reference, error) {
+	// Validate required fields
+	if item.Title == "" {
+		return reference.Reference{}, fmt.Errorf("missing required field 'title'")
+	}
+	if len(item.Author) == 0 {
+		return reference.Reference{}, fmt.Errorf("missing required field 'author'")
+	}
+
+	// Parse publication date
+	pubDate, err := parseCSLDate(item.Issued)
+	if err != nil {
+		return reference.Reference{}, err
+	}
+
+	// Convert authors
+	authors := make([]reference.Author, len(item.Author))
+	for i, a := range item.Author {
+		if a.Literal != "" {
+			// Institutional author: store in Last, leave First empty
+			authors[i] = reference.Author{Last: a.Literal}
+		} else {
+			authors[i] = reference.Author{
+				First: a.Given,
+				Last:  a.Family,
+			}
+		}
+	}
+
+	// Determine ID: prefer citation-key, fall back to Zotero item key from URL
+	id := item.CitationKey
+	if id == "" {
+		id = extractZoteroItemKey(item.ID)
+	}
+
+	// Extract source ID (Zotero item key)
+	sourceID := extractZoteroItemKey(item.ID)
+
+	ref := reference.Reference{
+		ID:        id,
+		DOI:       item.DOI,
+		Title:     item.Title,
+		Authors:   authors,
+		Abstract:  item.Abstract,
+		Venue:     item.ContainerTitle,
+		Note:      item.Note,
+		Published: pubDate,
+		PMID:      item.PMID,
+		PMCID:     item.PMCID,
+		Source: reference.ImportSource{
+			Type: "zotero",
+			ID:   sourceID,
+		},
+	}
+
+	return ref, nil
+}
+
+// parseCSLDate parses a CSL-JSON date object into a PublicationDate.
+func parseCSLDate(d CSLDate) (reference.PublicationDate, error) {
+	if len(d.DateParts) == 0 || len(d.DateParts[0]) == 0 {
+		return reference.PublicationDate{}, fmt.Errorf("missing required field 'issued' (date)")
+	}
+
+	parts := d.DateParts[0]
+
+	year, err := strconv.Atoi(parts[0].String())
+	if err != nil || year == 0 {
+		return reference.PublicationDate{}, fmt.Errorf("invalid or missing year in 'issued'")
+	}
+
+	pub := reference.PublicationDate{Year: year}
+
+	if len(parts) >= 2 {
+		month, err := strconv.Atoi(parts[1].String())
+		if err == nil && month >= 1 && month <= 12 {
+			pub.Month = month
+		}
+	}
+
+	if len(parts) >= 3 {
+		day, err := strconv.Atoi(parts[2].String())
+		if err == nil && day >= 1 && day <= 31 {
+			pub.Day = day
+		}
+	}
+
+	return pub, nil
+}
+
+// extractZoteroItemKey extracts the 8-char item key from a Zotero ID URL.
+// e.g., "http://zotero.org/users/12345/items/ABCD1234" → "ABCD1234"
+// If the ID is not a URL, returns it as-is.
+func extractZoteroItemKey(id string) string {
+	const prefix = "/items/"
+	if idx := strings.LastIndex(id, prefix); idx != -1 {
+		return id[idx+len(prefix):]
+	}
+	return id
+}

--- a/internal/importer/zotero.go
+++ b/internal/importer/zotero.go
@@ -11,20 +11,20 @@ import (
 
 // CSLItem represents a single entry from a CSL-JSON export (Zotero's native export format).
 type CSLItem struct {
-	ID             string     `json:"id"`
-	Type           string     `json:"type"`
-	CitationKey    string     `json:"citation-key"`
-	Title          string     `json:"title"`
-	DOI            string     `json:"DOI"`
-	Abstract       string     `json:"abstract"`
-	ContainerTitle string     `json:"container-title"`
-	Note           string     `json:"note"`
-	PMID           string     `json:"PMID"`
-	PMCID          string     `json:"PMCID"`
-	Author         []CSLName  `json:"author"`
-	Issued         CSLDate    `json:"issued"`
-	Volume         string     `json:"volume"`
-	Issue          string     `json:"issue"`
+	ID             string    `json:"id"`
+	Type           string    `json:"type"`
+	CitationKey    string    `json:"citation-key"`
+	Title          string    `json:"title"`
+	DOI            string    `json:"DOI"`
+	Abstract       string    `json:"abstract"`
+	ContainerTitle string    `json:"container-title"`
+	Note           string    `json:"note"`
+	PMID           string    `json:"PMID"`
+	PMCID          string    `json:"PMCID"`
+	Author         []CSLName `json:"author"`
+	Issued         CSLDate   `json:"issued"`
+	Volume         string    `json:"volume"`
+	Issue          string    `json:"issue"`
 }
 
 // CSLName represents an author in CSL-JSON format.

--- a/internal/importer/zotero.go
+++ b/internal/importer/zotero.go
@@ -161,7 +161,7 @@ func parseCSLDate(d CSLDate) (reference.PublicationDate, error) {
 // If the ID is not a URL, returns it as-is.
 func extractZoteroItemKey(id string) string {
 	const prefix = "/items/"
-	if idx := strings.LastIndex(id, prefix); idx != -1 {
+	if idx := strings.Index(id, prefix); idx != -1 {
 		return id[idx+len(prefix):]
 	}
 	return id

--- a/internal/importer/zotero_pdf.go
+++ b/internal/importer/zotero_pdf.go
@@ -1,0 +1,97 @@
+package importer
+
+import (
+	"database/sql"
+	"fmt"
+	"path/filepath"
+
+	"github.com/matsen/bipartite/internal/reference"
+	_ "modernc.org/sqlite"
+)
+
+// ResolveZoteroPDFs enriches references with PDF paths from Zotero's local database.
+// It matches references by their Source.ID (Zotero item key) against Zotero's
+// itemAttachments table and sets the PDFPath field to the relative path within
+// Zotero's storage directory.
+//
+// dbPath is the path to Zotero's SQLite database (typically ~/Zotero/zotero.sqlite).
+// Only references with Source.Type == "zotero" and empty PDFPath are processed.
+//
+// The database is opened read-only. If Zotero is running and holds a lock,
+// this function returns an error advising the user to close Zotero.
+func ResolveZoteroPDFs(refs []reference.Reference, dbPath string) (int, error) {
+	db, err := sql.Open("sqlite", dbPath+"?mode=ro")
+	if err != nil {
+		return 0, fmt.Errorf("opening Zotero database: %w", err)
+	}
+	defer db.Close()
+
+	db.SetMaxOpenConns(1)
+
+	// Test the connection — catches SQLITE_BUSY from Zotero holding a lock
+	if err := db.Ping(); err != nil {
+		return 0, fmt.Errorf("cannot read Zotero database (is Zotero running? close it and retry): %w", err)
+	}
+
+	// Query: for each item key, find the PDF attachment path.
+	// Zotero stores attachments as child items linked via itemAttachments.parentItemID.
+	// The attachment path is in itemAttachments.path, prefixed with "storage:" for
+	// locally stored files.
+	//
+	// We join items (to get the item key) with itemAttachments (to get the file path).
+	// We filter for PDF content type.
+	const query = `
+		SELECT parent.key, ia.path
+		FROM itemAttachments ia
+		JOIN items child ON child.itemID = ia.itemID
+		JOIN items parent ON parent.itemID = ia.parentItemID
+		WHERE ia.contentType = 'application/pdf'
+		AND ia.path IS NOT NULL
+		AND ia.path != ''
+	`
+
+	rows, err := db.Query(query)
+	if err != nil {
+		return 0, fmt.Errorf("querying Zotero attachments: %w", err)
+	}
+	defer rows.Close()
+
+	// Build a map of Zotero item key → relative PDF path
+	pdfMap := make(map[string]string)
+	for rows.Next() {
+		var key, path string
+		if err := rows.Scan(&key, &path); err != nil {
+			continue
+		}
+		// Zotero stores paths as "storage:filename.pdf" for managed files
+		relPath := stripStoragePrefix(path)
+		// Full relative path within Zotero storage: <key>/<filename>
+		pdfMap[key] = filepath.Join(key, relPath)
+	}
+	if err := rows.Err(); err != nil {
+		return 0, fmt.Errorf("reading Zotero attachments: %w", err)
+	}
+
+	// Enrich references
+	resolved := 0
+	for i := range refs {
+		if refs[i].Source.Type != "zotero" || refs[i].PDFPath != "" {
+			continue
+		}
+		if path, ok := pdfMap[refs[i].Source.ID]; ok {
+			refs[i].PDFPath = path
+			resolved++
+		}
+	}
+
+	return resolved, nil
+}
+
+// stripStoragePrefix removes the "storage:" prefix from Zotero attachment paths.
+func stripStoragePrefix(path string) string {
+	const prefix = "storage:"
+	if len(path) > len(prefix) && path[:len(prefix)] == prefix {
+		return path[len(prefix):]
+	}
+	return path
+}

--- a/internal/importer/zotero_test.go
+++ b/internal/importer/zotero_test.go
@@ -1,8 +1,8 @@
 package importer
 
 import (
-	"path/filepath"
 	"os"
+	"path/filepath"
 	"testing"
 )
 

--- a/internal/importer/zotero_test.go
+++ b/internal/importer/zotero_test.go
@@ -1,0 +1,357 @@
+package importer
+
+import (
+	"path/filepath"
+	"os"
+	"testing"
+)
+
+func TestParseZotero_ValidEntry(t *testing.T) {
+	data := []byte(`[{
+		"id": "http://zotero.org/users/12345/items/ABCD1234",
+		"type": "article-journal",
+		"citation-key": "Bloom2023-ne",
+		"title": "Fitness effects of mutations",
+		"author": [
+			{"family": "Bloom", "given": "Jesse D"},
+			{"family": "Neher", "given": "Richard A"}
+		],
+		"container-title": "Virus Evolution",
+		"DOI": "10.1093/ve/vead055",
+		"PMID": "37727785",
+		"PMCID": "PMC10506396",
+		"abstract": "Knowledge of fitness effects.",
+		"issued": {"date-parts": [[2023, 8, 22]]},
+		"note": "Key paper"
+	}]`)
+
+	refs, errs := ParseZotero(data)
+	if len(errs) > 0 {
+		t.Fatalf("ParseZotero() returned errors: %v", errs)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("ParseZotero() returned %d refs, want 1", len(refs))
+	}
+
+	ref := refs[0]
+	if ref.ID != "Bloom2023-ne" {
+		t.Errorf("ID = %v, want Bloom2023-ne", ref.ID)
+	}
+	if ref.DOI != "10.1093/ve/vead055" {
+		t.Errorf("DOI = %v, want 10.1093/ve/vead055", ref.DOI)
+	}
+	if ref.Title != "Fitness effects of mutations" {
+		t.Errorf("Title = %v, want 'Fitness effects of mutations'", ref.Title)
+	}
+	if len(ref.Authors) != 2 {
+		t.Fatalf("Authors count = %d, want 2", len(ref.Authors))
+	}
+	if ref.Authors[0].Last != "Bloom" || ref.Authors[0].First != "Jesse D" {
+		t.Errorf("Author[0] = %+v, want Bloom, Jesse D", ref.Authors[0])
+	}
+	if ref.Authors[1].Last != "Neher" || ref.Authors[1].First != "Richard A" {
+		t.Errorf("Author[1] = %+v, want Neher, Richard A", ref.Authors[1])
+	}
+	if ref.Venue != "Virus Evolution" {
+		t.Errorf("Venue = %v, want 'Virus Evolution'", ref.Venue)
+	}
+	if ref.Abstract != "Knowledge of fitness effects." {
+		t.Errorf("Abstract = %v, want 'Knowledge of fitness effects.'", ref.Abstract)
+	}
+	if ref.Published.Year != 2023 {
+		t.Errorf("Published.Year = %d, want 2023", ref.Published.Year)
+	}
+	if ref.Published.Month != 8 {
+		t.Errorf("Published.Month = %d, want 8", ref.Published.Month)
+	}
+	if ref.Published.Day != 22 {
+		t.Errorf("Published.Day = %d, want 22", ref.Published.Day)
+	}
+	if ref.PMID != "37727785" {
+		t.Errorf("PMID = %v, want 37727785", ref.PMID)
+	}
+	if ref.PMCID != "PMC10506396" {
+		t.Errorf("PMCID = %v, want PMC10506396", ref.PMCID)
+	}
+	if ref.Note != "Key paper" {
+		t.Errorf("Note = %v, want 'Key paper'", ref.Note)
+	}
+	if ref.Source.Type != "zotero" {
+		t.Errorf("Source.Type = %v, want zotero", ref.Source.Type)
+	}
+	if ref.Source.ID != "ABCD1234" {
+		t.Errorf("Source.ID = %v, want ABCD1234", ref.Source.ID)
+	}
+}
+
+func TestParseZotero_NoCitationKey(t *testing.T) {
+	data := []byte(`[{
+		"id": "http://zotero.org/users/12345/items/WXYZ9999",
+		"type": "article-journal",
+		"title": "A paper without citation-key",
+		"author": [{"family": "Smith", "given": "John"}],
+		"issued": {"date-parts": [[2024]]}
+	}]`)
+
+	refs, errs := ParseZotero(data)
+	if len(errs) > 0 {
+		t.Fatalf("ParseZotero() returned errors: %v", errs)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("ParseZotero() returned %d refs, want 1", len(refs))
+	}
+
+	// Without citation-key, ID should be the Zotero item key
+	if refs[0].ID != "WXYZ9999" {
+		t.Errorf("ID = %v, want WXYZ9999 (Zotero item key)", refs[0].ID)
+	}
+}
+
+func TestParseZotero_PlainIDNotURL(t *testing.T) {
+	data := []byte(`[{
+		"id": "some-plain-id",
+		"type": "article-journal",
+		"title": "A paper with plain ID",
+		"author": [{"family": "Doe", "given": "Jane"}],
+		"issued": {"date-parts": [[2020]]}
+	}]`)
+
+	refs, errs := ParseZotero(data)
+	if len(errs) > 0 {
+		t.Fatalf("ParseZotero() returned errors: %v", errs)
+	}
+	if refs[0].ID != "some-plain-id" {
+		t.Errorf("ID = %v, want some-plain-id", refs[0].ID)
+	}
+	if refs[0].Source.ID != "some-plain-id" {
+		t.Errorf("Source.ID = %v, want some-plain-id", refs[0].Source.ID)
+	}
+}
+
+func TestParseZotero_MissingRequiredFields(t *testing.T) {
+	tests := []struct {
+		name string
+		data string
+	}{
+		{
+			name: "missing title",
+			data: `[{"id": "x", "author": [{"family": "A", "given": "B"}], "issued": {"date-parts": [[2020]]}}]`,
+		},
+		{
+			name: "missing author",
+			data: `[{"id": "x", "title": "Test", "issued": {"date-parts": [[2020]]}}]`,
+		},
+		{
+			name: "missing issued",
+			data: `[{"id": "x", "title": "Test", "author": [{"family": "A", "given": "B"}]}]`,
+		},
+		{
+			name: "empty date-parts",
+			data: `[{"id": "x", "title": "Test", "author": [{"family": "A", "given": "B"}], "issued": {"date-parts": []}}]`,
+		},
+		{
+			name: "zero year",
+			data: `[{"id": "x", "title": "Test", "author": [{"family": "A", "given": "B"}], "issued": {"date-parts": [[0]]}}]`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			refs, errs := ParseZotero([]byte(tt.data))
+			if len(refs) > 0 {
+				t.Errorf("ParseZotero() expected error for %s, got refs: %+v", tt.name, refs)
+			}
+			if len(errs) == 0 {
+				t.Errorf("ParseZotero() expected error for %s, got none", tt.name)
+			}
+		})
+	}
+}
+
+func TestParseZotero_DatePartsYearOnly(t *testing.T) {
+	data := []byte(`[{
+		"id": "x",
+		"title": "Year only",
+		"author": [{"family": "Test", "given": "A"}],
+		"issued": {"date-parts": [[2017]]}
+	}]`)
+
+	refs, errs := ParseZotero(data)
+	if len(errs) > 0 {
+		t.Fatalf("ParseZotero() returned errors: %v", errs)
+	}
+	if refs[0].Published.Year != 2017 {
+		t.Errorf("Year = %d, want 2017", refs[0].Published.Year)
+	}
+	if refs[0].Published.Month != 0 {
+		t.Errorf("Month = %d, want 0", refs[0].Published.Month)
+	}
+	if refs[0].Published.Day != 0 {
+		t.Errorf("Day = %d, want 0", refs[0].Published.Day)
+	}
+}
+
+func TestParseZotero_DatePartsYearMonth(t *testing.T) {
+	data := []byte(`[{
+		"id": "x",
+		"title": "Year and month",
+		"author": [{"family": "Test", "given": "A"}],
+		"issued": {"date-parts": [[2014, 5]]}
+	}]`)
+
+	refs, errs := ParseZotero(data)
+	if len(errs) > 0 {
+		t.Fatalf("ParseZotero() returned errors: %v", errs)
+	}
+	if refs[0].Published.Year != 2014 {
+		t.Errorf("Year = %d, want 2014", refs[0].Published.Year)
+	}
+	if refs[0].Published.Month != 5 {
+		t.Errorf("Month = %d, want 5", refs[0].Published.Month)
+	}
+	if refs[0].Published.Day != 0 {
+		t.Errorf("Day = %d, want 0", refs[0].Published.Day)
+	}
+}
+
+func TestParseZotero_LiteralAuthor(t *testing.T) {
+	data := []byte(`[{
+		"id": "x",
+		"title": "Institutional author test",
+		"author": [{"literal": "World Health Organization"}],
+		"issued": {"date-parts": [[2020]]}
+	}]`)
+
+	refs, errs := ParseZotero(data)
+	if len(errs) > 0 {
+		t.Fatalf("ParseZotero() returned errors: %v", errs)
+	}
+	if refs[0].Authors[0].Last != "World Health Organization" {
+		t.Errorf("Author Last = %v, want 'World Health Organization'", refs[0].Authors[0].Last)
+	}
+	if refs[0].Authors[0].First != "" {
+		t.Errorf("Author First = %v, want empty", refs[0].Authors[0].First)
+	}
+}
+
+func TestParseZotero_InvalidJSON(t *testing.T) {
+	data := []byte(`not json`)
+	refs, errs := ParseZotero(data)
+	if len(refs) > 0 {
+		t.Errorf("ParseZotero() expected error for invalid JSON, got refs: %+v", refs)
+	}
+	if len(errs) == 0 {
+		t.Error("ParseZotero() expected error for invalid JSON, got none")
+	}
+}
+
+func TestParseZotero_EmptyArray(t *testing.T) {
+	data := []byte(`[]`)
+	refs, errs := ParseZotero(data)
+	if len(errs) > 0 {
+		t.Fatalf("ParseZotero() returned errors: %v", errs)
+	}
+	if len(refs) != 0 {
+		t.Errorf("ParseZotero() returned %d refs, want 0", len(refs))
+	}
+}
+
+func TestParseZotero_MultipleEntries(t *testing.T) {
+	data := []byte(`[
+		{"id": "a", "title": "First", "author": [{"family": "A", "given": "B"}], "issued": {"date-parts": [[2020]]}},
+		{"id": "b", "title": "Second", "author": [{"family": "C", "given": "D"}], "issued": {"date-parts": [[2021]]}}
+	]`)
+
+	refs, errs := ParseZotero(data)
+	if len(errs) > 0 {
+		t.Fatalf("ParseZotero() returned errors: %v", errs)
+	}
+	if len(refs) != 2 {
+		t.Fatalf("ParseZotero() returned %d refs, want 2", len(refs))
+	}
+}
+
+func TestParseZotero_PartialErrors(t *testing.T) {
+	data := []byte(`[
+		{"id": "a", "title": "Valid", "author": [{"family": "A", "given": "B"}], "issued": {"date-parts": [[2020]]}},
+		{"id": "b", "title": "", "author": [{"family": "C", "given": "D"}], "issued": {"date-parts": [[2021]]}},
+		{"id": "c", "title": "Also valid", "author": [{"family": "E", "given": "F"}], "issued": {"date-parts": [[2022]]}}
+	]`)
+
+	refs, errs := ParseZotero(data)
+	if len(refs) != 2 {
+		t.Errorf("ParseZotero() returned %d valid refs, want 2", len(refs))
+	}
+	if len(errs) != 1 {
+		t.Errorf("ParseZotero() returned %d errors, want 1", len(errs))
+	}
+}
+
+func TestParseZotero_RealTestData(t *testing.T) {
+	testFile := filepath.Join("..", "..", "testdata", "zotero_csl_sample.json")
+	data, err := os.ReadFile(testFile)
+	if err != nil {
+		t.Fatalf("Failed to read test file: %v", err)
+	}
+
+	refs, errs := ParseZotero(data)
+	if len(errs) > 0 {
+		t.Errorf("ParseZotero() returned %d errors parsing real test data: %v", len(errs), errs)
+	}
+	if len(refs) == 0 {
+		t.Error("ParseZotero() returned 0 refs from test data")
+	}
+	if len(refs) != 5 {
+		t.Errorf("ParseZotero() returned %d refs, want 5", len(refs))
+	}
+
+	// Verify first entry
+	ref := refs[0]
+	if ref.ID != "Bloom2023-ne" {
+		t.Errorf("First ref ID = %s, want Bloom2023-ne", ref.ID)
+	}
+	if ref.Source.Type != "zotero" {
+		t.Errorf("First ref Source.Type = %s, want zotero", ref.Source.Type)
+	}
+	if ref.Source.ID != "ABCD1234" {
+		t.Errorf("First ref Source.ID = %s, want ABCD1234", ref.Source.ID)
+	}
+	if ref.PMID != "37727785" {
+		t.Errorf("First ref PMID = %s, want 37727785", ref.PMID)
+	}
+
+	// Verify institutional author entry (4th)
+	who := refs[3]
+	if who.Authors[0].Last != "World Health Organization" {
+		t.Errorf("WHO entry author = %+v, want literal 'World Health Organization'", who.Authors[0])
+	}
+	if who.Authors[0].First != "" {
+		t.Errorf("WHO entry author First = %v, want empty", who.Authors[0].First)
+	}
+
+	// Entry without citation-key should use Zotero item key
+	dudas := refs[2]
+	if dudas.ID != "IJKL9012" {
+		t.Errorf("Entry without citation-key ID = %s, want IJKL9012", dudas.ID)
+	}
+}
+
+func TestExtractZoteroItemKey(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"http://zotero.org/users/12345/items/ABCD1234", "ABCD1234"},
+		{"https://zotero.org/users/12345/items/XYZ", "XYZ"},
+		{"http://zotero.org/groups/99/items/KEY123", "KEY123"},
+		{"plain-id", "plain-id"},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		got := extractZoteroItemKey(tt.input)
+		if got != tt.want {
+			t.Errorf("extractZoteroItemKey(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}

--- a/internal/zotero/client.go
+++ b/internal/zotero/client.go
@@ -142,6 +142,10 @@ func (c *Client) GetItems(ctx context.Context) ([]ZoteroItem, error) {
 
 		allItems = append(allItems, items...)
 
+		if len(items) == 0 {
+			break // guard against infinite loop if API returns empty page
+		}
+
 		// Check if there are more pages via Total-Results header
 		totalStr := resp.Header.Get("Total-Results")
 		if totalStr == "" {
@@ -202,6 +206,10 @@ func (c *Client) GetItemsSince(ctx context.Context, sinceVersion int) ([]ZoteroI
 		resp.Body.Close()
 
 		allItems = append(allItems, items...)
+
+		if len(items) == 0 {
+			break // guard against infinite loop if API returns empty page
+		}
 
 		totalStr := resp.Header.Get("Total-Results")
 		if totalStr == "" {
@@ -355,6 +363,8 @@ func checkResponse(resp *http.Response) error {
 // generateWriteToken creates a random 32-char hex token for write requests.
 func generateWriteToken() string {
 	b := make([]byte, 16)
-	rand.Read(b)
+	if _, err := rand.Read(b); err != nil {
+		panic("crypto/rand.Read failed: " + err.Error())
+	}
 	return hex.EncodeToString(b)
 }

--- a/internal/zotero/client.go
+++ b/internal/zotero/client.go
@@ -1,0 +1,360 @@
+package zotero
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/matsen/bipartite/internal/config"
+	"golang.org/x/time/rate"
+)
+
+const (
+	// BaseURL is the Zotero Web API base URL.
+	BaseURL = "https://api.zotero.org"
+
+	// APIVersion is the Zotero API version to use.
+	APIVersion = "3"
+
+	// DefaultTimeout is the default HTTP request timeout.
+	DefaultTimeout = 30 * time.Second
+
+	// RateLimit is a conservative rate limit for the Zotero API.
+	// Zotero doesn't publish exact limits but recommends being polite.
+	RateLimit = 5.0 // 5 req/sec
+
+	// MaxItemsPerPage is the maximum items per request.
+	MaxItemsPerPage = 100
+)
+
+// Client is a rate-limited HTTP client for the Zotero Web API.
+type Client struct {
+	httpClient *http.Client
+	limiter    *rate.Limiter
+	apiKey     string
+	userID     string
+	baseURL    string
+}
+
+// ClientOption configures a Client.
+type ClientOption func(*Client)
+
+// WithAPIKey sets the API key for authenticated requests.
+func WithAPIKey(key string) ClientOption {
+	return func(c *Client) {
+		c.apiKey = key
+	}
+}
+
+// WithUserID sets the Zotero user ID.
+func WithUserID(id string) ClientOption {
+	return func(c *Client) {
+		c.userID = id
+	}
+}
+
+// WithHTTPClient sets a custom HTTP client.
+func WithHTTPClient(hc *http.Client) ClientOption {
+	return func(c *Client) {
+		c.httpClient = hc
+	}
+}
+
+// WithBaseURL sets a custom base URL (for testing).
+func WithBaseURL(url string) ClientOption {
+	return func(c *Client) {
+		c.baseURL = url
+	}
+}
+
+// NewClient creates a new Zotero API client.
+func NewClient(opts ...ClientOption) (*Client, error) {
+	c := &Client{
+		httpClient: &http.Client{Timeout: DefaultTimeout},
+		baseURL:    BaseURL,
+		limiter:    rate.NewLimiter(rate.Limit(RateLimit), 1),
+	}
+
+	// Load from global config
+	if key := config.GetZoteroAPIKey(); key != "" {
+		c.apiKey = key
+	}
+	if uid := config.GetZoteroUserID(); uid != "" {
+		c.userID = uid
+	}
+
+	// Apply options
+	for _, opt := range opts {
+		opt(c)
+	}
+
+	// Validate
+	if c.apiKey == "" || c.userID == "" {
+		return nil, ErrNotConfigured
+	}
+
+	return c, nil
+}
+
+// GetItems fetches all items from the user's library.
+// Handles pagination automatically.
+func (c *Client) GetItems(ctx context.Context) ([]ZoteroItem, error) {
+	var allItems []ZoteroItem
+	start := 0
+
+	for {
+		endpoint := fmt.Sprintf("%s/users/%s/items/top", c.baseURL, c.userID)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+		if err != nil {
+			return nil, fmt.Errorf("creating request: %w", err)
+		}
+
+		q := req.URL.Query()
+		q.Set("limit", strconv.Itoa(MaxItemsPerPage))
+		q.Set("start", strconv.Itoa(start))
+		q.Set("itemType", "-attachment || note") // Exclude attachments and notes
+		req.URL.RawQuery = q.Encode()
+
+		resp, err := c.do(req)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := checkResponse(resp); err != nil {
+			resp.Body.Close()
+			return nil, err
+		}
+
+		var items []ZoteroItem
+		if err := json.NewDecoder(resp.Body).Decode(&items); err != nil {
+			resp.Body.Close()
+			return nil, fmt.Errorf("decoding response: %w", err)
+		}
+		resp.Body.Close()
+
+		allItems = append(allItems, items...)
+
+		// Check if there are more pages via Total-Results header
+		totalStr := resp.Header.Get("Total-Results")
+		if totalStr == "" {
+			break
+		}
+		total, err := strconv.Atoi(totalStr)
+		if err != nil || start+len(items) >= total {
+			break
+		}
+		start += len(items)
+	}
+
+	return allItems, nil
+}
+
+// GetItemsSince fetches items modified since the given library version.
+func (c *Client) GetItemsSince(ctx context.Context, sinceVersion int) ([]ZoteroItem, int, error) {
+	var allItems []ZoteroItem
+	start := 0
+	latestVersion := sinceVersion
+
+	for {
+		endpoint := fmt.Sprintf("%s/users/%s/items/top", c.baseURL, c.userID)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+		if err != nil {
+			return nil, 0, fmt.Errorf("creating request: %w", err)
+		}
+
+		q := req.URL.Query()
+		q.Set("limit", strconv.Itoa(MaxItemsPerPage))
+		q.Set("start", strconv.Itoa(start))
+		q.Set("since", strconv.Itoa(sinceVersion))
+		q.Set("itemType", "-attachment || note")
+		req.URL.RawQuery = q.Encode()
+
+		resp, err := c.do(req)
+		if err != nil {
+			return nil, 0, err
+		}
+
+		if err := checkResponse(resp); err != nil {
+			resp.Body.Close()
+			return nil, 0, err
+		}
+
+		// Track the latest library version
+		if v := resp.Header.Get("Last-Modified-Version"); v != "" {
+			if ver, err := strconv.Atoi(v); err == nil && ver > latestVersion {
+				latestVersion = ver
+			}
+		}
+
+		var items []ZoteroItem
+		if err := json.NewDecoder(resp.Body).Decode(&items); err != nil {
+			resp.Body.Close()
+			return nil, 0, fmt.Errorf("decoding response: %w", err)
+		}
+		resp.Body.Close()
+
+		allItems = append(allItems, items...)
+
+		totalStr := resp.Header.Get("Total-Results")
+		if totalStr == "" {
+			break
+		}
+		total, err := strconv.Atoi(totalStr)
+		if err != nil || start+len(items) >= total {
+			break
+		}
+		start += len(items)
+	}
+
+	return allItems, latestVersion, nil
+}
+
+// CreateItem creates a new item in the user's library.
+func (c *Client) CreateItem(ctx context.Context, item ZoteroItemData) (*ZoteroItem, error) {
+	endpoint := fmt.Sprintf("%s/users/%s/items", c.baseURL, c.userID)
+
+	body, err := json.Marshal([]ZoteroItemData{item})
+	if err != nil {
+		return nil, fmt.Errorf("encoding request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Zotero-Write-Token", generateWriteToken())
+
+	resp, err := c.do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if err := checkResponse(resp); err != nil {
+		return nil, err
+	}
+
+	var result CreateItemResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decoding response: %w", err)
+	}
+
+	// Check for failures
+	for idx, failure := range result.Failed {
+		return nil, fmt.Errorf("item creation failed (index %s): %s", idx, failure.Message)
+	}
+
+	// Return the created item
+	for _, item := range result.Successful {
+		return &item, nil
+	}
+
+	return nil, fmt.Errorf("no item returned from Zotero API")
+}
+
+// GetLibraryVersion returns the current library version number.
+func (c *Client) GetLibraryVersion(ctx context.Context) (int, error) {
+	endpoint := fmt.Sprintf("%s/users/%s/items/top", c.baseURL, c.userID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return 0, fmt.Errorf("creating request: %w", err)
+	}
+
+	q := req.URL.Query()
+	q.Set("limit", "1")
+	req.URL.RawQuery = q.Encode()
+
+	resp, err := c.do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+
+	if err := checkResponse(resp); err != nil {
+		return 0, err
+	}
+
+	vStr := resp.Header.Get("Last-Modified-Version")
+	if vStr == "" {
+		return 0, nil
+	}
+	return strconv.Atoi(vStr)
+}
+
+// do executes an HTTP request with rate limiting and common headers.
+func (c *Client) do(req *http.Request) (*http.Response, error) {
+	if err := c.limiter.Wait(req.Context()); err != nil {
+		return nil, fmt.Errorf("rate limiter: %w", err)
+	}
+
+	req.Header.Set("Zotero-API-Version", APIVersion)
+	if c.apiKey != "" {
+		req.Header.Set("Zotero-API-Key", c.apiKey)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrNetworkError, err)
+	}
+
+	// Handle Backoff header (soft rate limit)
+	if backoff := resp.Header.Get("Backoff"); backoff != "" {
+		if secs, err := strconv.Atoi(backoff); err == nil {
+			c.limiter.SetLimit(rate.Every(time.Duration(secs) * time.Second))
+		}
+	}
+
+	return resp, nil
+}
+
+// checkResponse checks for API errors.
+func checkResponse(resp *http.Response) error {
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return nil
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	msg := string(body)
+	if msg == "" {
+		msg = resp.Status
+	}
+
+	apiErr := &APIError{
+		StatusCode: resp.StatusCode,
+		Message:    strings.TrimSpace(msg),
+	}
+
+	switch resp.StatusCode {
+	case 403:
+		return fmt.Errorf("%w: %v", ErrForbidden, apiErr)
+	case 404:
+		return fmt.Errorf("%w: %v", ErrNotFound, apiErr)
+	case 412:
+		return fmt.Errorf("%w: %v", ErrConflict, apiErr)
+	case 429:
+		if retryAfter := resp.Header.Get("Retry-After"); retryAfter != "" {
+			if secs, err := strconv.Atoi(retryAfter); err == nil {
+				apiErr.RetryAfter = secs
+			}
+		}
+		return fmt.Errorf("%w: %v", ErrRateLimited, apiErr)
+	}
+
+	return apiErr
+}
+
+// generateWriteToken creates a random 32-char hex token for write requests.
+func generateWriteToken() string {
+	b := make([]byte, 16)
+	rand.Read(b)
+	return hex.EncodeToString(b)
+}

--- a/internal/zotero/client.go
+++ b/internal/zotero/client.go
@@ -80,7 +80,7 @@ func NewClient(opts ...ClientOption) (*Client, error) {
 	c := &Client{
 		httpClient: &http.Client{Timeout: DefaultTimeout},
 		baseURL:    BaseURL,
-		limiter:    rate.NewLimiter(rate.Limit(RateLimit), 1),
+		limiter:    rate.NewLimiter(rate.Limit(RateLimit), 3),
 	}
 
 	// Load from global config

--- a/internal/zotero/crossref.go
+++ b/internal/zotero/crossref.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"html"
 	"net/http"
 	"net/url"
 	"strings"
@@ -128,7 +129,8 @@ func mapCrossRefToReference(work crossrefWork) (reference.Reference, error) {
 	return ref, nil
 }
 
-// stripHTMLTags removes HTML/XML tags from a string.
+// stripHTMLTags removes HTML/XML tags and unescapes HTML entities.
+// CrossRef abstracts commonly contain JATS XML markup and entities like &amp;.
 func stripHTMLTags(s string) string {
 	var result strings.Builder
 	inTag := false
@@ -145,5 +147,5 @@ func stripHTMLTags(s string) string {
 			result.WriteRune(r)
 		}
 	}
-	return strings.TrimSpace(result.String())
+	return strings.TrimSpace(html.UnescapeString(result.String()))
 }

--- a/internal/zotero/crossref.go
+++ b/internal/zotero/crossref.go
@@ -1,0 +1,149 @@
+package zotero
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/matsen/bipartite/internal/reference"
+)
+
+const (
+	crossrefBaseURL = "https://api.crossref.org"
+	crossrefTimeout = 15 * time.Second
+)
+
+// crossrefResponse represents the CrossRef API response.
+type crossrefResponse struct {
+	Message crossrefWork `json:"message"`
+}
+
+type crossrefWork struct {
+	DOI            string           `json:"DOI"`
+	Title          []string         `json:"title"`
+	ContainerTitle []string         `json:"container-title"`
+	Abstract       string           `json:"abstract"`
+	Author         []crossrefAuthor `json:"author"`
+	Published      crossrefDate     `json:"published"`
+	ISSN           []string         `json:"ISSN"`
+}
+
+type crossrefAuthor struct {
+	Given  string `json:"given"`
+	Family string `json:"family"`
+	Name   string `json:"name"` // For institutional authors
+}
+
+type crossrefDate struct {
+	DateParts [][]int `json:"date-parts"`
+}
+
+// LookupDOI fetches paper metadata from CrossRef by DOI.
+// This is a free API that doesn't require authentication.
+func LookupDOI(ctx context.Context, doi string) (reference.Reference, error) {
+	client := &http.Client{Timeout: crossrefTimeout}
+
+	endpoint := fmt.Sprintf("%s/works/%s", crossrefBaseURL, url.PathEscape(doi))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return reference.Reference{}, fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return reference.Reference{}, fmt.Errorf("CrossRef lookup failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return reference.Reference{}, fmt.Errorf("DOI not found in CrossRef: %s", doi)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return reference.Reference{}, fmt.Errorf("CrossRef API error (status %d)", resp.StatusCode)
+	}
+
+	var result crossrefResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return reference.Reference{}, fmt.Errorf("decoding CrossRef response: %w", err)
+	}
+
+	return mapCrossRefToReference(result.Message)
+}
+
+func mapCrossRefToReference(work crossrefWork) (reference.Reference, error) {
+	title := ""
+	if len(work.Title) > 0 {
+		title = work.Title[0]
+	}
+	if title == "" {
+		return reference.Reference{}, fmt.Errorf("no title in CrossRef record")
+	}
+
+	authors := make([]reference.Author, 0, len(work.Author))
+	for _, a := range work.Author {
+		if a.Name != "" {
+			authors = append(authors, reference.Author{Last: a.Name})
+		} else {
+			authors = append(authors, reference.Author{First: a.Given, Last: a.Family})
+		}
+	}
+
+	var pubDate reference.PublicationDate
+	if len(work.Published.DateParts) > 0 && len(work.Published.DateParts[0]) > 0 {
+		parts := work.Published.DateParts[0]
+		pubDate.Year = parts[0]
+		if len(parts) >= 2 {
+			pubDate.Month = parts[1]
+		}
+		if len(parts) >= 3 {
+			pubDate.Day = parts[2]
+		}
+	}
+
+	venue := ""
+	if len(work.ContainerTitle) > 0 {
+		venue = work.ContainerTitle[0]
+	}
+
+	// Strip HTML tags from abstract (CrossRef often includes JATS XML)
+	abstract := stripHTMLTags(work.Abstract)
+
+	id := generateCiteKey(authors, pubDate.Year, title)
+
+	ref := reference.Reference{
+		ID:        id,
+		DOI:       work.DOI,
+		Title:     title,
+		Authors:   authors,
+		Abstract:  abstract,
+		Venue:     venue,
+		Published: pubDate,
+	}
+
+	return ref, nil
+}
+
+// stripHTMLTags removes HTML/XML tags from a string.
+func stripHTMLTags(s string) string {
+	var result strings.Builder
+	inTag := false
+	for _, r := range s {
+		if r == '<' {
+			inTag = true
+			continue
+		}
+		if r == '>' {
+			inTag = false
+			continue
+		}
+		if !inTag {
+			result.WriteRune(r)
+		}
+	}
+	return strings.TrimSpace(result.String())
+}

--- a/internal/zotero/errors.go
+++ b/internal/zotero/errors.go
@@ -1,0 +1,77 @@
+package zotero
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Common errors returned by the Zotero client.
+var (
+	// ErrNotFound indicates the item was not found.
+	ErrNotFound = errors.New("item not found in Zotero")
+
+	// ErrRateLimited indicates the rate limit has been exceeded.
+	ErrRateLimited = errors.New("Zotero API rate limit exceeded")
+
+	// ErrNetworkError indicates a network connectivity issue.
+	ErrNetworkError = errors.New("network error communicating with Zotero API")
+
+	// ErrConflict indicates a version conflict (412 Precondition Failed).
+	ErrConflict = errors.New("version conflict: library was modified since last sync")
+
+	// ErrForbidden indicates an authentication or permission error.
+	ErrForbidden = errors.New("Zotero API key invalid or insufficient permissions")
+
+	// ErrNotConfigured indicates missing API credentials.
+	ErrNotConfigured = errors.New("Zotero API key or user ID not configured")
+)
+
+// APIError represents an error from the Zotero API.
+type APIError struct {
+	StatusCode int
+	Message    string
+	RetryAfter int // Seconds to wait before retrying (for rate limits)
+}
+
+func (e *APIError) Error() string {
+	if e.RetryAfter > 0 {
+		return fmt.Sprintf("Zotero API error (status %d): %s (retry after %ds)", e.StatusCode, e.Message, e.RetryAfter)
+	}
+	return fmt.Sprintf("Zotero API error (status %d): %s", e.StatusCode, e.Message)
+}
+
+// IsNotFound returns true if the error indicates an item was not found.
+func IsNotFound(err error) bool {
+	if errors.Is(err, ErrNotFound) {
+		return true
+	}
+	var apiErr *APIError
+	if errors.As(err, &apiErr) {
+		return apiErr.StatusCode == 404
+	}
+	return false
+}
+
+// IsRateLimited returns true if the error indicates rate limiting.
+func IsRateLimited(err error) bool {
+	if errors.Is(err, ErrRateLimited) {
+		return true
+	}
+	var apiErr *APIError
+	if errors.As(err, &apiErr) {
+		return apiErr.StatusCode == 429
+	}
+	return false
+}
+
+// IsConflict returns true if the error indicates a version conflict.
+func IsConflict(err error) bool {
+	if errors.Is(err, ErrConflict) {
+		return true
+	}
+	var apiErr *APIError
+	if errors.As(err, &apiErr) {
+		return apiErr.StatusCode == 412
+	}
+	return false
+}

--- a/internal/zotero/errors_test.go
+++ b/internal/zotero/errors_test.go
@@ -1,0 +1,56 @@
+package zotero
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestIsNotFound(t *testing.T) {
+	if !IsNotFound(ErrNotFound) {
+		t.Error("IsNotFound(ErrNotFound) = false")
+	}
+	if !IsNotFound(fmt.Errorf("wrapped: %w", ErrNotFound)) {
+		t.Error("IsNotFound(wrapped ErrNotFound) = false")
+	}
+	if !IsNotFound(&APIError{StatusCode: 404, Message: "not found"}) {
+		t.Error("IsNotFound(APIError 404) = false")
+	}
+	if IsNotFound(ErrRateLimited) {
+		t.Error("IsNotFound(ErrRateLimited) = true")
+	}
+}
+
+func TestIsRateLimited(t *testing.T) {
+	if !IsRateLimited(ErrRateLimited) {
+		t.Error("IsRateLimited(ErrRateLimited) = false")
+	}
+	if !IsRateLimited(&APIError{StatusCode: 429, Message: "too many"}) {
+		t.Error("IsRateLimited(APIError 429) = false")
+	}
+	if IsRateLimited(ErrNotFound) {
+		t.Error("IsRateLimited(ErrNotFound) = true")
+	}
+}
+
+func TestIsConflict(t *testing.T) {
+	if !IsConflict(ErrConflict) {
+		t.Error("IsConflict(ErrConflict) = false")
+	}
+	if !IsConflict(&APIError{StatusCode: 412, Message: "precondition"}) {
+		t.Error("IsConflict(APIError 412) = false")
+	}
+}
+
+func TestAPIError_Error(t *testing.T) {
+	err := &APIError{StatusCode: 429, Message: "slow down", RetryAfter: 30}
+	got := err.Error()
+	if got != "Zotero API error (status 429): slow down (retry after 30s)" {
+		t.Errorf("Error() = %q", got)
+	}
+
+	err2 := &APIError{StatusCode: 500, Message: "internal"}
+	got2 := err2.Error()
+	if got2 != "Zotero API error (status 500): internal" {
+		t.Errorf("Error() = %q", got2)
+	}
+}

--- a/internal/zotero/mapper.go
+++ b/internal/zotero/mapper.go
@@ -1,0 +1,238 @@
+package zotero
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode"
+
+	"github.com/matsen/bipartite/internal/reference"
+)
+
+// MapZoteroToReference converts a Zotero API item to a Reference.
+func MapZoteroToReference(item ZoteroItem) (reference.Reference, error) {
+	data := item.Data
+
+	if data.Title == "" {
+		return reference.Reference{}, fmt.Errorf("missing title")
+	}
+	if len(data.Creators) == 0 {
+		return reference.Reference{}, fmt.Errorf("missing creators")
+	}
+
+	// Convert creators to authors
+	authors := make([]reference.Author, 0, len(data.Creators))
+	for _, c := range data.Creators {
+		if c.CreatorType != "author" {
+			continue
+		}
+		if c.Name != "" {
+			// Institutional/single-field name
+			authors = append(authors, reference.Author{Last: c.Name})
+		} else {
+			authors = append(authors, reference.Author{
+				First: c.FirstName,
+				Last:  c.LastName,
+			})
+		}
+	}
+	if len(authors) == 0 {
+		// Fall back to all creators if no "author" type
+		for _, c := range data.Creators {
+			if c.Name != "" {
+				authors = append(authors, reference.Author{Last: c.Name})
+			} else {
+				authors = append(authors, reference.Author{
+					First: c.FirstName,
+					Last:  c.LastName,
+				})
+			}
+		}
+	}
+
+	// Parse date
+	pubDate := parseZoteroDate(data.Date)
+	if pubDate.Year == 0 {
+		return reference.Reference{}, fmt.Errorf("missing or invalid date")
+	}
+
+	// Extract PMID/PMCID/arXiv from Extra field
+	pmid, pmcid, arxiv := parseExtra(data.Extra)
+
+	// Generate citation key
+	id := generateCiteKey(authors, pubDate.Year, data.Title)
+
+	ref := reference.Reference{
+		ID:        id,
+		DOI:       data.DOI,
+		Title:     data.Title,
+		Authors:   authors,
+		Abstract:  data.AbstractNote,
+		Venue:     data.PublicationTitle,
+		Published: pubDate,
+		PMID:      pmid,
+		PMCID:     pmcid,
+		ArXivID:   arxiv,
+		Source: reference.ImportSource{
+			Type: "zotero",
+			ID:   item.Key,
+		},
+	}
+
+	return ref, nil
+}
+
+// MapReferenceToZotero converts a Reference to a ZoteroItemData for creation.
+func MapReferenceToZotero(ref reference.Reference) ZoteroItemData {
+	creators := make([]ZoteroCreator, len(ref.Authors))
+	for i, a := range ref.Authors {
+		if a.First == "" && a.Last != "" {
+			// Institutional author
+			creators[i] = ZoteroCreator{
+				CreatorType: "author",
+				Name:        a.Last,
+			}
+		} else {
+			creators[i] = ZoteroCreator{
+				CreatorType: "author",
+				FirstName:   a.First,
+				LastName:    a.Last,
+			}
+		}
+	}
+
+	// Build date string
+	dateStr := strconv.Itoa(ref.Published.Year)
+	if ref.Published.Month > 0 {
+		dateStr += fmt.Sprintf("-%02d", ref.Published.Month)
+		if ref.Published.Day > 0 {
+			dateStr += fmt.Sprintf("-%02d", ref.Published.Day)
+		}
+	}
+
+	// Build Extra field for PMID/PMCID/arXiv
+	var extraParts []string
+	if ref.PMID != "" {
+		extraParts = append(extraParts, "PMID: "+ref.PMID)
+	}
+	if ref.PMCID != "" {
+		extraParts = append(extraParts, "PMCID: "+ref.PMCID)
+	}
+	if ref.ArXivID != "" {
+		extraParts = append(extraParts, "arXiv: "+ref.ArXivID)
+	}
+
+	item := ZoteroItemData{
+		ItemType:         "journalArticle",
+		Title:            ref.Title,
+		Creators:         creators,
+		AbstractNote:     ref.Abstract,
+		PublicationTitle: ref.Venue,
+		Date:             dateStr,
+		DOI:              ref.DOI,
+		Extra:            strings.Join(extraParts, "\n"),
+	}
+
+	return item
+}
+
+// parseZoteroDate parses Zotero's free-form date string.
+// Handles: "2023-08-22", "2023-08", "2023", "August 22, 2023", etc.
+func parseZoteroDate(date string) reference.PublicationDate {
+	date = strings.TrimSpace(date)
+	if date == "" {
+		return reference.PublicationDate{}
+	}
+
+	// Try YYYY-MM-DD format first
+	parts := strings.Split(date, "-")
+	if len(parts) >= 1 {
+		if y, err := strconv.Atoi(parts[0]); err == nil && y > 0 {
+			pub := reference.PublicationDate{Year: y}
+			if len(parts) >= 2 {
+				if m, err := strconv.Atoi(parts[1]); err == nil && m >= 1 && m <= 12 {
+					pub.Month = m
+				}
+			}
+			if len(parts) >= 3 {
+				if d, err := strconv.Atoi(parts[2]); err == nil && d >= 1 && d <= 31 {
+					pub.Day = d
+				}
+			}
+			return pub
+		}
+	}
+
+	// Try to extract a 4-digit year from anywhere in the string
+	for _, word := range strings.Fields(date) {
+		word = strings.Trim(word, ",.")
+		if len(word) == 4 {
+			if y, err := strconv.Atoi(word); err == nil && y > 1000 && y < 3000 {
+				return reference.PublicationDate{Year: y}
+			}
+		}
+	}
+
+	return reference.PublicationDate{}
+}
+
+// parseExtra extracts PMID, PMCID, and arXiv ID from the Extra field.
+// Zotero stores these as "PMID: 12345\nPMCID: PMC12345\narXiv: 2106.15928"
+func parseExtra(extra string) (pmid, pmcid, arxiv string) {
+	for _, line := range strings.Split(extra, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "PMID:") {
+			pmid = strings.TrimSpace(strings.TrimPrefix(line, "PMID:"))
+		} else if strings.HasPrefix(line, "PMCID:") {
+			pmcid = strings.TrimSpace(strings.TrimPrefix(line, "PMCID:"))
+		} else if strings.HasPrefix(line, "arXiv:") {
+			arxiv = strings.TrimSpace(strings.TrimPrefix(line, "arXiv:"))
+		}
+	}
+	return
+}
+
+// generateCiteKey generates a citation key from metadata.
+// Format: LastName + Year + suffix (e.g., "Zhang2018-vi")
+func generateCiteKey(authors []reference.Author, year int, title string) string {
+	lastName := "Unknown"
+	if len(authors) > 0 && authors[0].Last != "" {
+		lastName = sanitizeForCiteKey(authors[0].Last)
+	}
+
+	if year == 0 {
+		year = 9999
+	}
+
+	suffix := generateTitleSuffix(title)
+	return fmt.Sprintf("%s%d-%s", lastName, year, suffix)
+}
+
+func sanitizeForCiteKey(s string) string {
+	var result strings.Builder
+	for _, r := range s {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			result.WriteRune(r)
+		}
+	}
+	return result.String()
+}
+
+func generateTitleSuffix(title string) string {
+	words := strings.Fields(strings.ToLower(title))
+	stopWords := map[string]bool{"a": true, "an": true, "the": true, "of": true, "and": true, "in": true, "on": true, "for": true, "to": true, "with": true}
+
+	var suffix strings.Builder
+	for _, word := range words {
+		if !stopWords[word] && len(word) > 0 {
+			suffix.WriteByte(word[0])
+			if suffix.Len() >= 2 {
+				break
+			}
+		}
+	}
+	for suffix.Len() < 2 {
+		suffix.WriteByte('x')
+	}
+	return suffix.String()
+}

--- a/internal/zotero/mapper_test.go
+++ b/internal/zotero/mapper_test.go
@@ -1,0 +1,251 @@
+package zotero
+
+import (
+	"testing"
+
+	"github.com/matsen/bipartite/internal/reference"
+)
+
+func TestMapZoteroToReference_ValidItem(t *testing.T) {
+	item := ZoteroItem{
+		Key:     "ABCD1234",
+		Version: 42,
+		Data: ZoteroItemData{
+			ItemType:         "journalArticle",
+			Title:            "Test Paper Title",
+			AbstractNote:     "An abstract.",
+			PublicationTitle: "Nature Methods",
+			DOI:              "10.1038/test",
+			Date:             "2023-08-22",
+			Extra:            "PMID: 12345\nPMCID: PMC67890\narXiv: 2106.15928",
+			Creators: []ZoteroCreator{
+				{CreatorType: "author", FirstName: "Jane", LastName: "Doe"},
+				{CreatorType: "author", FirstName: "John", LastName: "Smith"},
+			},
+		},
+	}
+
+	ref, err := MapZoteroToReference(item)
+	if err != nil {
+		t.Fatalf("MapZoteroToReference() error: %v", err)
+	}
+
+	if ref.Title != "Test Paper Title" {
+		t.Errorf("Title = %q, want 'Test Paper Title'", ref.Title)
+	}
+	if ref.DOI != "10.1038/test" {
+		t.Errorf("DOI = %q, want '10.1038/test'", ref.DOI)
+	}
+	if ref.Venue != "Nature Methods" {
+		t.Errorf("Venue = %q, want 'Nature Methods'", ref.Venue)
+	}
+	if ref.Abstract != "An abstract." {
+		t.Errorf("Abstract = %q, want 'An abstract.'", ref.Abstract)
+	}
+	if ref.Published.Year != 2023 || ref.Published.Month != 8 || ref.Published.Day != 22 {
+		t.Errorf("Published = %+v, want 2023-08-22", ref.Published)
+	}
+	if len(ref.Authors) != 2 {
+		t.Fatalf("Authors count = %d, want 2", len(ref.Authors))
+	}
+	if ref.Authors[0].First != "Jane" || ref.Authors[0].Last != "Doe" {
+		t.Errorf("Author[0] = %+v, want Jane Doe", ref.Authors[0])
+	}
+	if ref.PMID != "12345" {
+		t.Errorf("PMID = %q, want '12345'", ref.PMID)
+	}
+	if ref.PMCID != "PMC67890" {
+		t.Errorf("PMCID = %q, want 'PMC67890'", ref.PMCID)
+	}
+	if ref.ArXivID != "2106.15928" {
+		t.Errorf("ArXivID = %q, want '2106.15928'", ref.ArXivID)
+	}
+	if ref.Source.Type != "zotero" {
+		t.Errorf("Source.Type = %q, want 'zotero'", ref.Source.Type)
+	}
+	if ref.Source.ID != "ABCD1234" {
+		t.Errorf("Source.ID = %q, want 'ABCD1234'", ref.Source.ID)
+	}
+}
+
+func TestMapZoteroToReference_InstitutionalAuthor(t *testing.T) {
+	item := ZoteroItem{
+		Key: "KEY1",
+		Data: ZoteroItemData{
+			Title: "Report",
+			Date:  "2020",
+			Creators: []ZoteroCreator{
+				{CreatorType: "author", Name: "World Health Organization"},
+			},
+		},
+	}
+
+	ref, err := MapZoteroToReference(item)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if ref.Authors[0].Last != "World Health Organization" || ref.Authors[0].First != "" {
+		t.Errorf("Author = %+v, want institutional name in Last only", ref.Authors[0])
+	}
+}
+
+func TestMapZoteroToReference_EditorFallback(t *testing.T) {
+	item := ZoteroItem{
+		Key: "KEY2",
+		Data: ZoteroItemData{
+			Title: "Edited Volume",
+			Date:  "2021",
+			Creators: []ZoteroCreator{
+				{CreatorType: "editor", FirstName: "Ed", LastName: "Smith"},
+			},
+		},
+	}
+
+	ref, err := MapZoteroToReference(item)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	// Should fall back to editors when no authors
+	if len(ref.Authors) != 1 || ref.Authors[0].Last != "Smith" {
+		t.Errorf("Expected editor fallback, got %+v", ref.Authors)
+	}
+}
+
+func TestMapZoteroToReference_MissingTitle(t *testing.T) {
+	item := ZoteroItem{
+		Key: "KEY3",
+		Data: ZoteroItemData{
+			Date:     "2020",
+			Creators: []ZoteroCreator{{CreatorType: "author", LastName: "X"}},
+		},
+	}
+
+	_, err := MapZoteroToReference(item)
+	if err == nil {
+		t.Error("expected error for missing title")
+	}
+}
+
+func TestMapZoteroToReference_MissingCreators(t *testing.T) {
+	item := ZoteroItem{
+		Key: "KEY4",
+		Data: ZoteroItemData{
+			Title: "No Authors",
+			Date:  "2020",
+		},
+	}
+
+	_, err := MapZoteroToReference(item)
+	if err == nil {
+		t.Error("expected error for missing creators")
+	}
+}
+
+func TestMapZoteroToReference_MissingDate(t *testing.T) {
+	item := ZoteroItem{
+		Key: "KEY5",
+		Data: ZoteroItemData{
+			Title:    "No Date",
+			Creators: []ZoteroCreator{{CreatorType: "author", LastName: "X"}},
+		},
+	}
+
+	_, err := MapZoteroToReference(item)
+	if err == nil {
+		t.Error("expected error for missing date")
+	}
+}
+
+func TestMapReferenceToZotero(t *testing.T) {
+	ref := reference.Reference{
+		Title:    "Test Paper",
+		DOI:      "10.1234/test",
+		Abstract: "Abstract text",
+		Venue:    "Science",
+		Authors: []reference.Author{
+			{First: "Jane", Last: "Doe"},
+			{Last: "WHO"}, // institutional
+		},
+		Published: reference.PublicationDate{Year: 2023, Month: 5, Day: 15},
+		PMID:      "99999",
+		ArXivID:   "2301.00001",
+	}
+
+	item := MapReferenceToZotero(ref)
+
+	if item.ItemType != "journalArticle" {
+		t.Errorf("ItemType = %q, want 'journalArticle'", item.ItemType)
+	}
+	if item.Title != "Test Paper" {
+		t.Errorf("Title = %q", item.Title)
+	}
+	if item.DOI != "10.1234/test" {
+		t.Errorf("DOI = %q", item.DOI)
+	}
+	if item.Date != "2023-05-15" {
+		t.Errorf("Date = %q, want '2023-05-15'", item.Date)
+	}
+	if len(item.Creators) != 2 {
+		t.Fatalf("Creators count = %d, want 2", len(item.Creators))
+	}
+	if item.Creators[0].FirstName != "Jane" || item.Creators[0].LastName != "Doe" {
+		t.Errorf("Creator[0] = %+v", item.Creators[0])
+	}
+	// Institutional author should use Name field
+	if item.Creators[1].Name != "WHO" {
+		t.Errorf("Creator[1] = %+v, want Name='WHO'", item.Creators[1])
+	}
+	if item.Extra != "PMID: 99999\narXiv: 2301.00001" {
+		t.Errorf("Extra = %q", item.Extra)
+	}
+}
+
+func TestParseZoteroDate(t *testing.T) {
+	tests := []struct {
+		input string
+		want  reference.PublicationDate
+	}{
+		{"2023-08-22", reference.PublicationDate{Year: 2023, Month: 8, Day: 22}},
+		{"2023-08", reference.PublicationDate{Year: 2023, Month: 8}},
+		{"2023", reference.PublicationDate{Year: 2023}},
+		{"August 22, 2023", reference.PublicationDate{Year: 2023}},
+		{"", reference.PublicationDate{}},
+		{"no date here", reference.PublicationDate{}},
+	}
+
+	for _, tt := range tests {
+		got := parseZoteroDate(tt.input)
+		if got != tt.want {
+			t.Errorf("parseZoteroDate(%q) = %+v, want %+v", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestParseExtra(t *testing.T) {
+	tests := []struct {
+		input                  string
+		wantPMID, wantPMCID, wantArXiv string
+	}{
+		{"PMID: 12345\nPMCID: PMC67890\narXiv: 2106.15928", "12345", "PMC67890", "2106.15928"},
+		{"PMID: 12345", "12345", "", ""},
+		{"some other stuff", "", "", ""},
+		{"", "", "", ""},
+		{"PMID: 111\nSome noise\narXiv: 222", "111", "", "222"},
+	}
+
+	for _, tt := range tests {
+		pmid, pmcid, arxiv := parseExtra(tt.input)
+		if pmid != tt.wantPMID || pmcid != tt.wantPMCID || arxiv != tt.wantArXiv {
+			t.Errorf("parseExtra(%q) = (%q, %q, %q), want (%q, %q, %q)",
+				tt.input, pmid, pmcid, arxiv, tt.wantPMID, tt.wantPMCID, tt.wantArXiv)
+		}
+	}
+}
+
+func TestGenerateCiteKey(t *testing.T) {
+	authors := []reference.Author{{First: "Jane", Last: "Doe"}}
+	key := generateCiteKey(authors, 2023, "Attention Is All You Need")
+	if key != "Doe2023-ai" {
+		t.Errorf("generateCiteKey() = %q, want 'Doe2023-ai'", key)
+	}
+}

--- a/internal/zotero/mapper_test.go
+++ b/internal/zotero/mapper_test.go
@@ -223,7 +223,7 @@ func TestParseZoteroDate(t *testing.T) {
 
 func TestParseExtra(t *testing.T) {
 	tests := []struct {
-		input                  string
+		input                          string
 		wantPMID, wantPMCID, wantArXiv string
 	}{
 		{"PMID: 12345\nPMCID: PMC67890\narXiv: 2106.15928", "12345", "PMC67890", "2106.15928"},

--- a/internal/zotero/types.go
+++ b/internal/zotero/types.go
@@ -18,34 +18,34 @@ type ZoteroLibrary struct {
 
 // ZoteroItemData holds the metadata for a Zotero item.
 type ZoteroItemData struct {
-	Key              string           `json:"key"`
-	Version          int              `json:"version"`
+	Key              string           `json:"key,omitempty"`
+	Version          int              `json:"version,omitempty"`
 	ItemType         string           `json:"itemType"`
 	Title            string           `json:"title"`
 	Creators         []ZoteroCreator  `json:"creators"`
-	AbstractNote     string           `json:"abstractNote"`
-	PublicationTitle string           `json:"publicationTitle"` // Journal/conference name
-	Volume           string           `json:"volume"`
-	Issue            string           `json:"issue"`
-	Pages            string           `json:"pages"`
-	Date             string           `json:"date"` // Free-form date string
-	DOI              string           `json:"DOI"`
-	ISSN             string           `json:"ISSN"`
-	URL              string           `json:"url"`
-	Extra            string           `json:"extra"` // Contains PMID, PMCID, arXiv etc.
-	Tags             []ZoteroTag      `json:"tags"`
-	Collections      []string         `json:"collections"`
-	Relations        map[string]interface{} `json:"relations"`
-	DateAdded        string           `json:"dateAdded"`
-	DateModified     string           `json:"dateModified"`
+	AbstractNote     string           `json:"abstractNote,omitempty"`
+	PublicationTitle string           `json:"publicationTitle,omitempty"` // Journal/conference name
+	Volume           string           `json:"volume,omitempty"`
+	Issue            string           `json:"issue,omitempty"`
+	Pages            string           `json:"pages,omitempty"`
+	Date             string           `json:"date,omitempty"` // Free-form date string
+	DOI              string           `json:"DOI,omitempty"`
+	ISSN             string           `json:"ISSN,omitempty"`
+	URL              string           `json:"url,omitempty"`
+	Extra            string           `json:"extra,omitempty"` // Contains PMID, PMCID, arXiv etc.
+	Tags             []ZoteroTag      `json:"tags,omitempty"`
+	Collections      []string         `json:"collections,omitempty"`
+	Relations        map[string]interface{} `json:"relations,omitempty"`
+	DateAdded        string           `json:"dateAdded,omitempty"`
+	DateModified     string           `json:"dateModified,omitempty"`
 }
 
 // ZoteroCreator represents an author or other contributor.
 type ZoteroCreator struct {
 	CreatorType string `json:"creatorType"` // "author", "editor", etc.
-	FirstName   string `json:"firstName"`
-	LastName    string `json:"lastName"`
-	Name        string `json:"name"` // For single-field names (institutional)
+	FirstName   string `json:"firstName,omitempty"`
+	LastName    string `json:"lastName,omitempty"`
+	Name        string `json:"name,omitempty"` // For single-field names (institutional)
 }
 
 // ZoteroTag represents a tag on an item.

--- a/internal/zotero/types.go
+++ b/internal/zotero/types.go
@@ -1,0 +1,83 @@
+// Package zotero provides a client for the Zotero Web API v3.
+package zotero
+
+// ZoteroItem represents an item from the Zotero API.
+type ZoteroItem struct {
+	Key     string         `json:"key"`
+	Version int            `json:"version"`
+	Library ZoteroLibrary  `json:"library"`
+	Data    ZoteroItemData `json:"data"`
+}
+
+// ZoteroLibrary identifies which library an item belongs to.
+type ZoteroLibrary struct {
+	Type string `json:"type"` // "user" or "group"
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+// ZoteroItemData holds the metadata for a Zotero item.
+type ZoteroItemData struct {
+	Key              string           `json:"key"`
+	Version          int              `json:"version"`
+	ItemType         string           `json:"itemType"`
+	Title            string           `json:"title"`
+	Creators         []ZoteroCreator  `json:"creators"`
+	AbstractNote     string           `json:"abstractNote"`
+	PublicationTitle string           `json:"publicationTitle"` // Journal/conference name
+	Volume           string           `json:"volume"`
+	Issue            string           `json:"issue"`
+	Pages            string           `json:"pages"`
+	Date             string           `json:"date"` // Free-form date string
+	DOI              string           `json:"DOI"`
+	ISSN             string           `json:"ISSN"`
+	URL              string           `json:"url"`
+	Extra            string           `json:"extra"` // Contains PMID, PMCID, arXiv etc.
+	Tags             []ZoteroTag      `json:"tags"`
+	Collections      []string         `json:"collections"`
+	Relations        map[string]interface{} `json:"relations"`
+	DateAdded        string           `json:"dateAdded"`
+	DateModified     string           `json:"dateModified"`
+}
+
+// ZoteroCreator represents an author or other contributor.
+type ZoteroCreator struct {
+	CreatorType string `json:"creatorType"` // "author", "editor", etc.
+	FirstName   string `json:"firstName"`
+	LastName    string `json:"lastName"`
+	Name        string `json:"name"` // For single-field names (institutional)
+}
+
+// ZoteroTag represents a tag on an item.
+type ZoteroTag struct {
+	Tag  string `json:"tag"`
+	Type int    `json:"type,omitempty"`
+}
+
+// ZoteroItemTemplate is the template returned by the /items/new endpoint.
+type ZoteroItemTemplate struct {
+	ItemType string `json:"itemType"`
+	// All other fields are dynamic
+}
+
+// CreateItemRequest wraps items for the POST /items endpoint.
+// The Zotero API expects an array of items at the top level.
+type CreateItemRequest []ZoteroItemData
+
+// CreateItemResponse is the response from POST /items.
+type CreateItemResponse struct {
+	Successful   map[string]ZoteroItem `json:"successful"`
+	Success      map[string]string     `json:"success"` // index -> key
+	Unchanged    map[string]string     `json:"unchanged"`
+	Failed       map[string]FailedItem `json:"failed"`
+}
+
+// FailedItem describes why an item creation failed.
+type FailedItem struct {
+	Key     string `json:"key"`
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// VersionsResponse maps item keys to their version numbers.
+type VersionsResponse map[string]int

--- a/internal/zotero/types.go
+++ b/internal/zotero/types.go
@@ -18,26 +18,26 @@ type ZoteroLibrary struct {
 
 // ZoteroItemData holds the metadata for a Zotero item.
 type ZoteroItemData struct {
-	Key              string           `json:"key,omitempty"`
-	Version          int              `json:"version,omitempty"`
-	ItemType         string           `json:"itemType"`
-	Title            string           `json:"title"`
-	Creators         []ZoteroCreator  `json:"creators"`
-	AbstractNote     string           `json:"abstractNote,omitempty"`
-	PublicationTitle string           `json:"publicationTitle,omitempty"` // Journal/conference name
-	Volume           string           `json:"volume,omitempty"`
-	Issue            string           `json:"issue,omitempty"`
-	Pages            string           `json:"pages,omitempty"`
-	Date             string           `json:"date,omitempty"` // Free-form date string
-	DOI              string           `json:"DOI,omitempty"`
-	ISSN             string           `json:"ISSN,omitempty"`
-	URL              string           `json:"url,omitempty"`
-	Extra            string           `json:"extra,omitempty"` // Contains PMID, PMCID, arXiv etc.
-	Tags             []ZoteroTag      `json:"tags,omitempty"`
-	Collections      []string         `json:"collections,omitempty"`
+	Key              string                 `json:"key,omitempty"`
+	Version          int                    `json:"version,omitempty"`
+	ItemType         string                 `json:"itemType"`
+	Title            string                 `json:"title"`
+	Creators         []ZoteroCreator        `json:"creators"`
+	AbstractNote     string                 `json:"abstractNote,omitempty"`
+	PublicationTitle string                 `json:"publicationTitle,omitempty"` // Journal/conference name
+	Volume           string                 `json:"volume,omitempty"`
+	Issue            string                 `json:"issue,omitempty"`
+	Pages            string                 `json:"pages,omitempty"`
+	Date             string                 `json:"date,omitempty"` // Free-form date string
+	DOI              string                 `json:"DOI,omitempty"`
+	ISSN             string                 `json:"ISSN,omitempty"`
+	URL              string                 `json:"url,omitempty"`
+	Extra            string                 `json:"extra,omitempty"` // Contains PMID, PMCID, arXiv etc.
+	Tags             []ZoteroTag            `json:"tags,omitempty"`
+	Collections      []string               `json:"collections,omitempty"`
 	Relations        map[string]interface{} `json:"relations,omitempty"`
-	DateAdded        string           `json:"dateAdded,omitempty"`
-	DateModified     string           `json:"dateModified,omitempty"`
+	DateAdded        string                 `json:"dateAdded,omitempty"`
+	DateModified     string                 `json:"dateModified,omitempty"`
 }
 
 // ZoteroCreator represents an author or other contributor.
@@ -66,10 +66,10 @@ type CreateItemRequest []ZoteroItemData
 
 // CreateItemResponse is the response from POST /items.
 type CreateItemResponse struct {
-	Successful   map[string]ZoteroItem `json:"successful"`
-	Success      map[string]string     `json:"success"` // index -> key
-	Unchanged    map[string]string     `json:"unchanged"`
-	Failed       map[string]FailedItem `json:"failed"`
+	Successful map[string]ZoteroItem `json:"successful"`
+	Success    map[string]string     `json:"success"` // index -> key
+	Unchanged  map[string]string     `json:"unchanged"`
+	Failed     map[string]FailedItem `json:"failed"`
 }
 
 // FailedItem describes why an item creation failed.

--- a/skills/bip.lit.import/SKILL.md
+++ b/skills/bip.lit.import/SKILL.md
@@ -1,27 +1,34 @@
 ---
 name: bip.lit.import
-description: Import Paperpile JSON export into bip library, rebuild database, and clean up.
+description: Import references from Paperpile or Zotero into bip library, rebuild database, and clean up.
 ---
 
-# Import Paperpile Library
+# Import Reference Library
 
-Import a Paperpile JSON export from `~/Downloads/` into the bip reference library.
+Import references from Paperpile JSON or Zotero CSL-JSON exports into the bip reference library.
 
 ## Usage
 
 ```bash
-/bip.lit.import              # Auto-detect latest Paperpile JSON in ~/Downloads
-/bip.lit.import ~/path.json  # Explicit file path
+/bip.lit.import                     # Auto-detect latest export in ~/Downloads
+/bip.lit.import ~/path.json         # Explicit file path
+/bip.lit.import zotero ~/path.json  # Explicit format + file
 ```
+
+## Format Detection
+
+If the format is not specified, inspect the JSON to determine it:
+- Contains `_id` and `citekey` fields → **Paperpile**
+- Contains `type` and `issued` fields → **Zotero** (CSL-JSON)
 
 ## Workflow
 
 ### 1. Find the export file
 
-If no path argument given, look for `~/Downloads/Paperpile*.json` or `~/Downloads/*.json`:
+If no path argument given, look for recent JSON exports:
 
 ```bash
-ls -lt ~/Downloads/Paperpile*.json 2>/dev/null || ls -lt ~/Downloads/*.json
+ls -lt ~/Downloads/Paperpile*.json ~/Downloads/*.json 2>/dev/null | head -5
 ```
 
 If multiple files match, ask the user which one.
@@ -31,15 +38,26 @@ If multiple files match, ask the user which one.
 Always dry-run first to show what will change:
 
 ```bash
+# Paperpile
 bip import --format paperpile "<file>" --dry-run --human
+
+# Zotero CSL-JSON
+bip import --format zotero "<file>" --dry-run --human
+
+# Zotero with PDF resolution (reads Zotero's local database for PDF paths)
+bip import --format zotero --zotero-db ~/Zotero/zotero.sqlite "<file>" --dry-run --human
 ```
 
-Report the counts (new, updated, skipped) to the user. The skipped entries are typically old Paperpile records missing year or author — expected and not actionable.
+Report the counts (new, updated, skipped) to the user.
 
 ### 3. Import
 
 ```bash
+# Paperpile
 bip import --format paperpile "<file>" --human
+
+# Zotero
+bip import --format zotero "<file>" --human
 ```
 
 ### 4. Rebuild database
@@ -56,4 +74,11 @@ rm "<file>"
 
 ### 6. Report
 
-Summarize: new refs added, total count, file deleted. Notes from Paperpile are preserved and searchable via `bip search`.
+Summarize: new refs added, total count, file deleted. Notes are preserved and searchable via `bip search`.
+
+## Zotero-Specific Notes
+
+- Export from Zotero: right-click a collection → Export Collection → CSL-JSON format
+- Install the Better BibTeX plugin for cleaner citation keys in exports
+- PDF resolution requires `--zotero-db` pointing to `~/Zotero/zotero.sqlite` (close Zotero first)
+- Set `pdf_root: ~/Zotero/storage` in `.bipartite/config.yml` for PDF access

--- a/skills/bip.lit/SKILL.md
+++ b/skills/bip.lit/SKILL.md
@@ -87,6 +87,8 @@ Suggest creating concepts when you notice:
 | Get paper details | `bip get <id>` |
 | Export to BibTeX | `bip export --bibtex <id>...` |
 | Append to .bib file | `bip export --bibtex --append main.bib <id>...` |
+| Import from Paperpile | `bip import --format paperpile <file>` |
+| Import from Zotero | `bip import --format zotero <file>` |
 | Add paper to collection | `bip s2 add DOI:10.1234/...` |
 | Find literature gaps | `bip s2 gaps` |
 | Fast paper search (external) | `bip asta search "query"` |
@@ -255,6 +257,28 @@ See [api-guide.md](api-guide.md) for detailed comparison.
    bip rebuild
    ```
 5. Optionally delete the export file after confirming success
+
+### Update Library from Zotero
+
+1. In Zotero, right-click a collection → Export Collection → CSL-JSON format
+2. Save to ~/Downloads
+3. Find the export file:
+   ```bash
+   ls -t ~/Downloads/*.json | head -1
+   ```
+4. Import (with optional PDF resolution):
+   ```bash
+   bip import --format zotero "<path>"
+   # Or with PDF path resolution from Zotero's database:
+   bip import --format zotero --zotero-db ~/Zotero/zotero.sqlite "<path>"
+   ```
+5. Rebuild the search index:
+   ```bash
+   bip rebuild
+   ```
+6. Optionally delete the export file after confirming success
+
+**Zotero setup**: Set `pdf_root: ~/Zotero/storage` in `.bipartite/config.yml` so `bip open` can find PDFs.
 
 ### Explore Literature
 

--- a/testdata/zotero_csl_sample.json
+++ b/testdata/zotero_csl_sample.json
@@ -1,0 +1,89 @@
+[
+  {
+    "id": "http://zotero.org/users/12345/items/ABCD1234",
+    "type": "article-journal",
+    "citation-key": "Bloom2023-ne",
+    "title": "Fitness effects of mutations to SARS-CoV-2 proteins",
+    "author": [
+      {"family": "Bloom", "given": "Jesse D"},
+      {"family": "Neher", "given": "Richard A"}
+    ],
+    "container-title": "Virus Evolution",
+    "DOI": "10.1093/ve/vead055",
+    "PMID": "37727785",
+    "PMCID": "PMC10506396",
+    "abstract": "Knowledge of the fitness effects of mutations to SARS-CoV-2 proteins can inform assessment of new viral variants.",
+    "issued": {
+      "date-parts": [[2023, 8, 22]]
+    },
+    "volume": "9",
+    "issue": "2",
+    "note": "Key paper on viral fitness landscapes"
+  },
+  {
+    "id": "http://zotero.org/users/12345/items/EFGH5678",
+    "type": "paper-conference",
+    "citation-key": "Vaswani2017-at",
+    "title": "Attention Is All You Need",
+    "author": [
+      {"family": "Vaswani", "given": "Ashish"},
+      {"family": "Shazeer", "given": "Noam"},
+      {"family": "Parmar", "given": "Niki"},
+      {"family": "Uszkoreit", "given": "Jakob"},
+      {"family": "Jones", "given": "Llion"},
+      {"family": "Gomez", "given": "Aidan N"},
+      {"family": "Kaiser", "given": "Lukasz"},
+      {"family": "Polosukhin", "given": "Illia"}
+    ],
+    "container-title": "Advances in Neural Information Processing Systems",
+    "DOI": "10.48550/arXiv.1706.03762",
+    "abstract": "The dominant sequence transduction models are based on complex recurrent or convolutional neural networks.",
+    "issued": {
+      "date-parts": [[2017]]
+    }
+  },
+  {
+    "id": "http://zotero.org/users/12345/items/IJKL9012",
+    "type": "article-journal",
+    "title": "Phylogenetic analysis of Guinea 2014 EBOV Ebolavirus outbreak",
+    "author": [
+      {"family": "Dudas", "given": "Gytis"},
+      {"family": "Rambaut", "given": "Andrew"}
+    ],
+    "container-title": "PLoS Currents",
+    "DOI": "10.1371/currents.outbreaks.84eefe5ce43ec9dc0bf0670f7b8b417d",
+    "abstract": "The 2013-2015 Ebola virus epidemic in West Africa is the largest on record.",
+    "issued": {
+      "date-parts": [[2014, 5]]
+    },
+    "PMID": "24860690"
+  },
+  {
+    "id": "http://zotero.org/users/12345/items/MNOP3456",
+    "type": "article-journal",
+    "citation-key": "WHO2020-report",
+    "title": "Global surveillance for COVID-19 caused by human infection with COVID-19 virus",
+    "author": [
+      {"literal": "World Health Organization"}
+    ],
+    "container-title": "WHO Interim Guidance",
+    "issued": {
+      "date-parts": [[2020, 3, 20]]
+    }
+  },
+  {
+    "id": "http://zotero.org/users/12345/items/QRST7890",
+    "type": "article-journal",
+    "citation-key": "Poupard1989-jk",
+    "title": "Two short proofs of Cayley formula",
+    "author": [
+      {"family": "Poupard", "given": "Christiane"}
+    ],
+    "DOI": "10.1016/S0195-6698(89)80023-6",
+    "container-title": "European Journal of Combinatorics",
+    "abstract": "We provide two short combinatorial proofs of the Cayley formula.",
+    "issued": {
+      "date-parts": [[1989, 11, 1]]
+    }
+  }
+]


### PR DESCRIPTION
## Summary

Adds full [Zotero](https://www.zotero.org/) support to bip. Zotero is a free, open-source reference manager widely used in academia — the open-source counterpart to Paperpile. It stores papers locally with optional cloud sync, provides browser-based paper capture, and exposes both a [Web API](https://www.zotero.org/support/dev/web_api/v3/basics) and a local SQLite database for programmatic access.

### Three access methods

- `bip import --format zotero export.json` — import from Zotero's [CSL-JSON](https://citeproc-js.readthedocs.io/en/latest/csl-json/markup.html) export format, with optional `--zotero-db` flag for PDF path resolution from Zotero's local SQLite database
- `bip zotero sync` — pull all items from Zotero's Web API into bip, with skip-if-unchanged deduplication
- `bip zotero add DOI:10.xxx` — add paper to both bip and Zotero simultaneously; fetches metadata from S2 with automatic [CrossRef](https://www.crossref.org/documentation/retrieve-metadata/rest-api/) fallback when rate-limited

### How this differs from the Paperpile integration

The Paperpile and Zotero backends take different approaches due to the different capabilities each tool exposes.

**Paperpile** embeds PDF attachment paths directly in its JSON export, so `bip import --format paperpile` gets both metadata and file locations in one step. However, this requires a manual export-download-import cycle each time the library changes.

**Zotero's** CSL-JSON export does not include file paths, since Zotero manages PDFs in its own storage directory (`~/Zotero/storage/<key>/<file>.pdf`). To bridge this gap, the `--zotero-db` flag reads Zotero's local SQLite database to resolve PDF paths as a separate enrichment step after parsing.

Beyond the file import, Zotero's Web API enables live sync (`bip zotero sync`) and bidirectional writes (`bip zotero add`), which aren't available in the current Paperpile integration because it relies on file exports rather than an API. The same API-based approach could be added for Paperpile in the future.

Both importers produce identical `Reference` structs and feed into the same deduplication pipeline — only `Source.Type` (`"paperpile"` vs `"zotero"`) differs. A mixed library with papers from both sources works without issues.

### New packages/files
- `internal/importer/zotero.go` — CSL-JSON parser (`ParseZotero`), follows `ParsePaperpile` pattern exactly
- `internal/importer/zotero_pdf.go` — PDF path resolution from Zotero's SQLite DB (`~/Zotero/zotero.sqlite`)
- `internal/zotero/` — Web API v3 client (rate-limited, paginated), bidirectional mapper (`Reference` ↔ `ZoteroItemData`), CrossRef DOI resolver, error types
- `testdata/zotero_csl_sample.json` — 5-entry test fixture

### Modified
- `cmd/bip/import.go` — `--format zotero` dispatch + `--zotero-db` flag
- `internal/config/global.go` — `zotero_api_key`, `zotero_user_id` config fields
- `skills/bip.lit.import/SKILL.md`, `skills/bip.lit/SKILL.md` — Zotero workflow docs

### Config
```yaml
# ~/.config/bip/config.yml
zotero_api_key: your-key   # from https://www.zotero.org/settings/keys
zotero_user_id: "12345"    # numeric ID shown on the same page
```

For Zotero users, set `pdf_root: ~/Zotero/storage` in `.bipartite/config.yml` since Zotero stores PDFs as `~/Zotero/storage/<8-char-key>/<filename>.pdf`.

## Test plan

- [x] `go test ./...` — all 28 packages pass
- [x] `go vet ./...` — clean
- [x] 12 unit tests for CSL-JSON parser (valid entries, missing fields, partial dates, institutional authors, real fixture)
- [x] 14 unit tests for Zotero API package (mapper round-trip, date parsing, Extra field extraction, error types)
- [x] End-to-end: synced 100 papers from a real Zotero library
- [x] Re-sync correctly skips unchanged refs (103 skipped, 3 actual updates)
- [x] `bip zotero add DOI:...` — added to both bip and Zotero via CrossRef fallback
- [x] Existing Paperpile import and all other tests unaffected