### PR TITLE
Support Paperpile tags/labels in search

### DIFF
--- a/cmd/bip/get.go
+++ b/cmd/bip/get.go
@@ -79,6 +79,11 @@ func printRefDetail(ref reference.Reference) {
 		fmt.Printf("DOI:      %s\n", ref.DOI)
 	}
 
+	// Tags
+	if len(ref.Tags) > 0 {
+		fmt.Printf("Tags:     %s\n", strings.Join(ref.Tags, ", "))
+	}
+
 	// Notes
 	if ref.Note != "" {
 		fmt.Println()

--- a/cmd/bip/search.go
+++ b/cmd/bip/search.go
@@ -48,7 +48,7 @@ var searchCmd = &cobra.Command{
 	Long: `Search references with flexible filtering options.
 
 Query Syntax (positional argument):
-  Plain text     - Searches title, abstract, and authors
+  Plain text     - Searches title, abstract, authors, and tags
   author:name    - Search author names only (legacy syntax)
   title:text     - Search title only
 

--- a/cmd/bip/search.go
+++ b/cmd/bip/search.go
@@ -17,6 +17,7 @@ var (
 	searchTitle   string
 	searchVenue   string
 	searchDOI     string
+	searchTag     string
 )
 
 // hasAnyFilterFlags returns true if any field-specific search flags were provided.
@@ -26,7 +27,8 @@ func hasAnyFilterFlags() bool {
 		searchYear != "" ||
 		searchTitle != "" ||
 		searchVenue != "" ||
-		searchDOI != ""
+		searchDOI != "" ||
+		searchTag != ""
 }
 
 func init() {
@@ -36,6 +38,7 @@ func init() {
 	searchCmd.Flags().StringVarP(&searchTitle, "title", "t", "", "Search in title only")
 	searchCmd.Flags().StringVar(&searchVenue, "venue", "", "Filter by venue/journal (partial match)")
 	searchCmd.Flags().StringVar(&searchDOI, "doi", "", "Lookup by exact DOI")
+	searchCmd.Flags().StringVar(&searchTag, "tag", "", "Filter by tag/label (partial match)")
 	rootCmd.AddCommand(searchCmd)
 }
 
@@ -55,6 +58,7 @@ Flags:
   --year         - Filter by year (exact, range, or open-ended)
   --venue        - Filter by venue/journal (partial match)
   --doi          - Lookup by exact DOI
+  --tag          - Filter by tag/label (partial match)
 
 Author matching uses exact last name matching to avoid false positives:
   -a "Yu"           - Matches last name "Yu" exactly (not "Yujia")
@@ -74,7 +78,8 @@ Examples:
   bip search "deep mutational scanning" -a "Bloom" --year 2023:
   bip search -a "Yu" -a "Bloom" --year 2022:
   bip search --title "SARS-CoV-2" --venue Nature
-  bip search --doi "10.1126/science.abf4063"`,
+  bip search --doi "10.1126/science.abf4063"
+  bip search --tag "antibody"`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runSearch,
 }
@@ -96,6 +101,7 @@ func runSearch(cmd *cobra.Command, args []string) error {
 			Title:   searchTitle,
 			Venue:   searchVenue,
 			DOI:     searchDOI,
+			Tag:     searchTag,
 		}
 
 		if len(args) > 0 {

--- a/internal/importer/paperpile.go
+++ b/internal/importer/paperpile.go
@@ -70,7 +70,9 @@ type PaperpileEntry struct {
 		ArticlePDF int    `json:"article_pdf"` // 1 = main PDF, 0 = supplement
 		Filename   string `json:"filename"`
 	} `json:"attachments"`
-	Note string `json:"note"`
+	Note         string   `json:"note"`
+	LabelsNamed  []string `json:"labelsNamed"`
+	FoldersNamed []string `json:"foldersNamed"`
 }
 
 // ParsePaperpile parses a Paperpile JSON export and returns references.
@@ -150,6 +152,22 @@ func paperpileEntryToReference(entry PaperpileEntry) (reference.Reference, error
 		}
 	}
 
+	// Collect tags from labels and folders (deduplicated)
+	var tags []string
+	seen := make(map[string]bool)
+	for _, label := range entry.LabelsNamed {
+		if label != "" && !seen[label] {
+			tags = append(tags, label)
+			seen[label] = true
+		}
+	}
+	for _, folder := range entry.FoldersNamed {
+		if folder != "" && !seen[folder] {
+			tags = append(tags, folder)
+			seen[folder] = true
+		}
+	}
+
 	// Use citekey as ID, falling back to Paperpile ID if no citekey
 	id := entry.Citekey
 	if id == "" {
@@ -164,6 +182,7 @@ func paperpileEntryToReference(entry PaperpileEntry) (reference.Reference, error
 		Abstract:        entry.Abstract,
 		Venue:           entry.Journal,
 		Note:            entry.Note,
+		Tags:            tags,
 		Published:       pubDate,
 		PDFPath:         pdfPath,
 		SupplementPaths: supplementPaths,

--- a/internal/importer/paperpile_test.go
+++ b/internal/importer/paperpile_test.go
@@ -365,6 +365,67 @@ func TestPaperpileEntry_AuthorWithOnlyLast(t *testing.T) {
 	}
 }
 
+func TestParsePaperpile_WithLabelsAndFolders(t *testing.T) {
+	data := []byte(`[{
+		"_id": "abc123",
+		"citekey": "Tagged2026",
+		"title": "Tagged Paper",
+		"published": {"year": "2026"},
+		"author": [{"first": "John", "last": "Smith"}],
+		"labelsNamed": ["antibody", "vaccine"],
+		"foldersNamed": ["my papers"]
+	}]`)
+
+	refs, errs := ParsePaperpile(data)
+	if len(errs) > 0 {
+		t.Fatalf("ParsePaperpile() returned errors: %v", errs)
+	}
+	if len(refs[0].Tags) != 3 {
+		t.Fatalf("Tags count = %d, want 3, got %v", len(refs[0].Tags), refs[0].Tags)
+	}
+	if refs[0].Tags[0] != "antibody" || refs[0].Tags[1] != "vaccine" || refs[0].Tags[2] != "my papers" {
+		t.Errorf("Tags = %v, want [antibody vaccine my papers]", refs[0].Tags)
+	}
+}
+
+func TestParsePaperpile_DuplicateLabelAndFolder(t *testing.T) {
+	data := []byte(`[{
+		"_id": "abc123",
+		"citekey": "Dedup2026",
+		"title": "Dedup Paper",
+		"published": {"year": "2026"},
+		"author": [{"first": "John", "last": "Smith"}],
+		"labelsNamed": ["antibody"],
+		"foldersNamed": ["antibody"]
+	}]`)
+
+	refs, errs := ParsePaperpile(data)
+	if len(errs) > 0 {
+		t.Fatalf("ParsePaperpile() returned errors: %v", errs)
+	}
+	if len(refs[0].Tags) != 1 {
+		t.Errorf("Tags count = %d, want 1 (deduplicated), got %v", len(refs[0].Tags), refs[0].Tags)
+	}
+}
+
+func TestParsePaperpile_NoLabelsOrFolders(t *testing.T) {
+	data := []byte(`[{
+		"_id": "abc123",
+		"citekey": "NoTags2026",
+		"title": "No Tags Paper",
+		"published": {"year": "2026"},
+		"author": [{"first": "John", "last": "Smith"}]
+	}]`)
+
+	refs, errs := ParsePaperpile(data)
+	if len(errs) > 0 {
+		t.Fatalf("ParsePaperpile() returned errors: %v", errs)
+	}
+	if len(refs[0].Tags) != 0 {
+		t.Errorf("Tags = %v, want empty", refs[0].Tags)
+	}
+}
+
 // Helper function for comparing references
 func refsEqual(a, b reference.Reference) bool {
 	if a.ID != b.ID || a.DOI != b.DOI || a.Title != b.Title {

--- a/internal/reference/reference.go
+++ b/internal/reference/reference.go
@@ -24,7 +24,7 @@ type Reference struct {
 	// Import Tracking
 	Source ImportSource `json:"source"`
 
-	// Tags (e.g., Paperpile labels and folders)
+	// Tags are user-defined labels for organizing references.
 	Tags []string `json:"tags,omitempty"`
 
 	// Relationships

--- a/internal/reference/reference.go
+++ b/internal/reference/reference.go
@@ -24,6 +24,9 @@ type Reference struct {
 	// Import Tracking
 	Source ImportSource `json:"source"`
 
+	// Tags (e.g., Paperpile labels and folders)
+	Tags []string `json:"tags,omitempty"`
+
 	// Relationships
 	Supersedes string `json:"supersedes,omitempty"` // DOI of paper this replaces
 

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -22,7 +22,7 @@ const selectRefFields = `id, doi, title, abstract, venue,
 	pub_year, pub_month, pub_day,
 	pdf_path, source_type, source_id, supersedes,
 	authors_json, supplement_paths_json,
-	pmid, pmcid, arxiv_id, s2_id, notes`
+	pmid, pmcid, arxiv_id, s2_id, notes, tags_json`
 
 // OpenDB opens or creates a SQLite database at the given path.
 func OpenDB(path string) (*DB, error) {
@@ -71,7 +71,8 @@ func createSchema(db *sql.DB) error {
 			pmcid TEXT,
 			arxiv_id TEXT,
 			s2_id TEXT,
-			notes TEXT
+			notes TEXT,
+			tags_json TEXT
 		);
 
 		-- Index for DOI lookups
@@ -84,7 +85,8 @@ func createSchema(db *sql.DB) error {
 			abstract,
 			authors_text,
 			pub_year,
-			notes
+			notes,
+			tags_text
 		);
 
 		-- Embedding metadata for semantic index staleness detection (Phase II)
@@ -123,8 +125,8 @@ func (d *DB) RebuildFromJSONL(jsonlPath string) (int, error) {
 			pub_year, pub_month, pub_day,
 			pdf_path, source_type, source_id, supersedes,
 			authors_json, supplement_paths_json,
-			pmid, pmcid, arxiv_id, s2_id, notes
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			pmid, pmcid, arxiv_id, s2_id, notes, tags_json
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`)
 	if err != nil {
 		return 0, fmt.Errorf("preparing refs insert: %w", err)
@@ -132,8 +134,8 @@ func (d *DB) RebuildFromJSONL(jsonlPath string) (int, error) {
 	defer refsStmt.Close()
 
 	ftsStmt, err := d.db.Prepare(`
-		INSERT INTO refs_fts (id, title, abstract, authors_text, pub_year, notes)
-		VALUES (?, ?, ?, ?, ?, ?)
+		INSERT INTO refs_fts (id, title, abstract, authors_text, pub_year, notes, tags_text)
+		VALUES (?, ?, ?, ?, ?, ?, ?)
 	`)
 	if err != nil {
 		return 0, fmt.Errorf("preparing fts insert: %w", err)
@@ -152,6 +154,13 @@ func (d *DB) RebuildFromJSONL(jsonlPath string) (int, error) {
 				return 0, fmt.Errorf("marshaling supplement paths for %s: %w", ref.ID, err)
 			}
 		}
+		var tagsJSON []byte
+		if len(ref.Tags) > 0 {
+			tagsJSON, err = json.Marshal(ref.Tags)
+			if err != nil {
+				return 0, fmt.Errorf("marshaling tags for %s: %w", ref.ID, err)
+			}
+		}
 
 		// Insert into refs table
 		_, err = refsStmt.Exec(
@@ -161,7 +170,7 @@ func (d *DB) RebuildFromJSONL(jsonlPath string) (int, error) {
 			string(authorsJSON), nullableString(supplementJSON),
 			nullableStringValue(ref.PMID), nullableStringValue(ref.PMCID),
 			nullableStringValue(ref.ArXivID), nullableStringValue(ref.S2ID),
-			nullableStringValue(ref.Note),
+			nullableStringValue(ref.Note), nullableString(tagsJSON),
 		)
 		if err != nil {
 			return 0, fmt.Errorf("inserting ref %s: %w", ref.ID, err)
@@ -170,8 +179,11 @@ func (d *DB) RebuildFromJSONL(jsonlPath string) (int, error) {
 		// Build authors text for FTS
 		authorsText := formatAuthorsText(ref.Authors)
 
+		// Build tags text for FTS (space-separated)
+		tagsText := strings.Join(ref.Tags, " ")
+
 		// Insert into FTS table
-		_, err = ftsStmt.Exec(ref.ID, ref.Title, ref.Abstract, authorsText, strconv.Itoa(ref.Published.Year), ref.Note)
+		_, err = ftsStmt.Exec(ref.ID, ref.Title, ref.Abstract, authorsText, strconv.Itoa(ref.Published.Year), ref.Note, tagsText)
 		if err != nil {
 			return 0, fmt.Errorf("inserting fts for %s: %w", ref.ID, err)
 		}
@@ -263,6 +275,7 @@ type SearchFilters struct {
 	Title    string   // Search in title only (FTS)
 	Venue    string   // Filter by venue (SQL LIKE, case-insensitive)
 	DOI      string   // Exact DOI match (SQL)
+	Tag      string   // Filter by tag (SQL LIKE on tags_json, case-insensitive)
 }
 
 // SearchWithFilters performs a search with multiple optional filters.
@@ -335,6 +348,10 @@ func (d *DB) SearchWithFilters(filters SearchFilters, limit int) ([]reference.Re
 	if filters.DOI != "" {
 		query += " AND doi = ?"
 		args = append(args, filters.DOI)
+	}
+	if filters.Tag != "" {
+		query += " AND tags_json LIKE ?"
+		args = append(args, "%"+filters.Tag+"%")
 	}
 
 	query += " LIMIT ?"
@@ -430,7 +447,7 @@ type scanner interface {
 
 func scanReference(s scanner) (*reference.Reference, error) {
 	var ref reference.Reference
-	var authorsJSON, supplementJSON sql.NullString
+	var authorsJSON, supplementJSON, tagsJSON sql.NullString
 	var doi, abstract, venue, pdfPath, sourceID, supersedes sql.NullString
 	var pmid, pmcid, arxivID, s2id, notes sql.NullString
 	var pubMonth, pubDay sql.NullInt64
@@ -440,7 +457,7 @@ func scanReference(s scanner) (*reference.Reference, error) {
 		&ref.Published.Year, &pubMonth, &pubDay,
 		&pdfPath, &ref.Source.Type, &sourceID, &supersedes,
 		&authorsJSON, &supplementJSON,
-		&pmid, &pmcid, &arxivID, &s2id, &notes,
+		&pmid, &pmcid, &arxivID, &s2id, &notes, &tagsJSON,
 	)
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -478,6 +495,11 @@ func scanReference(s scanner) (*reference.Reference, error) {
 	if supplementJSON.Valid && supplementJSON.String != "" {
 		if err := json.Unmarshal([]byte(supplementJSON.String), &ref.SupplementPaths); err != nil {
 			return nil, fmt.Errorf("parsing supplement paths JSON for %s: %w", ref.ID, err)
+		}
+	}
+	if tagsJSON.Valid && tagsJSON.String != "" {
+		if err := json.Unmarshal([]byte(tagsJSON.String), &ref.Tags); err != nil {
+			return nil, fmt.Errorf("parsing tags JSON for %s: %w", ref.ID, err)
 		}
 	}
 

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -275,7 +275,7 @@ type SearchFilters struct {
 	Title    string   // Search in title only (FTS)
 	Venue    string   // Filter by venue (SQL LIKE, case-insensitive)
 	DOI      string   // Exact DOI match (SQL)
-	Tag      string   // Filter by tag (SQL LIKE on tags_json, case-insensitive)
+	Tag      string   // Filter by tag (SQL LIKE on tags_json, partial match)
 }
 
 // SearchWithFilters performs a search with multiple optional filters.

--- a/internal/storage/sqlite_test.go
+++ b/internal/storage/sqlite_test.go
@@ -222,6 +222,9 @@ func TestDB_GetByID_FullReference(t *testing.T) {
 	if ref.Source.Type != "paperpile" || ref.Source.ID != "abc123" {
 		t.Errorf("Source = %+v, want paperpile/abc123", ref.Source)
 	}
+	if len(ref.Tags) != 2 || ref.Tags[0] != "antibody" || ref.Tags[1] != "vaccine" {
+		t.Errorf("Tags = %v, want [antibody vaccine]", ref.Tags)
+	}
 }
 
 func TestDB_GetByID_Notes(t *testing.T) {
@@ -373,6 +376,7 @@ func TestDB_SearchWithFilters(t *testing.T) {
 		limit   int
 		wantIDs []string
 		wantMin int
+		wantMax int // 0 means no upper bound check
 	}{
 		{
 			name:    "keyword only",
@@ -543,10 +547,11 @@ func TestDB_SearchWithFilters(t *testing.T) {
 			wantMin: 1,
 		},
 		{
-			name:    "no tags ref excluded by tag filter",
+			name:    "tag filter excludes untagged refs",
 			filters: SearchFilters{Tag: "antibody"},
 			limit:   10,
-			wantMin: 1,
+			wantIDs: []string{"Smith2026-ab"},
+			wantMax: 1,
 		},
 	}
 
@@ -559,6 +564,9 @@ func TestDB_SearchWithFilters(t *testing.T) {
 
 			if len(refs) < tt.wantMin {
 				t.Errorf("SearchWithFilters() returned %d results, want at least %d", len(refs), tt.wantMin)
+			}
+			if tt.wantMax > 0 && len(refs) > tt.wantMax {
+				t.Errorf("SearchWithFilters() returned %d results, want at most %d", len(refs), tt.wantMax)
 			}
 
 			if tt.wantIDs != nil {

--- a/internal/storage/sqlite_test.go
+++ b/internal/storage/sqlite_test.go
@@ -31,6 +31,7 @@ func setupTestDB(t *testing.T) (*DB, string, func()) {
 			},
 			Published: reference.PublicationDate{Year: 2026, Month: 3, Day: 15},
 			PDFPath:   "Papers/smith.pdf",
+			Tags:      []string{"antibody", "vaccine"},
 			Source:    reference.ImportSource{Type: "paperpile", ID: "abc123"},
 		},
 		{
@@ -45,6 +46,7 @@ func setupTestDB(t *testing.T) (*DB, string, func()) {
 			},
 			Published: reference.PublicationDate{Year: 2025, Month: 6},
 			PDFPath:   "Papers/jones.pdf",
+			Tags:      []string{"protein"},
 			Source:    reference.ImportSource{Type: "paperpile", ID: "def456"},
 		},
 		{
@@ -512,6 +514,39 @@ func TestDB_SearchWithFilters(t *testing.T) {
 			filters: SearchFilters{DOI: "10.1234/nonexistent"},
 			limit:   10,
 			wantMin: 0,
+		},
+		{
+			name:    "tag filter",
+			filters: SearchFilters{Tag: "antibody"},
+			limit:   10,
+			wantIDs: []string{"Smith2026-ab"},
+			wantMin: 1,
+		},
+		{
+			name:    "tag filter protein",
+			filters: SearchFilters{Tag: "protein"},
+			limit:   10,
+			wantIDs: []string{"Jones2025-cd"},
+			wantMin: 1,
+		},
+		{
+			name:    "tag filter no match",
+			filters: SearchFilters{Tag: "nonexistent"},
+			limit:   10,
+			wantMin: 0,
+		},
+		{
+			name:    "tag and author combined",
+			filters: SearchFilters{Tag: "antibody", Authors: []string{"Smith"}},
+			limit:   10,
+			wantIDs: []string{"Smith2026-ab"},
+			wantMin: 1,
+		},
+		{
+			name:    "no tags ref excluded by tag filter",
+			filters: SearchFilters{Tag: "antibody"},
+			limit:   10,
+			wantMin: 1,
 		},
 	}
 


### PR DESCRIPTION
🤖

## Summary

- Import Paperpile `labelsNamed` and `foldersNamed` into a new `Tags` field on `Reference` (deduplicated, labels first then folders)
- Add `--tag` flag to `bip search` for filtering by tag (partial match via SQL LIKE on tags_json)
- Display tags in `bip get` output
- Add `tags_json` column to SQLite `refs` table and `tags_text` to FTS5 index

Closes #131

## Schema change

After merging, users must rebuild: `rm $NEXUS_PATH/.bipartite/cache/refs.db && bip rebuild`

Existing refs without tags will have no `tags` field in JSONL (omitempty). To populate tags, re-import from a fresh Paperpile JSON export.

## Test plan

- [x] `bip search --tag antibody` returns only tagged refs
- [x] `bip search --tag variational` returns only tagged refs
- [x] `bip get <id>` displays `Tags:` line for tagged refs
- [x] Combined filters work (`--tag antibody -a Matsen`)
- [x] Untagged refs excluded from tag searches
- [x] Duplicate labels/folders deduplicated
- [x] All existing tests pass (`go test ./...`)
- [x] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)