### PR TITLE
Fix concept-edge queries returning 0 results

### DIFF
--- a/cmd/bip/edge.go
+++ b/cmd/bip/edge.go
@@ -711,7 +711,12 @@ func runEdgeListByProject(db *storage.DB, projectID string) error {
 
 // runEdgeListByConcept outputs edges involving a specific concept.
 func runEdgeListByConcept(db *storage.DB, conceptID string) error {
-	edges, err := db.GetEdgesByTarget(conceptID)
+	// Ensure "concept:" prefix so the query matches stored edge target_ids.
+	prefixedID := conceptID
+	if !strings.HasPrefix(prefixedID, "concept:") {
+		prefixedID = "concept:" + conceptID
+	}
+	edges, err := db.GetEdgesByTarget(prefixedID)
 	if err != nil {
 		exitWithError(ExitDataError, "querying edges: %v", err)
 	}

--- a/internal/storage/concepts_sqlite.go
+++ b/internal/storage/concepts_sqlite.go
@@ -9,6 +9,14 @@ import (
 	"github.com/matsen/bipartite/internal/concept"
 )
 
+// ensureConceptPrefix returns the ID with a "concept:" prefix if not already present.
+func ensureConceptPrefix(id string) string {
+	if strings.HasPrefix(id, "concept:") {
+		return id
+	}
+	return "concept:" + id
+}
+
 // ensureConceptsSchema ensures the concepts schema exists (idempotent via CREATE IF NOT EXISTS).
 func (d *DB) ensureConceptsSchema() error {
 	schema := `
@@ -191,6 +199,9 @@ func (d *DB) GetPapersByConcept(conceptID string, relationshipType string) ([]Pa
 		return nil, err
 	}
 
+	// Edge target_ids use the "concept:" prefix, so ensure it's present.
+	prefixedID := ensureConceptPrefix(conceptID)
+
 	var query string
 	var args []interface{}
 
@@ -201,7 +212,7 @@ func (d *DB) GetPapersByConcept(conceptID string, relationshipType string) ([]Pa
 			WHERE e.target_id = ? AND e.relationship_type = ?
 			ORDER BY e.relationship_type, e.source_id
 		`
-		args = []interface{}{conceptID, relationshipType}
+		args = []interface{}{prefixedID, relationshipType}
 	} else {
 		query = `
 			SELECT e.source_id, e.relationship_type, e.summary
@@ -209,7 +220,7 @@ func (d *DB) GetPapersByConcept(conceptID string, relationshipType string) ([]Pa
 			WHERE e.target_id = ?
 			ORDER BY e.relationship_type, e.source_id
 		`
-		args = []interface{}{conceptID}
+		args = []interface{}{prefixedID}
 	}
 
 	rows, err := d.db.Query(query, args...)
@@ -247,7 +258,7 @@ func (d *DB) GetConceptsByPaper(paperID string, relationshipType string) ([]Pape
 			SELECT e.target_id, e.relationship_type, e.summary
 			FROM edges e
 			WHERE e.source_id = ? AND e.relationship_type = ?
-			  AND e.target_id IN (SELECT id FROM concepts)
+			  AND e.target_id IN (SELECT 'concept:' || id FROM concepts)
 			ORDER BY e.relationship_type, e.target_id
 		`
 		args = []interface{}{paperID, relationshipType}
@@ -256,7 +267,7 @@ func (d *DB) GetConceptsByPaper(paperID string, relationshipType string) ([]Pape
 			SELECT e.target_id, e.relationship_type, e.summary
 			FROM edges e
 			WHERE e.source_id = ?
-			  AND e.target_id IN (SELECT id FROM concepts)
+			  AND e.target_id IN (SELECT 'concept:' || id FROM concepts)
 			ORDER BY e.relationship_type, e.target_id
 		`
 		args = []interface{}{paperID}
@@ -281,13 +292,15 @@ func (d *DB) GetConceptsByPaper(paperID string, relationshipType string) ([]Pape
 }
 
 // CountEdgesByTarget returns the number of edges pointing to a given target.
+// The targetID may be bare or prefixed; both forms are checked.
 func (d *DB) CountEdgesByTarget(targetID string) (int, error) {
 	if err := d.ensureEdgesSchema(); err != nil {
 		return 0, err
 	}
 
 	var count int
-	err := d.db.QueryRow("SELECT COUNT(*) FROM edges WHERE target_id = ?", targetID).Scan(&count)
+	prefixed := ensureConceptPrefix(targetID)
+	err := d.db.QueryRow("SELECT COUNT(*) FROM edges WHERE target_id = ? OR target_id = ?", targetID, prefixed).Scan(&count)
 	return count, err
 }
 

--- a/internal/storage/concepts_sqlite_test.go
+++ b/internal/storage/concepts_sqlite_test.go
@@ -211,11 +211,11 @@ func TestGetPapersByConcept(t *testing.T) {
 	}
 	defer db.Close()
 
-	// Create test edges file and rebuild
+	// Create test edges file and rebuild (target_ids use "concept:" prefix as produced by edge add)
 	edgesPath := filepath.Join(tmpDir, "edges.jsonl")
-	testEdges := `{"source_id": "Paper1", "target_id": "test-concept", "relationship_type": "introduces", "summary": "Test 1"}
-{"source_id": "Paper2", "target_id": "test-concept", "relationship_type": "applies", "summary": "Test 2"}
-{"source_id": "Paper3", "target_id": "other-concept", "relationship_type": "applies", "summary": "Test 3"}
+	testEdges := `{"source_id": "Paper1", "target_id": "concept:test-concept", "relationship_type": "introduces", "summary": "Test 1"}
+{"source_id": "Paper2", "target_id": "concept:test-concept", "relationship_type": "applies", "summary": "Test 2"}
+{"source_id": "Paper3", "target_id": "concept:other-concept", "relationship_type": "applies", "summary": "Test 3"}
 `
 	if err := os.WriteFile(edgesPath, []byte(testEdges), 0644); err != nil {
 		t.Fatalf("WriteFile error = %v", err)
@@ -224,7 +224,7 @@ func TestGetPapersByConcept(t *testing.T) {
 		t.Fatalf("RebuildEdgesFromJSONL() error = %v", err)
 	}
 
-	// Test all papers for concept
+	// Test all papers for concept (bare ID should work thanks to prefix normalization)
 	papers, err := db.GetPapersByConcept("test-concept", "")
 	if err != nil {
 		t.Fatalf("GetPapersByConcept() error = %v", err)
@@ -267,8 +267,8 @@ func TestGetConceptsByPaper(t *testing.T) {
 	}
 
 	edgesPath := filepath.Join(tmpDir, "edges.jsonl")
-	testEdges := `{"source_id": "Paper1", "target_id": "concept-a", "relationship_type": "introduces", "summary": "Test 1"}
-{"source_id": "Paper1", "target_id": "concept-b", "relationship_type": "applies", "summary": "Test 2"}
+	testEdges := `{"source_id": "Paper1", "target_id": "concept:concept-a", "relationship_type": "introduces", "summary": "Test 1"}
+{"source_id": "Paper1", "target_id": "concept:concept-b", "relationship_type": "applies", "summary": "Test 2"}
 {"source_id": "Paper1", "target_id": "Paper2", "relationship_type": "cites", "summary": "Not a concept edge"}
 `
 	if err := os.WriteFile(edgesPath, []byte(testEdges), 0644); err != nil {
@@ -308,11 +308,11 @@ func TestCountEdgesByTarget(t *testing.T) {
 	}
 	defer db.Close()
 
-	// Create test edges
+	// Create test edges (target_ids use "concept:" prefix as produced by edge add)
 	edgesPath := filepath.Join(tmpDir, "edges.jsonl")
-	testEdges := `{"source_id": "Paper1", "target_id": "test-concept", "relationship_type": "introduces", "summary": "Test 1"}
-{"source_id": "Paper2", "target_id": "test-concept", "relationship_type": "applies", "summary": "Test 2"}
-{"source_id": "Paper3", "target_id": "other-concept", "relationship_type": "applies", "summary": "Test 3"}
+	testEdges := `{"source_id": "Paper1", "target_id": "concept:test-concept", "relationship_type": "introduces", "summary": "Test 1"}
+{"source_id": "Paper2", "target_id": "concept:test-concept", "relationship_type": "applies", "summary": "Test 2"}
+{"source_id": "Paper3", "target_id": "concept:other-concept", "relationship_type": "applies", "summary": "Test 3"}
 `
 	if err := os.WriteFile(edgesPath, []byte(testEdges), 0644); err != nil {
 		t.Fatalf("WriteFile error = %v", err)


### PR DESCRIPTION
Fixes #126

## Summary

- `bip concept papers`, `bip paper concepts`, `bip edge list --concept`, and `bip concept delete` all silently return 0 results for concept edges because query functions pass bare concept IDs while `edge add` stores them with a `concept:` prefix.
- Add `ensureConceptPrefix` helper and normalize IDs in `GetPapersByConcept`, `GetConceptsByPaper`, `CountEdgesByTarget`, and `runEdgeListByConcept`.
- Update test fixtures to use `concept:`-prefixed target_ids matching actual `edge add` output.

## Test plan

- [x] `TestGetPapersByConcept` — passes with prefixed edge data
- [x] `TestGetConceptsByPaper` — passes with prefixed edge data
- [x] `TestCountEdgesByTarget` — passes with prefixed edge data
- [x] Full `go test ./...` passes