### PR TITLE
Add anti-deferral rule for EPIC workers

### DIFF
--- a/agents/issue-lead.md
+++ b/agents/issue-lead.md
@@ -31,10 +31,24 @@ Read ALL of these before making any judgment:
 ### Step 2: Scope check (mandatory every time)
 
 Compare the issue body (the contract) against what the worker actually
-did (commits + diff). Ask:
+did (commits + diff). Scope has two failure modes — expansion (drift)
+and contraction (premature deferral) — and you must check for both.
+
+Expansion check:
 - Is the worker still solving what was asked?
 - Has scope crept? ("while I'm here" refactors, unrelated cleanups)
 - Has the worker discovered adjacent work? (note as follow-up, don't pursue)
+
+Contraction check:
+- Has the worker punted finishable work into follow-up issues or
+  "deferred" notes that they could have completed in this session?
+- Search the diff, PR body, and worklog for phrases like "deferred",
+  "follow-up", "out of scope", "future work", "TODO", "left for later".
+  For each, ask: is this genuinely out of scope, or is the worker punting?
+- Apply the DEFERRAL RULE (three conditions: not requested/implied by
+  the issue, explicitly flagged as a design decision or previously
+  ruled out-of-scope by you, AND would more than double the PR diff).
+  If all three do not hold, the deferral is premature.
 
 ### Step 3: Classify the stop reason
 
@@ -49,6 +63,7 @@ did (commits + diff). Ask:
 | **quality-gate** | PR exists, needs checks | Instruct: run /bip.pr.check, fix all, run /bip.pr.review, fix all, repeat until clean |
 | **mechanical-blocker** | CI, merge conflict, deps | Provide specific fix instructions |
 | **scope-drift** | Work outside the issue | Redirect firmly to issue scope |
+| **premature-deferral** | Worker punted finishable work into follow-ups | Identify each deferred item, instruct the worker to complete the ones that fail the DEFERRAL RULE in this session, and justify why each is finishable now |
 | **needs-human** | Design question, ambiguous requirements, architectural tradeoff, genuine research direction choice | **STOP. Escalate.** |
 | **completed** | All requirements met, tested, PR clean | Confirm completion |
 
@@ -77,6 +92,14 @@ Before accepting "done" or "phase-complete", ask yourself:
 - "Has the worker addressed the *why* or just the *what*?"
 - "If we merge this PR, what's our confidence the issue is resolved?"
 - "Is there production/real data we should run this on first?"
+- "Did the worker defer anything? For each deferred item, does it pass
+  all three DEFERRAL RULE conditions, or could the worker have finished
+  it in this session?"
+- "If we merged this PR right now, would a user consider the issue fully
+  resolved, or would they immediately ask 'why didn't you also fix X'?"
+- "Are there finishing touches (test coverage, edge cases, error paths,
+  small refactors discovered along the way) the worker left for 'later'
+  without justification?"
 
 ### Step 6: Check for loops
 

--- a/skills/bip.epic.spawn/SKILL.md
+++ b/skills/bip.epic.spawn/SKILL.md
@@ -227,16 +227,35 @@ COMPLETION: When done (or when lead says completed):
    For everything else — formatting, test gaps, docs, naming,
    lint, cruft — just fix it and move on.
 
-REVIEW TRIAGE — For each /bip.pr.review finding, decide:
-  • FIX NOW — sensible improvements you can complete quickly
-    (naming, docs, small refactors, test gaps, lint). Just do them.
-  • DEFER — findings that are too large to complete in this PR or
-    require design decisions beyond the issue scope. For each deferred
-    finding, add a line to the DEFERRED section of the PR body:
-      > **Deferred**: <one-line description> — <why it's out of scope>
+DEFERRAL RULE — applies to ALL worker decisions, not just review findings.
+
+You may file a follow-up issue and defer work ONLY if ALL of the following hold:
+  1. The work is NOT requested or implied by the current issue body.
+  2. EITHER the issue body explicitly flags this work as a design decision
+     for the user, OR the issue-lead has previously told you (in
+     lead_guidance) that this specific work is out of scope.
+  3. The work would more than double the size of the current PR's diff.
+
+If all three are not true, do the work in this session. Specifically:
+  - "It would take a few minutes" → do it.
+  - "It would take an hour but it's a clear win" → do it.
+  - "I noticed a related test gap while editing" → do it.
+  - "There's an unhandled edge case" → do it.
+  - "The fix is mechanical but tedious" → do it.
+
+When in doubt, DO NOT defer. Bring it to the issue-lead with your reasoning.
+The cost of an over-large PR is small (split it later if needed). The cost
+of an under-finished PR is high (follow-up churn, broken windows, work
+re-loaded into context cold weeks later).
+
+REVIEW TRIAGE — For each /bip.pr.review finding, apply the DEFERRAL RULE above:
+  • FIX NOW (default) — sensible improvements you can complete
+    (naming, docs, small refactors, test gaps, lint, edge cases,
+    mechanical-but-tedious fixes). Just do them.
+  • DEFER — only when all three DEFERRAL RULE conditions hold. For each
+    deferred finding, add a line to the DEFERRED section of the PR body:
+      > **Deferred**: <one-line description> — <why all three conditions hold>
     These become fodder for follow-up issues.
-  Default to FIX NOW. Only defer when the fix would be a meaningful
-  scope expansion. "It would take a few minutes" is not a reason to defer.
 
 FINAL RECAP — Print this summary just before outputting the completion
 promise so the conductor (and user) can see the full story at a glance:


### PR DESCRIPTION
🤖

## Summary

- Workers routinely punt finishable work into follow-up issues ("deferred", "out of scope", "future work") when they could complete it in the current session. The existing guard rails catch scope *expansion* (drift) but not scope *contraction* (premature deferral).
- This PR adds a **DEFERRAL RULE** to `skills/bip.epic.spawn/SKILL.md` with three explicit conditions a finding must meet before it can be deferred, and generalizes it beyond the PR-review-findings case it used to govern.
- The `issue-lead` agent (`agents/issue-lead.md`) now checks for contraction in Step 2 alongside expansion, probes for premature deferral in Step 5, and has a new \`premature-deferral\` stop-reason category in the classification table.

## Why

Premature deferral generates follow-up churn: work gets re-loaded into context cold weeks later when the marginal cost of finishing the fix while the worker was already deep in the relevant code would have been near zero. The current workflow systematically chooses the high-cost option because the guard rails only push back against the opposite failure mode.

## Test plan

- [ ] On the next real EPIC worker run, manually inspect an issue-lead evaluation and confirm the lead is actively probing for premature deferral (either passes through cleanly or pushes back on a punted item).
- [ ] Grep the worklog of a representative run for the phrases the contraction check searches for (\`deferred\`, \`follow-up\`, \`out of scope\`, \`future work\`, \`TODO\`, \`left for later\`) and confirm the lead engaged with them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)