### PR TITLE
Fix concept-edge queries returning 0 results

### DIFF
--- a/cmd/bip/concept.go
+++ b/cmd/bip/concept.go
@@ -359,10 +359,11 @@ func deleteLinkedEdges(repoRoot string, conceptID string, db *storage.DB) int {
 		exitWithError(ExitDataError, "reading edges: %v", err)
 	}
 
+	prefixedID := "concept:" + conceptID
 	var remaining []edge.Edge
 	edgesRemoved := 0
 	for _, e := range edges {
-		if e.TargetID != conceptID {
+		if e.TargetID != prefixedID {
 			remaining = append(remaining, e)
 		} else {
 			edgesRemoved++
@@ -417,7 +418,8 @@ func runConceptDelete(cmd *cobra.Command, args []string) error {
 	db := mustOpenDatabase(repoRoot)
 	defer db.Close()
 
-	edgeCount, err := db.CountEdgesByTarget(conceptID)
+	prefixedID := "concept:" + conceptID
+	edgeCount, err := db.CountEdgesByTarget(prefixedID)
 	if err != nil {
 		exitWithError(ExitDataError, "counting edges: %v", err)
 	}

--- a/cmd/bip/edge.go
+++ b/cmd/bip/edge.go
@@ -711,7 +711,7 @@ func runEdgeListByProject(db *storage.DB, projectID string) error {
 
 // runEdgeListByConcept outputs edges involving a specific concept.
 func runEdgeListByConcept(db *storage.DB, conceptID string) error {
-	edges, err := db.GetEdgesByTarget(conceptID)
+	edges, err := db.GetEdgesByTarget("concept:" + conceptID)
 	if err != nil {
 		exitWithError(ExitDataError, "querying edges: %v", err)
 	}

--- a/internal/storage/concepts_sqlite.go
+++ b/internal/storage/concepts_sqlite.go
@@ -191,6 +191,9 @@ func (d *DB) GetPapersByConcept(conceptID string, relationshipType string) ([]Pa
 		return nil, err
 	}
 
+	// Edges store concept targets with "concept:" prefix
+	prefixedID := "concept:" + conceptID
+
 	var query string
 	var args []interface{}
 
@@ -201,7 +204,7 @@ func (d *DB) GetPapersByConcept(conceptID string, relationshipType string) ([]Pa
 			WHERE e.target_id = ? AND e.relationship_type = ?
 			ORDER BY e.relationship_type, e.source_id
 		`
-		args = []interface{}{conceptID, relationshipType}
+		args = []interface{}{prefixedID, relationshipType}
 	} else {
 		query = `
 			SELECT e.source_id, e.relationship_type, e.summary
@@ -209,7 +212,7 @@ func (d *DB) GetPapersByConcept(conceptID string, relationshipType string) ([]Pa
 			WHERE e.target_id = ?
 			ORDER BY e.relationship_type, e.source_id
 		`
-		args = []interface{}{conceptID}
+		args = []interface{}{prefixedID}
 	}
 
 	rows, err := d.db.Query(query, args...)
@@ -247,7 +250,7 @@ func (d *DB) GetConceptsByPaper(paperID string, relationshipType string) ([]Pape
 			SELECT e.target_id, e.relationship_type, e.summary
 			FROM edges e
 			WHERE e.source_id = ? AND e.relationship_type = ?
-			  AND e.target_id IN (SELECT id FROM concepts)
+			  AND e.target_id IN (SELECT 'concept:' || id FROM concepts)
 			ORDER BY e.relationship_type, e.target_id
 		`
 		args = []interface{}{paperID, relationshipType}
@@ -256,7 +259,7 @@ func (d *DB) GetConceptsByPaper(paperID string, relationshipType string) ([]Pape
 			SELECT e.target_id, e.relationship_type, e.summary
 			FROM edges e
 			WHERE e.source_id = ?
-			  AND e.target_id IN (SELECT id FROM concepts)
+			  AND e.target_id IN (SELECT 'concept:' || id FROM concepts)
 			ORDER BY e.relationship_type, e.target_id
 		`
 		args = []interface{}{paperID}

--- a/internal/storage/concepts_sqlite_test.go
+++ b/internal/storage/concepts_sqlite_test.go
@@ -213,9 +213,9 @@ func TestGetPapersByConcept(t *testing.T) {
 
 	// Create test edges file and rebuild
 	edgesPath := filepath.Join(tmpDir, "edges.jsonl")
-	testEdges := `{"source_id": "Paper1", "target_id": "test-concept", "relationship_type": "introduces", "summary": "Test 1"}
-{"source_id": "Paper2", "target_id": "test-concept", "relationship_type": "applies", "summary": "Test 2"}
-{"source_id": "Paper3", "target_id": "other-concept", "relationship_type": "applies", "summary": "Test 3"}
+	testEdges := `{"source_id": "Paper1", "target_id": "concept:test-concept", "relationship_type": "introduces", "summary": "Test 1"}
+{"source_id": "Paper2", "target_id": "concept:test-concept", "relationship_type": "applies", "summary": "Test 2"}
+{"source_id": "Paper3", "target_id": "concept:other-concept", "relationship_type": "applies", "summary": "Test 3"}
 `
 	if err := os.WriteFile(edgesPath, []byte(testEdges), 0644); err != nil {
 		t.Fatalf("WriteFile error = %v", err)
@@ -224,7 +224,7 @@ func TestGetPapersByConcept(t *testing.T) {
 		t.Fatalf("RebuildEdgesFromJSONL() error = %v", err)
 	}
 
-	// Test all papers for concept
+	// Test all papers for concept (bare ID — function prepends "concept:")
 	papers, err := db.GetPapersByConcept("test-concept", "")
 	if err != nil {
 		t.Fatalf("GetPapersByConcept() error = %v", err)
@@ -267,8 +267,8 @@ func TestGetConceptsByPaper(t *testing.T) {
 	}
 
 	edgesPath := filepath.Join(tmpDir, "edges.jsonl")
-	testEdges := `{"source_id": "Paper1", "target_id": "concept-a", "relationship_type": "introduces", "summary": "Test 1"}
-{"source_id": "Paper1", "target_id": "concept-b", "relationship_type": "applies", "summary": "Test 2"}
+	testEdges := `{"source_id": "Paper1", "target_id": "concept:concept-a", "relationship_type": "introduces", "summary": "Test 1"}
+{"source_id": "Paper1", "target_id": "concept:concept-b", "relationship_type": "applies", "summary": "Test 2"}
 {"source_id": "Paper1", "target_id": "Paper2", "relationship_type": "cites", "summary": "Not a concept edge"}
 `
 	if err := os.WriteFile(edgesPath, []byte(testEdges), 0644); err != nil {
@@ -308,11 +308,11 @@ func TestCountEdgesByTarget(t *testing.T) {
 	}
 	defer db.Close()
 
-	// Create test edges
+	// Create test edges (with concept: prefix as stored by edge add)
 	edgesPath := filepath.Join(tmpDir, "edges.jsonl")
-	testEdges := `{"source_id": "Paper1", "target_id": "test-concept", "relationship_type": "introduces", "summary": "Test 1"}
-{"source_id": "Paper2", "target_id": "test-concept", "relationship_type": "applies", "summary": "Test 2"}
-{"source_id": "Paper3", "target_id": "other-concept", "relationship_type": "applies", "summary": "Test 3"}
+	testEdges := `{"source_id": "Paper1", "target_id": "concept:test-concept", "relationship_type": "introduces", "summary": "Test 1"}
+{"source_id": "Paper2", "target_id": "concept:test-concept", "relationship_type": "applies", "summary": "Test 2"}
+{"source_id": "Paper3", "target_id": "concept:other-concept", "relationship_type": "applies", "summary": "Test 3"}
 `
 	if err := os.WriteFile(edgesPath, []byte(testEdges), 0644); err != nil {
 		t.Fatalf("WriteFile error = %v", err)
@@ -321,7 +321,8 @@ func TestCountEdgesByTarget(t *testing.T) {
 		t.Fatalf("RebuildEdgesFromJSONL() error = %v", err)
 	}
 
-	count, err := db.CountEdgesByTarget("test-concept")
+	// Callers must pass prefixed ID (CountEdgesByTarget is generic)
+	count, err := db.CountEdgesByTarget("concept:test-concept")
 	if err != nil {
 		t.Fatalf("CountEdgesByTarget() error = %v", err)
 	}
@@ -329,7 +330,7 @@ func TestCountEdgesByTarget(t *testing.T) {
 		t.Errorf("CountEdgesByTarget() = %d, want 2", count)
 	}
 
-	count, err = db.CountEdgesByTarget("nonexistent")
+	count, err = db.CountEdgesByTarget("concept:nonexistent")
 	if err != nil {
 		t.Fatalf("CountEdgesByTarget() error = %v", err)
 	}

--- a/internal/storage/concepts_sqlite_test.go
+++ b/internal/storage/concepts_sqlite_test.go
@@ -298,6 +298,79 @@ func TestGetConceptsByPaper(t *testing.T) {
 	}
 }
 
+// TestConceptPrefixMatching verifies that concept queries work correctly when
+// edges are stored with "concept:" prefix (as bip edge add produces) but
+// callers pass bare concept IDs. This was the bug in #126.
+func TestConceptPrefixMatching(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.db")
+
+	db, err := OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB() error = %v", err)
+	}
+	defer db.Close()
+
+	// Set up concepts (bare IDs in the concepts table)
+	conceptsPath := filepath.Join(tmpDir, "concepts.jsonl")
+	testConcepts := []concept.Concept{
+		{ID: "manifold-learning", Name: "Manifold Learning"},
+	}
+	if err := WriteAllConcepts(conceptsPath, testConcepts); err != nil {
+		t.Fatalf("WriteAllConcepts error = %v", err)
+	}
+	if _, err := db.RebuildConceptsFromJSONL(conceptsPath); err != nil {
+		t.Fatalf("RebuildConceptsFromJSONL() error = %v", err)
+	}
+
+	// Set up edges with concept: prefix (as bip edge add stores them)
+	edgesPath := filepath.Join(tmpDir, "edges.jsonl")
+	testEdges := `{"source_id": "Smith2024", "target_id": "concept:manifold-learning", "relationship_type": "introduces", "summary": "Introduces manifold methods"}
+`
+	if err := os.WriteFile(edgesPath, []byte(testEdges), 0644); err != nil {
+		t.Fatalf("WriteFile error = %v", err)
+	}
+	if _, err := db.RebuildEdgesFromJSONL(edgesPath); err != nil {
+		t.Fatalf("RebuildEdgesFromJSONL() error = %v", err)
+	}
+
+	// GetPapersByConcept: bare ID should find the prefixed edge
+	papers, err := db.GetPapersByConcept("manifold-learning", "")
+	if err != nil {
+		t.Fatalf("GetPapersByConcept() error = %v", err)
+	}
+	if len(papers) != 1 {
+		t.Errorf("GetPapersByConcept('manifold-learning') = %d results, want 1", len(papers))
+	}
+
+	// GetConceptsByPaper: should match prefixed edge against concepts table
+	concepts, err := db.GetConceptsByPaper("Smith2024", "")
+	if err != nil {
+		t.Fatalf("GetConceptsByPaper() error = %v", err)
+	}
+	if len(concepts) != 1 {
+		t.Errorf("GetConceptsByPaper('Smith2024') = %d results, want 1", len(concepts))
+	}
+
+	// CountEdgesByTarget: callers pass prefixed ID
+	count, err := db.CountEdgesByTarget("concept:manifold-learning")
+	if err != nil {
+		t.Fatalf("CountEdgesByTarget() error = %v", err)
+	}
+	if count != 1 {
+		t.Errorf("CountEdgesByTarget('concept:manifold-learning') = %d, want 1", count)
+	}
+
+	// Bare ID should NOT match (callers must prepend prefix)
+	count, err = db.CountEdgesByTarget("manifold-learning")
+	if err != nil {
+		t.Fatalf("CountEdgesByTarget() error = %v", err)
+	}
+	if count != 0 {
+		t.Errorf("CountEdgesByTarget('manifold-learning') = %d, want 0 (bare ID should not match)", count)
+	}
+}
+
 func TestCountEdgesByTarget(t *testing.T) {
 	tmpDir := t.TempDir()
 	dbPath := filepath.Join(tmpDir, "test.db")

--- a/internal/storage/edges_sqlite.go
+++ b/internal/storage/edges_sqlite.go
@@ -204,7 +204,7 @@ func (d *DB) GetPapersByProjectTransitive(projectID string) ([]edge.Edge, error)
 		)
 		SELECT e.source_id, e.target_id, e.relationship_type, e.summary, e.created_at
 		FROM edges e
-		JOIN project_concepts pc ON e.target_id = REPLACE(pc.concept_id, 'concept:', '')
+		JOIN project_concepts pc ON e.target_id = pc.concept_id
 		WHERE e.source_id NOT LIKE '%:%'
 		ORDER BY e.source_id, e.target_id
 	`, "querying papers by project transitive", prefixedID, prefixedID, prefixedID, prefixedID)


### PR DESCRIPTION
🤖

## Summary
- `bip edge add` stores concept targets with `concept:` prefix (e.g. `concept:manifold-learning`), but query functions passed bare IDs — so `WHERE target_id = ?` never matched
- Fixed `GetPapersByConcept` and callers of `CountEdgesByTarget`/`GetEdgesByTarget` to prepend `concept:` (matching the existing `GetEdgesByProject` pattern with `project:`)
- Fixed `GetConceptsByPaper` to compare `target_id IN (SELECT 'concept:' || id FROM concepts)` 
- Fixed `GetPapersByProjectTransitive` join that incorrectly stripped the prefix

Closes #126

## Test plan
- [x] All existing tests pass (updated test edge fixtures to use `concept:` prefix)
- [x] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)