### PR TITLE
Narrow default ball-in-court filter for multi-contributor repos

### DIFF
--- a/cmd/bip/checkin.go
+++ b/cmd/bip/checkin.go
@@ -292,21 +292,19 @@ func enrichPRsWithRequestedReviewers(repo string, prs []flow.GitHubItem) []flow.
 	return prs
 }
 
-// fetchCommentersForUnengaged returns commenter logins for items where there is
-// no action from githubUser in the window. These are the items the strict
-// filter would otherwise drop — fetching their commenters lets the filter keep
-// items the user previously engaged with (stale engagement still counts).
+// fetchCommentersForUnengaged returns commenter logins for teammate items with
+// no actions in the window. These are the items the strict filter routes
+// through HasInvolvement — past commenters only change the outcome when
+// `len(itemActions) == 0`; if anyone has acted, the last-actor rule decides
+// and involvement is not consulted.
 //
-// Only items that (a) have no actions from githubUser AND (b) are authored by
-// someone other than githubUser are queried, since those are the only ones
-// where past commenters change the outcome.
+// Only items that (a) have no actions from any participant AND (b) are authored
+// by someone other than githubUser are queried.
 func fetchCommentersForUnengaged(repo string, issues, prs []flow.GitHubItem, actions []flow.ItemAction, githubUser string) map[int][]string {
-	// Which items have the user already acted on in the window?
-	userActed := make(map[int]bool)
+	// Which items have any action in the window (from anyone)?
+	itemHasActions := make(map[int]bool)
 	for _, a := range actions {
-		if a.Actor == githubUser {
-			userActed[a.ItemNumber] = true
-		}
+		itemHasActions[a.ItemNumber] = true
 	}
 
 	var targets []int
@@ -314,7 +312,7 @@ func fetchCommentersForUnengaged(repo string, issues, prs []flow.GitHubItem, act
 		if it.User.Login == githubUser {
 			continue
 		}
-		if userActed[it.Number] {
+		if itemHasActions[it.Number] {
 			continue
 		}
 		targets = append(targets, it.Number)
@@ -323,7 +321,7 @@ func fetchCommentersForUnengaged(repo string, issues, prs []flow.GitHubItem, act
 		if it.User.Login == githubUser {
 			continue
 		}
-		if userActed[it.Number] {
+		if itemHasActions[it.Number] {
 			continue
 		}
 		targets = append(targets, it.Number)

--- a/cmd/bip/checkin.go
+++ b/cmd/bip/checkin.go
@@ -16,7 +16,12 @@ var checkinCmd = &cobra.Command{
 	Long: `Check in on GitHub activity across tracked repositories.
 
 By default, shows only items where the "ball is in your court" - items
-that need your attention or response. Use --all to see all activity.
+that need your attention or response. For items authored by someone else
+with no activity in the window, the default filter requires some signal
+of involvement: you are assigned, requested as reviewer, @mentioned in
+the body, or have previously commented. Use --broad to restore the older
+behavior (every teammate item counts as needing review), or --all to
+disable ball-in-my-court filtering entirely.
 
 The activity window defaults to the timestamp in .last-checkin.json (falling
 back to 3 days if the file doesn't exist). Each run updates .last-checkin.json
@@ -32,6 +37,7 @@ var (
 	checkinRepo      string
 	checkinCategory  string
 	checkinAll       bool
+	checkinBroad     bool
 	checkinSummarize bool
 )
 
@@ -42,6 +48,7 @@ func init() {
 	checkinCmd.Flags().StringVar(&checkinRepo, "repo", "", "Check single repo only")
 	checkinCmd.Flags().StringVar(&checkinCategory, "category", "", "Check repos in category only (code, writing)")
 	checkinCmd.Flags().BoolVar(&checkinAll, "all", false, "Show all activity (disable ball-in-my-court filtering)")
+	checkinCmd.Flags().BoolVar(&checkinBroad, "broad", false, "Use the legacy broad filter (count every teammate item as needing review)")
 	checkinCmd.Flags().BoolVar(&checkinSummarize, "summarize", false, "Generate LLM take-home summaries")
 }
 
@@ -174,8 +181,20 @@ func runCheckin(cmd *cobra.Command, args []string) {
 			enriched := flow.EnrichActionsWithLastComments(repo, itemsForEnrich, allActions)
 			allActions = append(allActions, enriched...)
 
-			issues = flow.FilterByBallInCourt(issues, allActions, githubUser)
-			prs = flow.FilterByBallInCourt(prs, allActions, githubUser)
+			if checkinBroad {
+				issues = flow.FilterByBallInCourt(issues, allActions, githubUser)
+				prs = flow.FilterByBallInCourt(prs, allActions, githubUser)
+			} else {
+				// Strict filter: for teammate items with no window activity, require
+				// some signal of involvement. Populate PR requested reviewers and
+				// past commenters for items that would otherwise fall through.
+				prs = enrichPRsWithRequestedReviewers(repo, prs)
+				inv := flow.Involvement{
+					Commenters: fetchCommentersForUnengaged(repo, issues, prs, allActions, githubUser),
+				}
+				issues = flow.FilterByBallInCourtStrict(issues, allActions, githubUser, inv)
+				prs = flow.FilterByBallInCourtStrict(prs, allActions, githubUser, inv)
+			}
 			allComments = flow.FilterCommentsByItems(allComments, append(issues, prs...))
 		}
 
@@ -243,6 +262,83 @@ func runCheckin(cmd *cobra.Command, args []string) {
 			printSummariesByRepo(allItems, summaries)
 		}
 	}
+}
+
+// enrichPRsWithRequestedReviewers populates RequestedReviewers on each PR via a
+// single batched GraphQL call. On failure, PRs keep empty reviewer lists and a
+// warning goes to stderr — the strict filter still runs using the other
+// involvement signals (assignees, mentions, past comments).
+func enrichPRsWithRequestedReviewers(repo string, prs []flow.GitHubItem) []flow.GitHubItem {
+	if len(prs) == 0 {
+		return prs
+	}
+	var numbers []int
+	for _, p := range prs {
+		numbers = append(numbers, p.Number)
+	}
+	reviewers, err := flow.FetchPRsRequestedReviewers(repo, numbers)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: could not fetch requested reviewers for %s: %v\n", repo, err)
+		return prs
+	}
+	for i, pr := range prs {
+		logins := reviewers[pr.Number]
+		var users []flow.GitHubUser
+		for _, l := range logins {
+			users = append(users, flow.GitHubUser{Login: l})
+		}
+		prs[i].RequestedReviewers = users
+	}
+	return prs
+}
+
+// fetchCommentersForUnengaged returns commenter logins for items where there is
+// no action from githubUser in the window. These are the items the strict
+// filter would otherwise drop — fetching their commenters lets the filter keep
+// items the user previously engaged with (stale engagement still counts).
+//
+// Only items that (a) have no actions from githubUser AND (b) are authored by
+// someone other than githubUser are queried, since those are the only ones
+// where past commenters change the outcome.
+func fetchCommentersForUnengaged(repo string, issues, prs []flow.GitHubItem, actions []flow.ItemAction, githubUser string) map[int][]string {
+	// Which items have the user already acted on in the window?
+	userActed := make(map[int]bool)
+	for _, a := range actions {
+		if a.Actor == githubUser {
+			userActed[a.ItemNumber] = true
+		}
+	}
+
+	var targets []int
+	for _, it := range issues {
+		if it.User.Login == githubUser {
+			continue
+		}
+		if userActed[it.Number] {
+			continue
+		}
+		targets = append(targets, it.Number)
+	}
+	for _, it := range prs {
+		if it.User.Login == githubUser {
+			continue
+		}
+		if userActed[it.Number] {
+			continue
+		}
+		targets = append(targets, it.Number)
+	}
+
+	if len(targets) == 0 {
+		return map[int][]string{}
+	}
+
+	commenters, err := flow.FetchItemsCommenters(repo, targets)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: could not fetch past commenters for %s: %v\n", repo, err)
+		return map[int][]string{}
+	}
+	return commenters
 }
 
 // printSummariesByRepo prints summaries grouped by repo with clickable URLs.

--- a/docs/guides/workflow-coordination.md
+++ b/docs/guides/workflow-coordination.md
@@ -10,6 +10,7 @@ Bipartite provides visibility across your team's GitHub repositories, Slack chan
 bip checkin                     # Items needing your attention since last checkin
 bip checkin --since 7d          # Last week (does not update .last-checkin.json)
 bip checkin --since 12h         # Last 12 hours
+bip checkin --broad             # Legacy broad filter (every teammate item counts)
 bip checkin --all               # All activity, not just action-needed
 bip checkin --category code     # Only repos in "code" category
 bip checkin --repo org/repo     # Single repo
@@ -18,7 +19,7 @@ bip checkin --summarize         # Include LLM-generated summaries
 
 Each run saves the current timestamp to `.last-checkin.json`, so the next run picks up where you left off (falling back to 3 days if the file doesn't exist). Using `--since` overrides the window without updating the state file.
 
-By default, checkin filters to items where the "ball is in your court" — PRs awaiting your review, issues assigned to you, discussions needing your response. Use `--all` to see everything.
+By default, checkin filters to items where the "ball is in your court" — PRs awaiting your review, issues assigned to you, discussions needing your response. For teammate items with no activity in the window, the default filter also requires some involvement signal: you are an assignee, requested reviewer, @mentioned in the body, or have previously commented. Use `--broad` to restore the older behavior (every teammate item counts), or `--all` to disable filtering entirely.
 
 Requires `sources.yml` in the working directory (typically your nexus repo).
 

--- a/internal/flow/ballcourt.go
+++ b/internal/flow/ballcourt.go
@@ -124,10 +124,11 @@ func bodyMentionsUser(body, user string) bool {
 	}
 	stripped := fencedCodeBlock.ReplaceAllString(body, "")
 	stripped = inlineCode.ReplaceAllString(stripped, "")
-	// GitHub handles contain [A-Za-z0-9-]. We also reject handle continuations of
-	// `_` so "alice" doesn't match bot-style handles like "alice_bot" that share
-	// the handle-character set. `foo@bar.com` emails are rejected because `foo`
-	// is in the trailing character set of the prefix check.
+	// Reject handle continuations in [A-Za-z0-9_-] so "@alice" doesn't match
+	// inside "@alice-bot" (a different GitHub user) or "@alice_bot" (underscore
+	// isn't valid in GitHub handles but rejecting it is defense-in-depth). The
+	// leading char class similarly prevents substring matches like "foo@alice"
+	// (email-like patterns).
 	pattern := regexp.MustCompile(`(?i)(^|[^A-Za-z0-9_-])@` + regexp.QuoteMeta(user) + `($|[^A-Za-z0-9_-])`)
 	return pattern.MatchString(stripped)
 }

--- a/internal/flow/ballcourt.go
+++ b/internal/flow/ballcourt.go
@@ -3,6 +3,7 @@ package flow
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -65,6 +66,108 @@ func BallInMyCourt(item GitHubItem, actions []ItemAction, githubUser string) boo
 	lastActor := itemActions[len(itemActions)-1].Actor
 
 	return lastActor != "" && lastActor != githubUser
+}
+
+// Involvement captures all the signals that indicate a user has some connection
+// to a GitHub item beyond "author posted it." Used by BallInMyCourtStrict to
+// decide whether a teammate's fresh item is really ball-in-court.
+//
+// The Commenters map carries past commenter logins keyed by item number; callers
+// populate it via FetchItemsCommenters (batched) so the check stays O(1) per item.
+type Involvement struct {
+	Commenters map[int][]string
+}
+
+// HasInvolvement reports whether the user has any non-authorship connection to
+// the item: assignee, requested reviewer, @mention in the body, or a past
+// commenter (from inv.Commenters).
+//
+// This is the gate for "their item, no actions" in BallInMyCourtStrict — without
+// at least one of these signals, a teammate's fresh item is not ball-in-court.
+func HasInvolvement(item GitHubItem, user string, inv Involvement) bool {
+	if user == "" {
+		return false
+	}
+	for _, a := range item.Assignees {
+		if a.Login == user {
+			return true
+		}
+	}
+	for _, r := range item.RequestedReviewers {
+		if r.Login == user {
+			return true
+		}
+	}
+	if bodyMentionsUser(item.Body, user) {
+		return true
+	}
+	for _, c := range inv.Commenters[item.Number] {
+		if c == user {
+			return true
+		}
+	}
+	return false
+}
+
+// fencedCodeBlock matches triple-backtick or tilde fenced code blocks.
+// @mentions inside these don't count as real mentions.
+var fencedCodeBlock = regexp.MustCompile("(?s)(```.*?```|~~~.*?~~~)")
+
+// inlineCode matches single-backtick inline code spans.
+var inlineCode = regexp.MustCompile("`[^`]*`")
+
+// bodyMentionsUser reports whether body contains an @user mention outside code
+// spans or fenced code blocks.
+func bodyMentionsUser(body, user string) bool {
+	if body == "" || user == "" {
+		return false
+	}
+	stripped := fencedCodeBlock.ReplaceAllString(body, "")
+	stripped = inlineCode.ReplaceAllString(stripped, "")
+	// GitHub handles contain [A-Za-z0-9-]. We also reject handle continuations of
+	// `_` so "alice" doesn't match bot-style handles like "alice_bot" that share
+	// the handle-character set. `foo@bar.com` emails are rejected because `foo`
+	// is in the trailing character set of the prefix check.
+	pattern := regexp.MustCompile(`(?i)(^|[^A-Za-z0-9_-])@` + regexp.QuoteMeta(user) + `($|[^A-Za-z0-9_-])`)
+	return pattern.MatchString(stripped)
+}
+
+// BallInMyCourtStrict is like BallInMyCourt but adds an involvement check for
+// the "their item, no actions" case. Without a signal that the user is actually
+// connected to the item (assigned, requested reviewer, @mentioned, or a past
+// commenter), a teammate's fresh item is not ball-in-court.
+//
+// All other cases match BallInMyCourt exactly: if there are actions in the
+// window, the last actor decides; if it's my item with no actions, it's not
+// ball-in-court.
+func BallInMyCourtStrict(item GitHubItem, actions []ItemAction, githubUser string, inv Involvement) bool {
+	author := item.User.Login
+	isMyItem := author == githubUser
+
+	itemActions := filterActionsForItem(actions, item.Number)
+
+	if len(itemActions) == 0 {
+		if isMyItem {
+			return false
+		}
+		return HasInvolvement(item, githubUser, inv)
+	}
+
+	sortActionsByTime(itemActions)
+	lastActor := itemActions[len(itemActions)-1].Actor
+
+	return lastActor != "" && lastActor != githubUser
+}
+
+// FilterByBallInCourtStrict applies BallInMyCourtStrict to each item.
+func FilterByBallInCourtStrict(items []GitHubItem, actions []ItemAction, githubUser string, inv Involvement) []GitHubItem {
+	var filtered []GitHubItem
+	for _, item := range items {
+		if BallInMyCourtStrict(item, actions, githubUser, inv) {
+			filtered = append(filtered, item)
+		}
+	}
+	return filtered
 }
 
 // filterActionsForItem returns actions that belong to the given item number.

--- a/internal/flow/ballcourt_test.go
+++ b/internal/flow/ballcourt_test.go
@@ -451,6 +451,246 @@ func TestCommentsToActions(t *testing.T) {
 	})
 }
 
+func TestBallInMyCourtStrict(t *testing.T) {
+	me := "jgallowa07"
+	now := time.Now()
+
+	t.Run("known-answer mix", func(t *testing.T) {
+		// 5 items from different authors, various involvement signals.
+		items := []GitHubItem{
+			{ // #1: assigned to me
+				Number:    1,
+				User:      GitHubUser{Login: "alice"},
+				Assignees: []GitHubUser{{Login: me}},
+				UpdatedAt: now,
+			},
+			{ // #2: mentioned in body
+				Number:    2,
+				User:      GitHubUser{Login: "bob"},
+				Body:      "hey @jgallowa07, can you look at this?",
+				UpdatedAt: now,
+			},
+			{ // #3: I previously commented
+				Number:    3,
+				User:      GitHubUser{Login: "carol"},
+				UpdatedAt: now,
+			},
+			{ // #4: requested reviewer
+				Number:             4,
+				User:               GitHubUser{Login: "dave"},
+				IsPR:               true,
+				RequestedReviewers: []GitHubUser{{Login: me}},
+				UpdatedAt:          now,
+			},
+			{ // #5: no connection
+				Number:    5,
+				User:      GitHubUser{Login: "eve"},
+				UpdatedAt: now,
+			},
+		}
+
+		inv := Involvement{
+			Commenters: map[int][]string{
+				3: {"carol", me, "frank"}, // I'm a past commenter on #3
+				5: {"eve", "frank"},       // not me
+			},
+		}
+
+		for _, n := range []int{1, 2, 3, 4} {
+			if !BallInMyCourtStrict(items[n-1], nil, me, inv) {
+				t.Errorf("item #%d: expected ball-in-my-court (involvement signal present)", n)
+			}
+		}
+		if BallInMyCourtStrict(items[4], nil, me, inv) {
+			t.Error("item #5: expected NOT ball-in-my-court (no connection)")
+		}
+	})
+
+	t.Run("their item no actions no involvement -> false", func(t *testing.T) {
+		// Regression for issue #123: EPIC #506 in dasm2-experiments authored by
+		// matsen with no assignees, no comments, no mentions of jgallowa07.
+		// Broad filter would show this; strict filter must drop it.
+		item := GitHubItem{
+			Number: 506,
+			User:   GitHubUser{Login: "matsen"},
+		}
+		if BallInMyCourtStrict(item, nil, me, Involvement{}) {
+			t.Error("Expected false: teammate item with no involvement should be dropped by strict filter")
+		}
+	})
+
+	t.Run("two-person repo regression", func(t *testing.T) {
+		// In a small repo where the user is assigned to or a requested reviewer
+		// on every teammate item, the strict filter matches the broad filter.
+		// No regression for small-team workflows.
+		items := []GitHubItem{
+			{Number: 1, User: GitHubUser{Login: "colleague"}, Assignees: []GitHubUser{{Login: me}}},
+			{Number: 2, User: GitHubUser{Login: "colleague"}, IsPR: true, RequestedReviewers: []GitHubUser{{Login: me}}},
+			{Number: 3, User: GitHubUser{Login: me}}, // my own, no actions
+		}
+		for _, item := range items {
+			broad := BallInMyCourt(item, nil, me)
+			strict := BallInMyCourtStrict(item, nil, me, Involvement{})
+			if broad != strict {
+				t.Errorf("item #%d: broad=%v strict=%v; expected agreement when user is connected to every teammate item", item.Number, broad, strict)
+			}
+		}
+	})
+
+	t.Run("stale engagement still counts", func(t *testing.T) {
+		// Their item, no actions in window, I commented 6 months ago.
+		// Should still show as ball-in-court.
+		item := GitHubItem{
+			Number: 42,
+			User:   GitHubUser{Login: "colleague"},
+		}
+		inv := Involvement{
+			Commenters: map[int][]string{42: {"colleague", me}},
+		}
+		if !BallInMyCourtStrict(item, nil, me, inv) {
+			t.Error("Expected true: past engagement should keep ball-in-court even without window actions")
+		}
+	})
+
+	t.Run("strict matches base when actions present", func(t *testing.T) {
+		// When there are actions in the window, strict and base behave identically:
+		// last actor decides, involvement is irrelevant.
+		item := GitHubItem{
+			Number: 7,
+			User:   GitHubUser{Login: "colleague"},
+		}
+		actions := []ItemAction{
+			{Actor: "colleague", ItemNumber: 7, Timestamp: now.Add(-1 * time.Hour)},
+			{Actor: me, ItemNumber: 7, Timestamp: now},
+		}
+		// I acted last -> false in both filters
+		if BallInMyCourtStrict(item, actions, me, Involvement{}) {
+			t.Error("Expected false: I acted last")
+		}
+		if BallInMyCourt(item, actions, me) != BallInMyCourtStrict(item, actions, me, Involvement{}) {
+			t.Error("Strict and base should agree when actions exist")
+		}
+	})
+
+	t.Run("my item no actions still false under strict", func(t *testing.T) {
+		// Involvement does not matter for my own items.
+		item := GitHubItem{
+			Number:    10,
+			User:      GitHubUser{Login: me},
+			Assignees: []GitHubUser{{Login: me}},
+		}
+		if BallInMyCourtStrict(item, nil, me, Involvement{}) {
+			t.Error("Expected false: my own item with no actions is waiting for feedback")
+		}
+	})
+
+	t.Run("mention in code block does not count", func(t *testing.T) {
+		item := GitHubItem{
+			Number: 20,
+			User:   GitHubUser{Login: "colleague"},
+			Body:   "here is some code:\n```\n@jgallowa07 wrote this\n```\nthat's it",
+		}
+		if BallInMyCourtStrict(item, nil, me, Involvement{}) {
+			t.Error("Expected false: @mention inside fenced code block should not count")
+		}
+	})
+
+	t.Run("mention in inline code does not count", func(t *testing.T) {
+		item := GitHubItem{
+			Number: 21,
+			User:   GitHubUser{Login: "colleague"},
+			Body:   "the handle `@jgallowa07` is formatted as code, not a mention",
+		}
+		if BallInMyCourtStrict(item, nil, me, Involvement{}) {
+			t.Error("Expected false: @mention inside inline code should not count")
+		}
+	})
+
+	t.Run("mention as substring of longer handle does not count", func(t *testing.T) {
+		item := GitHubItem{
+			Number: 22,
+			User:   GitHubUser{Login: "colleague"},
+			Body:   "cc @jgallowa07-alt please",
+		}
+		if BallInMyCourtStrict(item, nil, me, Involvement{}) {
+			t.Error("Expected false: @jgallowa07-alt is a different handle, not a mention of jgallowa07")
+		}
+	})
+}
+
+func TestBodyMentionsUser(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		user string
+		want bool
+	}{
+		{"simple mention", "hey @alice", "alice", true},
+		{"mention at start", "@alice please review", "alice", true},
+		{"mention after punctuation", "cc: @alice, thanks", "alice", true},
+		{"case insensitive", "cc @Alice", "alice", true},
+		{"no mention", "alice is the author", "alice", false},
+		{"email-like not a mention", "alice@example.com", "alice", false},
+		{"longer handle not a match", "cc @alice-bot", "alice", false},
+		{"underscore continuation not a match", "cc @alice_bot", "alice", false},
+		{"substring prefix not a match", "cc @alicia", "alice", false},
+		{"inside fenced block", "```\n@alice\n```", "alice", false},
+		{"inside inline code", "use `@alice` as handle", "alice", false},
+		{"mixed: mention + code", "`@alice` means @alice", "alice", true},
+		{"empty body", "", "alice", false},
+		{"empty user", "hey @alice", "", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := bodyMentionsUser(c.body, c.user); got != c.want {
+				t.Errorf("bodyMentionsUser(%q, %q) = %v, want %v", c.body, c.user, got, c.want)
+			}
+		})
+	}
+}
+
+func TestHasInvolvement(t *testing.T) {
+	me := "me"
+	t.Run("assignee", func(t *testing.T) {
+		item := GitHubItem{Assignees: []GitHubUser{{Login: me}}}
+		if !HasInvolvement(item, me, Involvement{}) {
+			t.Error("expected true: assignee")
+		}
+	})
+	t.Run("requested reviewer", func(t *testing.T) {
+		item := GitHubItem{RequestedReviewers: []GitHubUser{{Login: me}}}
+		if !HasInvolvement(item, me, Involvement{}) {
+			t.Error("expected true: requested reviewer")
+		}
+	})
+	t.Run("mention", func(t *testing.T) {
+		item := GitHubItem{Body: "cc @me here"}
+		if !HasInvolvement(item, me, Involvement{}) {
+			t.Error("expected true: mention")
+		}
+	})
+	t.Run("past commenter", func(t *testing.T) {
+		item := GitHubItem{Number: 1}
+		inv := Involvement{Commenters: map[int][]string{1: {"other", me}}}
+		if !HasInvolvement(item, me, inv) {
+			t.Error("expected true: past commenter")
+		}
+	})
+	t.Run("no signals", func(t *testing.T) {
+		item := GitHubItem{Number: 1, Body: "nothing here"}
+		inv := Involvement{Commenters: map[int][]string{1: {"other"}}}
+		if HasInvolvement(item, me, inv) {
+			t.Error("expected false: no involvement signals")
+		}
+	})
+	t.Run("empty user", func(t *testing.T) {
+		item := GitHubItem{Assignees: []GitHubUser{{Login: ""}}}
+		if HasInvolvement(item, "", Involvement{}) {
+			t.Error("expected false: empty user should not match empty assignee login")
+		}
+	})
+}
+
 func TestFilterByBallInCourt(t *testing.T) {
 	me := "me"
 	now := time.Now()

--- a/internal/flow/gh.go
+++ b/internal/flow/gh.go
@@ -679,6 +679,9 @@ func FetchItemsCommenters(repo string, itemNumbers []int) (map[int][]string, err
 				commenters = append(commenters, node.Author.Login)
 			}
 		}
+		if len(itemData.Comments.Nodes) >= 100 {
+			fmt.Fprintf(os.Stderr, "Warning: %s#%d returned 100 comments (GraphQL limit); older commenters may be missing\n", repo, n)
+		}
 		result[n] = commenters
 	}
 

--- a/internal/flow/gh.go
+++ b/internal/flow/gh.go
@@ -126,6 +126,7 @@ func FetchIssues(repo string, since time.Time) ([]GitHubItem, error) {
 		User        GitHubUser
 		PullRequest *struct{} `json:"pull_request,omitempty"`
 		Labels      []GitHubLabel
+		Assignees   []GitHubUser `json:"assignees"`
 	}
 
 	if err := json.Unmarshal(data, &rawItems); err != nil {
@@ -145,6 +146,7 @@ func FetchIssues(repo string, since time.Time) ([]GitHubItem, error) {
 			User:      raw.User,
 			IsPR:      raw.PullRequest != nil,
 			Labels:    raw.Labels,
+			Assignees: raw.Assignees,
 		})
 	}
 
@@ -206,6 +208,7 @@ func FetchIssue(repo string, number int) (*GitHubItem, error) {
 		User        GitHubUser
 		PullRequest *struct{} `json:"pull_request,omitempty"`
 		Labels      []GitHubLabel
+		Assignees   []GitHubUser `json:"assignees"`
 	}
 
 	if err := json.Unmarshal(data, &raw); err != nil {
@@ -223,6 +226,7 @@ func FetchIssue(repo string, number int) (*GitHubItem, error) {
 		User:      raw.User,
 		IsPR:      raw.PullRequest != nil,
 		Labels:    raw.Labels,
+		Assignees: raw.Assignees,
 	}, nil
 }
 
@@ -491,6 +495,194 @@ func FetchPRReviewsAsComments(repo string, prNumbers []int, since time.Time) []G
 		}
 	}
 	return comments
+}
+
+// FetchPRsRequestedReviewers fetches requested-reviewer logins for a batch of PRs
+// in a single GraphQL call. Returns a map from PR number to reviewer logins.
+// On failure, returns an error; callers may choose to continue without this data.
+//
+// Team and mannequin reviewers are omitted — only individual User reviewers are
+// returned (matching how ball-in-court checks a specific GitHub user login).
+func FetchPRsRequestedReviewers(repo string, prNumbers []int) (map[int][]string, error) {
+	if len(prNumbers) == 0 {
+		return map[int][]string{}, nil
+	}
+
+	parts := strings.SplitN(repo, "/", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid repo format %q, expected owner/name", repo)
+	}
+	owner, name := parts[0], parts[1]
+
+	if len(prNumbers) > 50 {
+		fmt.Fprintf(os.Stderr, "Warning: batching %d PRs in a single GraphQL query; may hit node limits\n", len(prNumbers))
+	}
+
+	var fragments []string
+	for _, n := range prNumbers {
+		fragments = append(fragments, fmt.Sprintf(`pr_%d: pullRequest(number: %d) {
+      reviewRequests(first: 100) {
+        nodes { requestedReviewer { __typename ... on User { login } } }
+      }
+    }`, n, n))
+	}
+
+	query := fmt.Sprintf(`query($owner: String!, $name: String!) {
+  repository(owner: $owner, name: $name) {
+    %s
+  }
+}`, strings.Join(fragments, "\n    "))
+
+	data, err := GHGraphQL(query, map[string]interface{}{
+		"owner": owner,
+		"name":  name,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("batch fetching requested reviewers for %s: %w", repo, err)
+	}
+
+	var top struct {
+		Data struct {
+			Repository json.RawMessage `json:"repository"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(data, &top); err != nil {
+		return nil, fmt.Errorf("parsing requested reviewers response: %w", err)
+	}
+
+	var prMap map[string]json.RawMessage
+	if err := json.Unmarshal(top.Data.Repository, &prMap); err != nil {
+		return nil, fmt.Errorf("parsing repository aliases: %w", err)
+	}
+
+	result := make(map[int][]string)
+	for _, n := range prNumbers {
+		alias := fmt.Sprintf("pr_%d", n)
+		raw, ok := prMap[alias]
+		if !ok {
+			continue
+		}
+
+		var prData struct {
+			ReviewRequests struct {
+				Nodes []struct {
+					RequestedReviewer struct {
+						Typename string `json:"__typename"`
+						Login    string `json:"login"`
+					} `json:"requestedReviewer"`
+				} `json:"nodes"`
+			} `json:"reviewRequests"`
+		}
+		if err := json.Unmarshal(raw, &prData); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: parsing requested reviewers for %s#%d: %v\n", repo, n, err)
+			continue
+		}
+
+		var reviewers []string
+		for _, node := range prData.ReviewRequests.Nodes {
+			if node.RequestedReviewer.Typename == "User" && node.RequestedReviewer.Login != "" {
+				reviewers = append(reviewers, node.RequestedReviewer.Login)
+			}
+		}
+		result[n] = reviewers
+	}
+
+	return result, nil
+}
+
+// FetchItemsCommenters fetches unique commenter logins for each issue/PR number
+// in a single batched GraphQL call. Returns a map from item number to commenter
+// logins. This is more efficient than N calls to FetchItemCommenters.
+//
+// Only the first 100 comments per item are fetched; items with more comments may
+// be missing older commenters. For ball-in-court "previously commented" checks,
+// this is acceptable — if the user commented on something with >100 comments, they
+// are almost certainly reachable via other signals (assignment, mention, review).
+func FetchItemsCommenters(repo string, itemNumbers []int) (map[int][]string, error) {
+	if len(itemNumbers) == 0 {
+		return map[int][]string{}, nil
+	}
+
+	parts := strings.SplitN(repo, "/", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid repo format %q, expected owner/name", repo)
+	}
+	owner, name := parts[0], parts[1]
+
+	if len(itemNumbers) > 50 {
+		fmt.Fprintf(os.Stderr, "Warning: batching %d items in a single GraphQL query; may hit node limits\n", len(itemNumbers))
+	}
+
+	var fragments []string
+	for _, n := range itemNumbers {
+		fragments = append(fragments, fmt.Sprintf(`item_%d: issueOrPullRequest(number: %d) {
+      ... on Issue { comments(first: 100) { nodes { author { login } } } }
+      ... on PullRequest { comments(first: 100) { nodes { author { login } } } }
+    }`, n, n))
+	}
+
+	query := fmt.Sprintf(`query($owner: String!, $name: String!) {
+  repository(owner: $owner, name: $name) {
+    %s
+  }
+}`, strings.Join(fragments, "\n    "))
+
+	data, err := GHGraphQL(query, map[string]interface{}{
+		"owner": owner,
+		"name":  name,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("batch fetching commenters for %s: %w", repo, err)
+	}
+
+	var top struct {
+		Data struct {
+			Repository json.RawMessage `json:"repository"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(data, &top); err != nil {
+		return nil, fmt.Errorf("parsing commenters response: %w", err)
+	}
+
+	var itemMap map[string]json.RawMessage
+	if err := json.Unmarshal(top.Data.Repository, &itemMap); err != nil {
+		return nil, fmt.Errorf("parsing repository aliases: %w", err)
+	}
+
+	result := make(map[int][]string)
+	for _, n := range itemNumbers {
+		alias := fmt.Sprintf("item_%d", n)
+		raw, ok := itemMap[alias]
+		if !ok {
+			continue
+		}
+
+		var itemData struct {
+			Comments struct {
+				Nodes []struct {
+					Author struct {
+						Login string `json:"login"`
+					} `json:"author"`
+				} `json:"nodes"`
+			} `json:"comments"`
+		}
+		if err := json.Unmarshal(raw, &itemData); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: parsing commenters for %s#%d: %v\n", repo, n, err)
+			continue
+		}
+
+		seen := make(map[string]bool)
+		var commenters []string
+		for _, node := range itemData.Comments.Nodes {
+			if node.Author.Login != "" && !seen[node.Author.Login] {
+				seen[node.Author.Login] = true
+				commenters = append(commenters, node.Author.Login)
+			}
+		}
+		result[n] = commenters
+	}
+
+	return result, nil
 }
 
 // FetchLastItemComment fetches the single most recent comment on an issue/PR.

--- a/internal/flow/types.go
+++ b/internal/flow/types.go
@@ -54,16 +54,18 @@ type GitHubRef struct {
 
 // GitHubItem represents an issue or PR from the GitHub API.
 type GitHubItem struct {
-	Number    int       `json:"number"`
-	Title     string    `json:"title"`
-	Body      string    `json:"body"`
-	State     string    `json:"state"`
-	HTMLURL   string    `json:"html_url"`
-	CreatedAt time.Time `json:"created_at"`
-	UpdatedAt time.Time `json:"updated_at"`
-	User      GitHubUser
-	IsPR      bool
-	Labels    []GitHubLabel
+	Number             int       `json:"number"`
+	Title              string    `json:"title"`
+	Body               string    `json:"body"`
+	State              string    `json:"state"`
+	HTMLURL            string    `json:"html_url"`
+	CreatedAt          time.Time `json:"created_at"`
+	UpdatedAt          time.Time `json:"updated_at"`
+	User               GitHubUser
+	IsPR               bool
+	Labels             []GitHubLabel
+	Assignees          []GitHubUser // Assignee logins (from issues list API)
+	RequestedReviewers []GitHubUser // Requested PR reviewers (PRs only; populated via separate fetch)
 }
 
 // GitHubUser represents a GitHub user.

--- a/skills/bip.checkin/SKILL.md
+++ b/skills/bip.checkin/SKILL.md
@@ -23,18 +23,25 @@ By default, checkin only shows items where you need to act:
 
 | Scenario | Shown? | Reason |
 |----------|--------|--------|
-| Their issue/PR, no comments | Yes | Need to review |
+| Their issue/PR, no comments, you're involved* | Yes | Need to review |
+| Their issue/PR, no comments, no involvement | No | Not your responsibility |
 | Their issue/PR, they commented last | Yes | They pinged again |
 | Their issue/PR, you commented last | No | Waiting for their reply |
 | Your issue/PR, no comments | No | Waiting for feedback |
 | Your issue/PR, they commented last | Yes | They replied |
 | Your issue/PR, you commented last | No | Waiting for their reply |
 
-Use `--all` to see everything (original behavior).
+*"You're involved" means at least one of: you're an assignee, requested
+reviewer, @mentioned in the body, or have previously commented on the item.
+
+Use `--broad` to restore the older behavior (every teammate item with no
+window activity counts as needing review). Use `--all` to disable filtering
+entirely.
 
 ## Options
 
 - `bip checkin --all` — Show all activity (disable ball-in-my-court filtering)
+- `bip checkin --broad` — Legacy broad filter (count every teammate item as needing review)
 - `bip checkin --since 2d` — Check activity from last 2 days instead of last check-in
 - `bip checkin --since 12h` — Check activity from last 12 hours
 - `bip checkin --repo matsengrp/dasm2-experiments` — Check single repo


### PR DESCRIPTION
## Summary

- Default `bip checkin` no longer flags every teammate issue/PR as needing your attention — it now requires an involvement signal for items authored by someone else with no activity in the window.
- Involvement = one of: you are an assignee, requested reviewer, `@mentioned` in the body, or a past commenter on the item.
- New `--broad` flag restores the previous behavior (every teammate item counts). `--all` is unchanged.

Closes #123

## Implementation

- **`internal/flow/types.go`**: added `Assignees` and `RequestedReviewers` to `GitHubItem`.
- **`internal/flow/gh.go`**: parse `assignees` from `/repos/{owner}/{repo}/issues`; added two batched GraphQL helpers, `FetchPRsRequestedReviewers` and `FetchItemsCommenters`. Each makes **one** call per repo regardless of item count.
- **`internal/flow/ballcourt.go`**: added `Involvement`, `HasInvolvement`, `BallInMyCourtStrict`, `FilterByBallInCourtStrict`. The legacy `BallInMyCourt` is unchanged.
- **`cmd/bip/checkin.go`**: wired up the strict filter as default; added helpers to populate requested-reviewers and past-commenters only for items where those signals could change the outcome (i.e., not-my-item, no user action in window).
- Skill doc (`skills/bip.checkin/SKILL.md`) and `docs/guides/workflow-coordination.md` updated.

## `@mention` handling

The body-mention check strips fenced code blocks and inline code before matching. The regex rejects handles that continue past the user login (e.g., `@alice-bot`, `@alicia`, `@alice_bot`) and email-like substrings (`foo@alice`).

## Smoke test

Sample run on `matsengrp/dasm2-experiments` over a 2-week window:

| Filter  | Issues | PRs |
|---------|--------|-----|
| `--broad` (old default) | 97 | 69 |
| new default (strict)    | 47 | 64 |

Issue noise drops by ~50%; PR count changes less because most PRs have window activity (reviews/comments) that the filter preserves regardless.

## Test plan

- [x] `go test ./...` — all green
- [x] `go vet ./...` — clean
- [x] `go fmt ./...` — clean
- [x] Unit tests cover: assignee / requested-reviewer / @mention / past-commenter signals; code-block and substring-handle edge cases; two-person-repo regression (strict matches broad when involvement always present); the #506 negative case.
- [x] Live smoke test: `bip checkin --repo matsengrp/bipartite --since 7d` and `--broad` variant verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)