### PR TITLE
Add bip epic watch — event-driven slot phase monitor

### DIFF
--- a/cmd/bip/epic.go
+++ b/cmd/bip/epic.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var epicCmd = &cobra.Command{
+	Use:   "epic",
+	Short: "EPIC slot orchestration commands",
+	Long: `Commands that support the EPIC multi-slot orchestration workflow.
+
+These commands operate against a repo containing an .epic-config.json file
+(see /bip.epic skill docs) and the .epic-status.json files written by each
+slot/clone/worktree.`,
+}
+
+func init() {
+	rootCmd.AddCommand(epicCmd)
+}

--- a/cmd/bip/epic_watch.go
+++ b/cmd/bip/epic_watch.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"errors"
@@ -60,7 +61,7 @@ func init() {
 	epicWatchCmd.Flags().StringVar(&epicWatchSince, "since", "",
 		"Replay log entries newer than DURATION to stdout, then exit (e.g. 30m, 2h)")
 	epicWatchCmd.Flags().StringVar(&epicWatchPoll, "poll", "",
-		"Use stat polling at DURATION instead of fsnotify (default 2s)")
+		"Stat-poll at DURATION instead of fsnotify (omit value to use 2s)")
 	epicWatchCmd.Flags().Lookup("poll").NoOptDefVal = defaultPollInterval
 	epicCmd.AddCommand(epicWatchCmd)
 }
@@ -103,6 +104,11 @@ type watchConfig struct {
 	logPath      string
 	stdout       io.Writer
 	stderr       io.Writer
+	// ready, when non-nil, is closed by runWatcher after the initial
+	// baseline reads complete and any fsnotify watches have been added,
+	// just before the event loop starts. Tests use this to synchronize
+	// on watcher startup so transition writes are not raced.
+	ready chan<- struct{}
 }
 
 func runEpicWatch(cmd *cobra.Command, args []string) error {
@@ -120,6 +126,11 @@ func runEpicWatch(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		exitWithError(ExitConfigError, "%v", err)
 	}
+	if len(slots) == 0 {
+		exitWithError(ExitConfigError,
+			"no slots resolved from %s — in worktree mode, at least one issue-* subdirectory must exist before starting the watcher",
+			epicConfigName)
+	}
 
 	logPath := filepath.Join(cwd, epicNotificationsName)
 
@@ -129,7 +140,7 @@ func runEpicWatch(cmd *cobra.Command, args []string) error {
 			exitWithError(ExitError, "invalid --since duration %q: %v", epicWatchSince, err)
 		}
 		cutoff := time.Now().Add(-dur)
-		return replaySince(logPath, cutoff, os.Stdout)
+		return replaySince(logPath, cutoff, os.Stdout, os.Stderr)
 	}
 
 	var pollInterval time.Duration
@@ -186,8 +197,13 @@ func loadEpicConfig(dir string) (*epicConfig, error) {
 // resolveSlots returns the slots to watch given the config.
 // Clone mode: one slot per entry in clone_names.
 // Worktree mode: one slot per existing issue-* subdirectory of clone_root.
+// Returns an empty slice (no error) if the worktree mode clone_root has no
+// issue-* subdirectories yet — the caller decides whether that is fatal.
 func resolveSlots(repoDir string, cfg *epicConfig) ([]slotInfo, error) {
-	cloneRoot := expandPath(cfg.CloneRoot)
+	cloneRoot, err := expandPath(cfg.CloneRoot)
+	if err != nil {
+		return nil, fmt.Errorf("expanding clone_root %q: %w", cfg.CloneRoot, err)
+	}
 	if !filepath.IsAbs(cloneRoot) {
 		cloneRoot = filepath.Join(repoDir, cloneRoot)
 	}
@@ -222,13 +238,16 @@ func resolveSlots(repoDir string, cfg *epicConfig) ([]slotInfo, error) {
 }
 
 // expandPath expands a leading ~/ to the user's home directory.
-func expandPath(p string) string {
-	if strings.HasPrefix(p, "~/") {
-		if home, err := os.UserHomeDir(); err == nil {
-			return filepath.Join(home, p[2:])
-		}
+// Returns an error if the home directory cannot be resolved.
+func expandPath(p string) (string, error) {
+	if !strings.HasPrefix(p, "~/") {
+		return p, nil
 	}
-	return p
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, p[2:]), nil
 }
 
 // parsePhasesFilter parses the comma-separated --phases value.
@@ -261,33 +280,11 @@ func readStatus(path string) (*epicStatus, error) {
 	return &s, nil
 }
 
-// seedLastPhases reads the notifications log and returns the most recent
-// new_phase per slot. Missing log returns an empty map.
-func seedLastPhases(logPath string) (map[string]string, error) {
-	last := map[string]string{}
-	f, err := os.Open(logPath)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return last, nil
-		}
-		return nil, err
-	}
-	defer f.Close()
-
-	dec := json.NewDecoder(f)
-	for dec.More() {
-		var ev epicEvent
-		if err := dec.Decode(&ev); err != nil {
-			break
-		}
-		last[ev.Slot] = ev.NewPhase
-	}
-	return last, nil
-}
-
-// replaySince writes log entries with timestamp >= now-DURATION to w.
-// It does not append to the log.
-func replaySince(logPath string, cutoff time.Time, w io.Writer) error {
+// scanLogLines streams the JSONL log file line-by-line, invoking handle for
+// each successfully parsed entry. Malformed lines are reported to warn (if
+// non-nil) and skipped — they never abort the scan, so a single corrupt entry
+// cannot drop subsequent valid ones.
+func scanLogLines(logPath string, warn io.Writer, handle func(epicEvent)) error {
 	f, err := os.Open(logPath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -297,22 +294,78 @@ func replaySince(logPath string, cutoff time.Time, w io.Writer) error {
 	}
 	defer f.Close()
 
-	dec := json.NewDecoder(f)
-	for dec.More() {
+	scanner := bufio.NewScanner(f)
+	// Allow long lines (large summaries with embedded newlines escaped via JSON).
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	lineNo := 0
+	for scanner.Scan() {
+		lineNo++
+		line := scanner.Bytes()
+		if len(bytesTrimSpace(line)) == 0 {
+			continue
+		}
 		var ev epicEvent
-		if err := dec.Decode(&ev); err != nil {
+		if err := json.Unmarshal(line, &ev); err != nil {
+			if warn != nil {
+				fmt.Fprintf(warn, "warning: %s line %d: %v\n", logPath, lineNo, err)
+			}
+			continue
+		}
+		handle(ev)
+	}
+	return scanner.Err()
+}
+
+// bytesTrimSpace trims ASCII whitespace from a byte slice without allocating
+// a new string.
+func bytesTrimSpace(b []byte) []byte {
+	start, end := 0, len(b)
+	for start < end {
+		c := b[start]
+		if c != ' ' && c != '\t' && c != '\r' && c != '\n' {
 			break
 		}
+		start++
+	}
+	for end > start {
+		c := b[end-1]
+		if c != ' ' && c != '\t' && c != '\r' && c != '\n' {
+			break
+		}
+		end--
+	}
+	return b[start:end]
+}
+
+// seedLastPhases reads the notifications log and returns the most recent
+// new_phase per slot. Missing log returns an empty map. Malformed lines are
+// reported to warn and skipped.
+func seedLastPhases(logPath string, warn io.Writer) (map[string]string, error) {
+	last := map[string]string{}
+	if err := scanLogLines(logPath, warn, func(ev epicEvent) {
+		last[ev.Slot] = ev.NewPhase
+	}); err != nil {
+		return last, err
+	}
+	return last, nil
+}
+
+// replaySince writes log entries with timestamp >= cutoff to w.
+// It does not append to the log.
+func replaySince(logPath string, cutoff time.Time, w io.Writer, warn io.Writer) error {
+	return scanLogLines(logPath, warn, func(ev epicEvent) {
 		ts, err := time.Parse(time.RFC3339, ev.Ts)
 		if err != nil {
-			continue
+			if warn != nil {
+				fmt.Fprintf(warn, "warning: invalid ts %q: %v\n", ev.Ts, err)
+			}
+			return
 		}
 		if ts.Before(cutoff) {
-			continue
+			return
 		}
 		fmt.Fprintln(w, formatEventLine(ev))
-	}
-	return nil
+	})
 }
 
 // formatEventLine renders an event as a single human-readable stdout line.
@@ -332,11 +385,13 @@ func formatEventLine(ev epicEvent) string {
 		ev.Slot, ev.Issue, old, ev.NewPhase, summary)
 }
 
-// runWatcher seeds state from the log, performs an initial baseline
-// read of every slot, and then either polls or uses fsnotify to detect
-// phase transitions until ctx is cancelled.
+// runWatcher seeds state from the log, performs an initial baseline read of
+// every slot, sets up fsnotify (or stat polling) and then dispatches phase
+// transitions until ctx is cancelled. lastPhase is the only mutable state
+// shared across the baseline read and the event loop; it lives entirely
+// inside this single goroutine.
 func runWatcher(ctx context.Context, cfg watchConfig) error {
-	lastPhase, err := seedLastPhases(cfg.logPath)
+	lastPhase, err := seedLastPhases(cfg.logPath, cfg.stderr)
 	if err != nil {
 		fmt.Fprintf(cfg.stderr, "warning: reading notifications log: %v\n", err)
 		lastPhase = map[string]string{}
@@ -353,9 +408,41 @@ func runWatcher(ctx context.Context, cfg watchConfig) error {
 	}
 
 	if cfg.pollInterval > 0 {
+		signalReady(cfg)
 		return runPollLoop(ctx, cfg, lastPhase, logFile)
 	}
-	return runFsnotifyLoop(ctx, cfg, lastPhase, logFile)
+
+	w, err := fsnotify.NewWatcher()
+	if err != nil {
+		return fmt.Errorf("creating fsnotify watcher: %w", err)
+	}
+	defer w.Close()
+
+	parentToSlots := map[string][]slotInfo{}
+	for _, s := range cfg.slots {
+		parent := filepath.Dir(s.statusPath)
+		parentToSlots[parent] = append(parentToSlots[parent], s)
+	}
+	added := 0
+	for parent := range parentToSlots {
+		if err := w.Add(parent); err != nil {
+			fmt.Fprintf(cfg.stderr, "warning: watching %s: %v\n", parent, err)
+			continue
+		}
+		added++
+	}
+	if added == 0 {
+		return fmt.Errorf("no parent directories could be watched (%d slots configured)", len(cfg.slots))
+	}
+
+	signalReady(cfg)
+	return runFsnotifyEvents(ctx, w, parentToSlots, cfg, lastPhase, logFile)
+}
+
+func signalReady(cfg watchConfig) {
+	if cfg.ready != nil {
+		close(cfg.ready)
+	}
 }
 
 // processStatus reads the slot's status file and emits a transition event
@@ -411,24 +498,7 @@ func emitEvent(ev epicEvent, logFile *os.File, stdout, stderr io.Writer) {
 	fmt.Fprintln(stdout, formatEventLine(ev))
 }
 
-func runFsnotifyLoop(ctx context.Context, cfg watchConfig, lastPhase map[string]string, logFile *os.File) error {
-	w, err := fsnotify.NewWatcher()
-	if err != nil {
-		return fmt.Errorf("creating fsnotify watcher: %w", err)
-	}
-	defer w.Close()
-
-	parentToSlots := map[string][]slotInfo{}
-	for _, s := range cfg.slots {
-		parent := filepath.Dir(s.statusPath)
-		parentToSlots[parent] = append(parentToSlots[parent], s)
-	}
-	for parent := range parentToSlots {
-		if err := w.Add(parent); err != nil {
-			fmt.Fprintf(cfg.stderr, "warning: watching %s: %v\n", parent, err)
-		}
-	}
-
+func runFsnotifyEvents(ctx context.Context, w *fsnotify.Watcher, parentToSlots map[string][]slotInfo, cfg watchConfig, lastPhase map[string]string, logFile *os.File) error {
 	for {
 		select {
 		case <-ctx.Done():

--- a/cmd/bip/epic_watch.go
+++ b/cmd/bip/epic_watch.go
@@ -1,0 +1,474 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/spf13/cobra"
+)
+
+const (
+	epicConfigName        = ".epic-config.json"
+	epicStatusName        = ".epic-status.json"
+	epicNotificationsName = ".epic-notifications.log"
+
+	defaultEpicWatchPhases = "needs-human,completed,awaiting-results,quality-gate"
+	defaultPollInterval    = "2s"
+)
+
+var (
+	epicWatchPhases string
+	epicWatchSince  string
+	epicWatchPoll   string
+)
+
+var epicWatchCmd = &cobra.Command{
+	Use:   "watch",
+	Short: "Watch .epic-status.json files for phase transitions",
+	Long: `Watch .epic-status.json files across all configured slots and emit
+phase-transition events to .epic-notifications.log (one JSONL line per
+event) and to stdout (one human-readable line per event).
+
+Reads .epic-config.json from the current working directory to discover
+slots. Watches each slot's parent directory using fsnotify, or falls back
+to stat polling when --poll is set (e.g. for NFS-mounted clone roots
+where inotify does not fire on remote writes).
+
+Run as a long-lived process. Exits cleanly on SIGINT or SIGTERM.
+
+Examples:
+  bip epic watch
+  bip epic watch --phases needs-human,completed
+  bip epic watch --since 30m
+  bip epic watch --poll=100ms`,
+	RunE: runEpicWatch,
+}
+
+func init() {
+	epicWatchCmd.Flags().StringVar(&epicWatchPhases, "phases", defaultEpicWatchPhases,
+		"Comma-separated phases to alert on")
+	epicWatchCmd.Flags().StringVar(&epicWatchSince, "since", "",
+		"Replay log entries newer than DURATION to stdout, then exit (e.g. 30m, 2h)")
+	epicWatchCmd.Flags().StringVar(&epicWatchPoll, "poll", "",
+		"Use stat polling at DURATION instead of fsnotify (default 2s)")
+	epicWatchCmd.Flags().Lookup("poll").NoOptDefVal = defaultPollInterval
+	epicCmd.AddCommand(epicWatchCmd)
+}
+
+// epicConfig mirrors the relevant fields of .epic-config.json.
+type epicConfig struct {
+	CloneRoot      string   `json:"clone_root"`
+	CloneNames     []string `json:"clone_names"`
+	LocalWorktrees bool     `json:"local_worktrees"`
+}
+
+// epicStatus mirrors the .epic-status.json fields the watcher reads.
+type epicStatus struct {
+	Issue   int    `json:"issue"`
+	Phase   string `json:"phase"`
+	Summary string `json:"summary"`
+}
+
+// epicEvent is the JSONL schema written to .epic-notifications.log.
+type epicEvent struct {
+	Ts       string  `json:"ts"`
+	Slot     string  `json:"slot"`
+	Issue    int     `json:"issue"`
+	OldPhase *string `json:"old_phase"`
+	NewPhase string  `json:"new_phase"`
+	Summary  string  `json:"summary"`
+}
+
+// slotInfo identifies a single slot the watcher tracks.
+type slotInfo struct {
+	name       string // e.g. "alpha" (clone mode) or "issue-100" (worktree mode)
+	statusPath string // absolute path to .epic-status.json
+}
+
+// watchConfig is the testable input to runWatcher.
+type watchConfig struct {
+	slots        []slotInfo
+	phases       map[string]bool
+	pollInterval time.Duration // 0 means use fsnotify
+	logPath      string
+	stdout       io.Writer
+	stderr       io.Writer
+}
+
+func runEpicWatch(cmd *cobra.Command, args []string) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		exitWithError(ExitError, "getting cwd: %v", err)
+	}
+
+	cfg, err := loadEpicConfig(cwd)
+	if err != nil {
+		exitWithError(ExitConfigError, "%v", err)
+	}
+
+	slots, err := resolveSlots(cwd, cfg)
+	if err != nil {
+		exitWithError(ExitConfigError, "%v", err)
+	}
+
+	logPath := filepath.Join(cwd, epicNotificationsName)
+
+	if epicWatchSince != "" {
+		dur, err := time.ParseDuration(epicWatchSince)
+		if err != nil {
+			exitWithError(ExitError, "invalid --since duration %q: %v", epicWatchSince, err)
+		}
+		cutoff := time.Now().Add(-dur)
+		return replaySince(logPath, cutoff, os.Stdout)
+	}
+
+	var pollInterval time.Duration
+	if epicWatchPoll != "" {
+		d, err := time.ParseDuration(epicWatchPoll)
+		if err != nil {
+			exitWithError(ExitError, "invalid --poll duration %q: %v", epicWatchPoll, err)
+		}
+		if d <= 0 {
+			exitWithError(ExitError, "invalid --poll duration %q: must be positive", epicWatchPoll)
+		}
+		pollInterval = d
+	}
+
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	return runWatcher(ctx, watchConfig{
+		slots:        slots,
+		phases:       parsePhasesFilter(epicWatchPhases),
+		pollInterval: pollInterval,
+		logPath:      logPath,
+		stdout:       os.Stdout,
+		stderr:       os.Stderr,
+	})
+}
+
+// loadEpicConfig reads and validates .epic-config.json from dir.
+func loadEpicConfig(dir string) (*epicConfig, error) {
+	path := filepath.Join(dir, epicConfigName)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("missing %s in %s", epicConfigName, dir)
+		}
+		return nil, fmt.Errorf("reading %s: %w", path, err)
+	}
+	var cfg epicConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", path, err)
+	}
+	if cfg.CloneRoot == "" {
+		return nil, fmt.Errorf("%s: clone_root is required", path)
+	}
+	if cfg.LocalWorktrees && len(cfg.CloneNames) > 0 {
+		return nil, fmt.Errorf("%s: local_worktrees and clone_names are mutually exclusive", path)
+	}
+	if !cfg.LocalWorktrees && len(cfg.CloneNames) == 0 {
+		return nil, fmt.Errorf("%s: must set local_worktrees: true or clone_names: [...]", path)
+	}
+	return &cfg, nil
+}
+
+// resolveSlots returns the slots to watch given the config.
+// Clone mode: one slot per entry in clone_names.
+// Worktree mode: one slot per existing issue-* subdirectory of clone_root.
+func resolveSlots(repoDir string, cfg *epicConfig) ([]slotInfo, error) {
+	cloneRoot := expandPath(cfg.CloneRoot)
+	if !filepath.IsAbs(cloneRoot) {
+		cloneRoot = filepath.Join(repoDir, cloneRoot)
+	}
+
+	if cfg.LocalWorktrees {
+		entries, err := os.ReadDir(cloneRoot)
+		if err != nil {
+			return nil, fmt.Errorf("reading clone_root %s: %w", cloneRoot, err)
+		}
+		var slots []slotInfo
+		for _, e := range entries {
+			name := e.Name()
+			if !e.IsDir() || !strings.HasPrefix(name, "issue-") {
+				continue
+			}
+			slots = append(slots, slotInfo{
+				name:       name,
+				statusPath: filepath.Join(cloneRoot, name, epicStatusName),
+			})
+		}
+		return slots, nil
+	}
+
+	var slots []slotInfo
+	for _, name := range cfg.CloneNames {
+		slots = append(slots, slotInfo{
+			name:       name,
+			statusPath: filepath.Join(cloneRoot, name, epicStatusName),
+		})
+	}
+	return slots, nil
+}
+
+// expandPath expands a leading ~/ to the user's home directory.
+func expandPath(p string) string {
+	if strings.HasPrefix(p, "~/") {
+		if home, err := os.UserHomeDir(); err == nil {
+			return filepath.Join(home, p[2:])
+		}
+	}
+	return p
+}
+
+// parsePhasesFilter parses the comma-separated --phases value.
+// An empty string yields an empty filter (matches no phase).
+func parsePhasesFilter(s string) map[string]bool {
+	out := map[string]bool{}
+	for _, p := range strings.Split(s, ",") {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		out[p] = true
+	}
+	return out
+}
+
+// readStatus loads and validates a slot's .epic-status.json.
+func readStatus(path string) (*epicStatus, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var s epicStatus
+	if err := json.Unmarshal(data, &s); err != nil {
+		return nil, err
+	}
+	if s.Phase == "" {
+		return nil, errors.New("missing phase")
+	}
+	return &s, nil
+}
+
+// seedLastPhases reads the notifications log and returns the most recent
+// new_phase per slot. Missing log returns an empty map.
+func seedLastPhases(logPath string) (map[string]string, error) {
+	last := map[string]string{}
+	f, err := os.Open(logPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return last, nil
+		}
+		return nil, err
+	}
+	defer f.Close()
+
+	dec := json.NewDecoder(f)
+	for dec.More() {
+		var ev epicEvent
+		if err := dec.Decode(&ev); err != nil {
+			break
+		}
+		last[ev.Slot] = ev.NewPhase
+	}
+	return last, nil
+}
+
+// replaySince writes log entries with timestamp >= now-DURATION to w.
+// It does not append to the log.
+func replaySince(logPath string, cutoff time.Time, w io.Writer) error {
+	f, err := os.Open(logPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	defer f.Close()
+
+	dec := json.NewDecoder(f)
+	for dec.More() {
+		var ev epicEvent
+		if err := dec.Decode(&ev); err != nil {
+			break
+		}
+		ts, err := time.Parse(time.RFC3339, ev.Ts)
+		if err != nil {
+			continue
+		}
+		if ts.Before(cutoff) {
+			continue
+		}
+		fmt.Fprintln(w, formatEventLine(ev))
+	}
+	return nil
+}
+
+// formatEventLine renders an event as a single human-readable stdout line.
+// Tabs and newlines in summary are collapsed to spaces.
+func formatEventLine(ev epicEvent) string {
+	summary := strings.Map(func(r rune) rune {
+		if r == '\t' || r == '\n' || r == '\r' {
+			return ' '
+		}
+		return r
+	}, ev.Summary)
+	old := "<none>"
+	if ev.OldPhase != nil {
+		old = *ev.OldPhase
+	}
+	return fmt.Sprintf("%s (i%d): %s → %s — %s",
+		ev.Slot, ev.Issue, old, ev.NewPhase, summary)
+}
+
+// runWatcher seeds state from the log, performs an initial baseline
+// read of every slot, and then either polls or uses fsnotify to detect
+// phase transitions until ctx is cancelled.
+func runWatcher(ctx context.Context, cfg watchConfig) error {
+	lastPhase, err := seedLastPhases(cfg.logPath)
+	if err != nil {
+		fmt.Fprintf(cfg.stderr, "warning: reading notifications log: %v\n", err)
+		lastPhase = map[string]string{}
+	}
+
+	logFile, err := os.OpenFile(cfg.logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("opening notifications log: %w", err)
+	}
+	defer logFile.Close()
+
+	for _, s := range cfg.slots {
+		processStatus(s, lastPhase, cfg, logFile)
+	}
+
+	if cfg.pollInterval > 0 {
+		return runPollLoop(ctx, cfg, lastPhase, logFile)
+	}
+	return runFsnotifyLoop(ctx, cfg, lastPhase, logFile)
+}
+
+// processStatus reads the slot's status file and emits a transition event
+// when the phase has changed and matches the filter. A slot first observed
+// without a prior phase has its phase recorded as a baseline (no emission).
+func processStatus(s slotInfo, lastPhase map[string]string, cfg watchConfig, logFile *os.File) {
+	status, err := readStatus(s.statusPath)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			fmt.Fprintf(cfg.stderr, "warning: reading %s: %v\n", s.statusPath, err)
+		}
+		return
+	}
+	prev, hadPrev := lastPhase[s.name]
+	if !hadPrev {
+		lastPhase[s.name] = status.Phase
+		return
+	}
+	if prev == status.Phase {
+		return
+	}
+	if !cfg.phases[status.Phase] {
+		// Non-milestone transition: silently update state.
+		lastPhase[s.name] = status.Phase
+		return
+	}
+	old := prev
+	ev := epicEvent{
+		Ts:       time.Now().UTC().Format(time.RFC3339),
+		Slot:     s.name,
+		Issue:    status.Issue,
+		OldPhase: &old,
+		NewPhase: status.Phase,
+		Summary:  status.Summary,
+	}
+	emitEvent(ev, logFile, cfg.stdout, cfg.stderr)
+	lastPhase[s.name] = status.Phase
+}
+
+// emitEvent appends a JSONL entry to the log and prints a human-readable
+// line to stdout. A failure to write either channel is reported to stderr
+// but never aborts the watcher.
+func emitEvent(ev epicEvent, logFile *os.File, stdout, stderr io.Writer) {
+	line, err := json.Marshal(ev)
+	if err != nil {
+		fmt.Fprintf(stderr, "warning: marshaling event: %v\n", err)
+		return
+	}
+	line = append(line, '\n')
+	if _, err := logFile.Write(line); err != nil {
+		fmt.Fprintf(stderr, "warning: writing notifications log: %v\n", err)
+	}
+	fmt.Fprintln(stdout, formatEventLine(ev))
+}
+
+func runFsnotifyLoop(ctx context.Context, cfg watchConfig, lastPhase map[string]string, logFile *os.File) error {
+	w, err := fsnotify.NewWatcher()
+	if err != nil {
+		return fmt.Errorf("creating fsnotify watcher: %w", err)
+	}
+	defer w.Close()
+
+	parentToSlots := map[string][]slotInfo{}
+	for _, s := range cfg.slots {
+		parent := filepath.Dir(s.statusPath)
+		parentToSlots[parent] = append(parentToSlots[parent], s)
+	}
+	for parent := range parentToSlots {
+		if err := w.Add(parent); err != nil {
+			fmt.Fprintf(cfg.stderr, "warning: watching %s: %v\n", parent, err)
+		}
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case ev, ok := <-w.Events:
+			if !ok {
+				return nil
+			}
+			if filepath.Base(ev.Name) != epicStatusName {
+				continue
+			}
+			if ev.Op&(fsnotify.Write|fsnotify.Create) == 0 {
+				continue
+			}
+			for _, s := range parentToSlots[filepath.Dir(ev.Name)] {
+				if s.statusPath == ev.Name {
+					processStatus(s, lastPhase, cfg, logFile)
+				}
+			}
+		case err, ok := <-w.Errors:
+			if !ok {
+				return nil
+			}
+			fmt.Fprintf(cfg.stderr, "warning: fsnotify error: %v\n", err)
+		}
+	}
+}
+
+func runPollLoop(ctx context.Context, cfg watchConfig, lastPhase map[string]string, logFile *os.File) error {
+	ticker := time.NewTicker(cfg.pollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			for _, s := range cfg.slots {
+				processStatus(s, lastPhase, cfg, logFile)
+			}
+		}
+	}
+}

--- a/cmd/bip/epic_watch_test.go
+++ b/cmd/bip/epic_watch_test.go
@@ -113,6 +113,7 @@ func startWatcher(t *testing.T, slots []slotInfo, phases map[string]bool, logPat
 	t.Helper()
 	stdout := &syncBuffer{}
 	stderr := &syncBuffer{}
+	ready := make(chan struct{})
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
 	go func() {
@@ -123,8 +124,21 @@ func startWatcher(t *testing.T, slots []slotInfo, phases map[string]bool, logPat
 			logPath:      logPath,
 			stdout:       stdout,
 			stderr:       stderr,
+			ready:        ready,
 		})
 	}()
+	// Block until the watcher has finished its baseline reads and (in
+	// fsnotify mode) installed all watches. This makes the subsequent
+	// transition writes deterministic — no race against startup.
+	select {
+	case <-ready:
+	case err := <-done:
+		// runWatcher returned before signaling ready (typically a setup error).
+		t.Fatalf("watcher exited before ready: %v", err)
+	case <-time.After(2 * time.Second):
+		cancel()
+		t.Fatal("watcher did not signal ready within 2s")
+	}
 	return &watcherHandle{cancel: cancel, done: done, stdout: stdout, stderr: stderr}
 }
 
@@ -163,9 +177,6 @@ func TestPhaseTransitionEmits(t *testing.T) {
 	h := startWatcher(t, []slotInfo{slot}, parsePhasesFilter(defaultEpicWatchPhases), logPath, 50*time.Millisecond)
 	defer h.stop(t)
 
-	// Wait for baseline read to complete.
-	time.Sleep(150 * time.Millisecond)
-
 	writeStatus(t, slot.statusPath, 42, "quality-gate", "PR open")
 
 	waitFor(t, 2*time.Second, func() bool {
@@ -202,7 +213,10 @@ func TestFirstReadIsBaselineNoEmit(t *testing.T) {
 	writeStatus(t, slot.statusPath, 1, "needs-human", "stuck")
 
 	h := startWatcher(t, []slotInfo{slot}, parsePhasesFilter(defaultEpicWatchPhases), logPath, 50*time.Millisecond)
-	time.Sleep(200 * time.Millisecond)
+	// startWatcher already blocked on the ready signal, so the baseline read
+	// is complete before this line. A short wait ensures any spurious
+	// post-baseline tick would also have fired.
+	time.Sleep(150 * time.Millisecond)
 	h.stop(t)
 
 	if events := readLogEvents(t, logPath); len(events) != 0 {
@@ -223,8 +237,8 @@ func TestNonMilestoneSuppressed(t *testing.T) {
 	h := startWatcher(t, []slotInfo{slot}, parsePhasesFilter(defaultEpicWatchPhases), logPath, 50*time.Millisecond)
 	defer h.stop(t)
 
-	time.Sleep(150 * time.Millisecond)
 	writeStatus(t, slot.statusPath, 1, "coding", "making changes")
+	// Allow several poll ticks to confirm no spurious event appears.
 	time.Sleep(250 * time.Millisecond)
 
 	if events := readLogEvents(t, logPath); len(events) != 0 {
@@ -242,19 +256,29 @@ func TestRepeatedWriteSamePhase(t *testing.T) {
 	h := startWatcher(t, []slotInfo{slot}, parsePhasesFilter(defaultEpicWatchPhases), logPath, 50*time.Millisecond)
 	defer h.stop(t)
 
-	time.Sleep(150 * time.Millisecond)
-
+	// First write IS a milestone transition (coding → needs-human).
 	writeStatus(t, slot.statusPath, 1, "needs-human", "v1")
 	waitFor(t, 2*time.Second, func() bool {
 		return len(readLogEvents(t, logPath)) >= 1
 	})
 
+	// Subsequent writes with the same phase but different summaries must
+	// NOT emit additional events — the gate is on phase, not on summary.
 	writeStatus(t, slot.statusPath, 1, "needs-human", "v2")
 	writeStatus(t, slot.statusPath, 1, "needs-human", "v3")
 	time.Sleep(200 * time.Millisecond)
 
-	if got := len(readLogEvents(t, logPath)); got != 1 {
-		t.Fatalf("expected exactly one transition event, got %d", got)
+	events := readLogEvents(t, logPath)
+	if len(events) != 1 {
+		t.Fatalf("expected exactly one transition event, got %d: %+v", len(events), events)
+	}
+	got := events[0]
+	if got.NewPhase != "needs-human" || got.OldPhase == nil || *got.OldPhase != "coding" {
+		t.Errorf("unexpected event content: %+v", got)
+	}
+	// Summary must come from the transitioning write, not a later same-phase rewrite.
+	if got.Summary != "v1" {
+		t.Errorf("summary = %q, want %q (transitioning write)", got.Summary, "v1")
 	}
 }
 
@@ -270,7 +294,6 @@ func TestLogLineIsValidJSON(t *testing.T) {
 	h := startWatcher(t, []slotInfo{slot}, parsePhasesFilter(defaultEpicWatchPhases), logPath, 50*time.Millisecond)
 	defer h.stop(t)
 
-	time.Sleep(150 * time.Millisecond)
 	gnarlySummary := "line1\nline2\twith\ttabs\nquoted: \"hello\" — emoji 🎉"
 	writeStatus(t, slot.statusPath, 7, "completed", gnarlySummary)
 	waitFor(t, 2*time.Second, func() bool {
@@ -289,13 +312,14 @@ func TestLogLineIsValidJSON(t *testing.T) {
 		t.Errorf("summary did not round-trip: got %q want %q", got.Summary, gnarlySummary)
 	}
 
-	// The stdout line must be a single line: tabs/newlines collapsed.
+	// The stdout line must be a single line: tabs AND newlines collapsed.
+	// stdoutLines splits on '\n', so the count check catches surviving newlines.
 	lines := stdoutLines(h.stdout)
 	if len(lines) != 1 {
-		t.Fatalf("expected single stdout line, got %d: %v", len(lines), lines)
+		t.Fatalf("expected single stdout line (newlines should be collapsed), got %d: %v", len(lines), lines)
 	}
-	if strings.ContainsAny(lines[0], "\t") {
-		t.Errorf("stdout line still contains tab: %q", lines[0])
+	if strings.ContainsAny(lines[0], "\t\n\r") {
+		t.Errorf("stdout line still contains tab/newline/cr: %q", lines[0])
 	}
 }
 
@@ -307,7 +331,6 @@ func TestNotificationLogPersists(t *testing.T) {
 	writeStatus(t, slot.statusPath, 1, "coding", "")
 
 	h := startWatcher(t, []slotInfo{slot}, parsePhasesFilter(defaultEpicWatchPhases), logPath, 50*time.Millisecond)
-	time.Sleep(150 * time.Millisecond)
 	writeStatus(t, slot.statusPath, 1, "completed", "done")
 	waitFor(t, 2*time.Second, func() bool {
 		return len(readLogEvents(t, logPath)) >= 1
@@ -348,7 +371,8 @@ func TestStateRecoveryFromLog(t *testing.T) {
 	writeStatus(t, slot.statusPath, 99, "quality-gate", "still here")
 
 	h := startWatcher(t, []slotInfo{slot}, parsePhasesFilter(defaultEpicWatchPhases), logPath, 50*time.Millisecond)
-	time.Sleep(200 * time.Millisecond)
+	// Allow several ticks; if seeding worked, no new event should appear.
+	time.Sleep(150 * time.Millisecond)
 	h.stop(t)
 
 	events := readLogEvents(t, logPath)
@@ -386,7 +410,7 @@ func TestSinceFlagReplaysFromLog(t *testing.T) {
 
 	var buf bytes.Buffer
 	cutoff := time.Now().Add(-1 * time.Hour)
-	if err := replaySince(logPath, cutoff, &buf); err != nil {
+	if err := replaySince(logPath, cutoff, &buf, io.Discard); err != nil {
 		t.Fatal(err)
 	}
 	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
@@ -422,11 +446,10 @@ func TestSinceBoundaryFuture(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// --since=-1h pushes the cutoff one hour into the future.
-	dur, _ := time.ParseDuration("-1h")
-	cutoff := time.Now().Add(-dur)
+	// Cutoff one hour in the future — no past entry should match.
+	cutoff := time.Now().Add(time.Hour)
 	var buf bytes.Buffer
-	if err := replaySince(logPath, cutoff, &buf); err != nil {
+	if err := replaySince(logPath, cutoff, &buf, io.Discard); err != nil {
 		t.Fatal(err)
 	}
 	if buf.Len() != 0 {
@@ -459,7 +482,7 @@ func TestSinceBoundaryAll(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	if err := replaySince(logPath, time.Now().Add(-1000*time.Hour), &buf); err != nil {
+	if err := replaySince(logPath, time.Now().Add(-1000*time.Hour), &buf, io.Discard); err != nil {
 		t.Fatal(err)
 	}
 	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
@@ -583,11 +606,20 @@ func TestMalformedStatusFileSkipped(t *testing.T) {
 	}
 
 	h := startWatcher(t, []slotInfo{slot}, parsePhasesFilter(defaultEpicWatchPhases), logPath, 50*time.Millisecond)
-	time.Sleep(200 * time.Millisecond)
 
-	// Now write a valid file: baseline read happens, then a transition.
+	// First valid write establishes a baseline (the malformed read produced
+	// a warning but no baseline). The next write is the milestone.
 	writeStatus(t, slot.statusPath, 1, "coding", "")
-	time.Sleep(150 * time.Millisecond)
+	// Give the poll loop time to read the baseline before triggering a transition.
+	waitFor(t, 2*time.Second, func() bool {
+		// Once we see the baseline write applied, h.stderr should contain
+		// at least one warning from the earlier malformed read.
+		return h.stderr.String() != ""
+	})
+	// Small additional pause so the baseline read tick happens before the
+	// transition write (avoids a race where both writes are observed in the
+	// same poll tick and the malformed-then-completed path skips the baseline).
+	time.Sleep(80 * time.Millisecond)
 	writeStatus(t, slot.statusPath, 1, "completed", "done")
 	waitFor(t, 2*time.Second, func() bool {
 		return len(readLogEvents(t, logPath)) >= 1
@@ -595,8 +627,8 @@ func TestMalformedStatusFileSkipped(t *testing.T) {
 
 	h.stop(t)
 
-	if h.stderr.String() == "" {
-		t.Errorf("expected a parse warning on stderr, got empty")
+	if !strings.Contains(h.stderr.String(), "warning") {
+		t.Errorf("expected a parse warning on stderr, got: %q", h.stderr.String())
 	}
 	if events := readLogEvents(t, logPath); len(events) != 1 {
 		t.Fatalf("expected exactly 1 event after recovery, got %d", len(events))
@@ -613,12 +645,9 @@ func TestStatusFileDeletedDuringWatch(t *testing.T) {
 	h := startWatcher(t, []slotInfo{slot}, parsePhasesFilter(defaultEpicWatchPhases), logPath, 50*time.Millisecond)
 	defer h.stop(t)
 
-	time.Sleep(150 * time.Millisecond)
 	if err := os.Remove(slot.statusPath); err != nil {
 		t.Fatal(err)
 	}
-	time.Sleep(150 * time.Millisecond)
-
 	// Recreate with a milestone phase and verify a transition is emitted.
 	writeStatus(t, slot.statusPath, 1, "completed", "back")
 	waitFor(t, 2*time.Second, func() bool {
@@ -637,22 +666,28 @@ func TestParentDirectoryWatched(t *testing.T) {
 
 	writeStatus(t, slot.statusPath, 1, "coding", "")
 
-	// Use fsnotify (pollInterval=0).
+	// Use fsnotify (pollInterval=0). startWatcher already blocks on ready,
+	// which in fsnotify mode runs after watches are installed.
 	h := startWatcher(t, []slotInfo{slot}, parsePhasesFilter(defaultEpicWatchPhases), logPath, 0)
 	defer h.stop(t)
-
-	time.Sleep(200 * time.Millisecond)
 
 	// Delete and recreate: a watch on the file alone would now be dead.
 	if err := os.Remove(slot.statusPath); err != nil {
 		t.Fatal(err)
 	}
-	time.Sleep(100 * time.Millisecond)
 	writeStatus(t, slot.statusPath, 1, "completed", "back")
 
 	waitFor(t, 3*time.Second, func() bool {
 		return len(readLogEvents(t, logPath)) >= 1
 	})
+	events := readLogEvents(t, logPath)
+	if len(events) != 1 {
+		t.Fatalf("got %d events, want 1: %+v", len(events), events)
+	}
+	got := events[0]
+	if got.Slot != "alpha" || got.NewPhase != "completed" || got.OldPhase == nil || *got.OldPhase != "coding" {
+		t.Errorf("unexpected event content: %+v", got)
+	}
 }
 
 // --- filter and poll ---
@@ -665,8 +700,6 @@ func TestPhasesFlagOverride(t *testing.T) {
 	writeStatus(t, slot.statusPath, 1, "exploring", "")
 	h := startWatcher(t, []slotInfo{slot}, parsePhasesFilter("coding,testing"), logPath, 50*time.Millisecond)
 	defer h.stop(t)
-
-	time.Sleep(150 * time.Millisecond)
 
 	// Transition to coding (in the override list) — should emit.
 	writeStatus(t, slot.statusPath, 1, "coding", "")
@@ -696,12 +729,15 @@ func TestPollFallback(t *testing.T) {
 	h := startWatcher(t, []slotInfo{slot}, parsePhasesFilter(defaultEpicWatchPhases), logPath, 100*time.Millisecond)
 	defer h.stop(t)
 
-	time.Sleep(250 * time.Millisecond)
 	writeStatus(t, slot.statusPath, 1, "completed", "done")
 
 	waitFor(t, 2*time.Second, func() bool {
 		return len(readLogEvents(t, logPath)) >= 1
 	})
+	events := readLogEvents(t, logPath)
+	if len(events) != 1 || events[0].NewPhase != "completed" {
+		t.Fatalf("unexpected events under poll mode: %+v", events)
+	}
 }
 
 func TestSigtermFlushesLog(t *testing.T) {
@@ -714,17 +750,21 @@ func TestSigtermFlushesLog(t *testing.T) {
 
 	writeStatus(t, slot.statusPath, 1, "coding", "")
 	h := startWatcher(t, []slotInfo{slot}, parsePhasesFilter(defaultEpicWatchPhases), logPath, 30*time.Millisecond)
-	time.Sleep(80 * time.Millisecond)
 
-	// Trigger a transition then cancel almost immediately.
+	// Write a transition and confirm at least one event lands BEFORE cancel.
+	// Without this wait, the test would pass trivially on an empty log.
 	writeStatus(t, slot.statusPath, 1, "completed", "rapid shutdown")
-	time.Sleep(60 * time.Millisecond)
+	waitFor(t, 2*time.Second, func() bool {
+		return len(readLogEvents(t, logPath)) >= 1
+	})
+
 	h.stop(t)
 
 	data, err := os.ReadFile(logPath)
 	if err != nil {
 		t.Fatal(err)
 	}
+	parsed := 0
 	for _, line := range strings.Split(strings.TrimRight(string(data), "\n"), "\n") {
 		if line == "" {
 			continue
@@ -733,6 +773,96 @@ func TestSigtermFlushesLog(t *testing.T) {
 		if err := json.Unmarshal([]byte(line), &ev); err != nil {
 			t.Errorf("torn or unparseable line %q: %v", line, err)
 		}
+		parsed++
+	}
+	if parsed == 0 {
+		t.Fatal("no parseable events on disk after shutdown")
+	}
+}
+
+// --- additional spec coverage from review ---
+
+func TestResolveSlotsWorktreeZeroSlots(t *testing.T) {
+	// Worktree mode with no issue-* subdirectories returns zero slots and
+	// no error. The CLI layer (runEpicWatch) is responsible for treating
+	// that as fatal.
+	dir := t.TempDir()
+	cloneRoot := filepath.Join(dir, "workers")
+	if err := os.MkdirAll(cloneRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &epicConfig{CloneRoot: cloneRoot, LocalWorktrees: true}
+	slots, err := resolveSlots(dir, cfg)
+	if err != nil {
+		t.Fatalf("resolveSlots returned error: %v", err)
+	}
+	if len(slots) != 0 {
+		t.Errorf("expected zero slots, got %+v", slots)
+	}
+}
+
+func TestRunWatcherFailsWhenNoFsnotifyAdd(t *testing.T) {
+	// A slot whose parent directory does not exist makes fsnotify Add fail.
+	// With every Add failing, runWatcher must return an error rather than
+	// silently entering an event loop with no watches.
+	dir := t.TempDir()
+	missing := filepath.Join(dir, "does-not-exist", "alpha")
+	slot := slotInfo{name: "alpha", statusPath: filepath.Join(missing, epicStatusName)}
+	logPath := filepath.Join(dir, epicNotificationsName)
+
+	stderr := &syncBuffer{}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	err := runWatcher(ctx, watchConfig{
+		slots:        []slotInfo{slot},
+		phases:       parsePhasesFilter(defaultEpicWatchPhases),
+		pollInterval: 0, // fsnotify mode
+		logPath:      logPath,
+		stdout:       io.Discard,
+		stderr:       stderr,
+	})
+	if err == nil {
+		t.Fatal("expected error when no parent directory could be watched, got nil")
+	}
+	if !strings.Contains(err.Error(), "no parent directories") {
+		t.Errorf("error %q does not mention the unwatched-directory cause", err)
+	}
+}
+
+func TestSeedLastPhasesSkipsCorruptLines(t *testing.T) {
+	// A malformed middle line must NOT silently drop subsequent valid
+	// entries — that would seed stale phase state and cause spurious
+	// re-emissions on watcher restart.
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, epicNotificationsName)
+
+	old := "coding"
+	good1, _ := json.Marshal(epicEvent{
+		Ts: time.Now().UTC().Format(time.RFC3339), Slot: "alpha", Issue: 1,
+		OldPhase: &old, NewPhase: "needs-human", Summary: "first",
+	})
+	good2, _ := json.Marshal(epicEvent{
+		Ts: time.Now().UTC().Format(time.RFC3339), Slot: "beta", Issue: 2,
+		OldPhase: &old, NewPhase: "completed", Summary: "second",
+	})
+	body := string(good1) + "\n{not json\n" + string(good2) + "\n"
+	if err := os.WriteFile(logPath, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	warn := &syncBuffer{}
+	last, err := seedLastPhases(logPath, warn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if last["alpha"] != "needs-human" {
+		t.Errorf("alpha not seeded: %v", last)
+	}
+	if last["beta"] != "completed" {
+		t.Errorf("beta not seeded — corrupt middle line dropped subsequent entries: %v", last)
+	}
+	if !strings.Contains(warn.String(), "warning") {
+		t.Errorf("expected a warning for the corrupt line, got: %q", warn.String())
 	}
 }
 

--- a/cmd/bip/epic_watch_test.go
+++ b/cmd/bip/epic_watch_test.go
@@ -1,0 +1,757 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// --- helpers ---
+
+// statusJSON returns a serialized .epic-status.json body with the given fields.
+func statusJSON(t *testing.T, issue int, phase, summary string) []byte {
+	t.Helper()
+	b, err := json.Marshal(map[string]any{
+		"issue":   issue,
+		"phase":   phase,
+		"summary": summary,
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return b
+}
+
+// writeStatus atomically replaces a slot's .epic-status.json.
+func writeStatus(t *testing.T, path string, issue int, phase, summary string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, statusJSON(t, issue, phase, summary), 0o644); err != nil {
+		t.Fatalf("write tmp: %v", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+}
+
+// readLogEvents parses every JSONL line from .epic-notifications.log.
+func readLogEvents(t *testing.T, logPath string) []epicEvent {
+	t.Helper()
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		t.Fatalf("read log: %v", err)
+	}
+	var out []epicEvent
+	for _, line := range strings.Split(strings.TrimRight(string(data), "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+		var ev epicEvent
+		if err := json.Unmarshal([]byte(line), &ev); err != nil {
+			t.Fatalf("parse log line %q: %v", line, err)
+		}
+		out = append(out, ev)
+	}
+	return out
+}
+
+// stdoutLines returns non-empty lines from a captured stdout buffer.
+func stdoutLines(buf *syncBuffer) []string {
+	raw := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	var out []string
+	for _, l := range raw {
+		if l != "" {
+			out = append(out, l)
+		}
+	}
+	return out
+}
+
+// syncBuffer is a goroutine-safe bytes.Buffer wrapper for capturing watcher output.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (s *syncBuffer) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.Write(p)
+}
+
+func (s *syncBuffer) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.String()
+}
+
+// runWatcherAsync starts runWatcher on a background goroutine and returns a
+// cancel func that stops it cleanly. The watcher uses poll mode by default
+// to avoid fsnotify-related test flakiness; pass pollInterval=0 to use fsnotify.
+type watcherHandle struct {
+	cancel context.CancelFunc
+	done   chan error
+	stdout *syncBuffer
+	stderr *syncBuffer
+}
+
+func startWatcher(t *testing.T, slots []slotInfo, phases map[string]bool, logPath string, pollInterval time.Duration) *watcherHandle {
+	t.Helper()
+	stdout := &syncBuffer{}
+	stderr := &syncBuffer{}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- runWatcher(ctx, watchConfig{
+			slots:        slots,
+			phases:       phases,
+			pollInterval: pollInterval,
+			logPath:      logPath,
+			stdout:       stdout,
+			stderr:       stderr,
+		})
+	}()
+	return &watcherHandle{cancel: cancel, done: done, stdout: stdout, stderr: stderr}
+}
+
+func (h *watcherHandle) stop(t *testing.T) {
+	t.Helper()
+	h.cancel()
+	select {
+	case <-h.done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("watcher did not exit after cancel")
+	}
+}
+
+// waitFor polls until cond returns true or the deadline elapses.
+func waitFor(t *testing.T, timeout time.Duration, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for condition after %v", timeout)
+}
+
+// --- core transition behavior ---
+
+func TestPhaseTransitionEmits(t *testing.T) {
+	dir := t.TempDir()
+	slot := slotInfo{name: "alpha", statusPath: filepath.Join(dir, "alpha", epicStatusName)}
+	logPath := filepath.Join(dir, epicNotificationsName)
+
+	writeStatus(t, slot.statusPath, 42, "coding", "hacking away")
+
+	h := startWatcher(t, []slotInfo{slot}, parsePhasesFilter(defaultEpicWatchPhases), logPath, 50*time.Millisecond)
+	defer h.stop(t)
+
+	// Wait for baseline read to complete.
+	time.Sleep(150 * time.Millisecond)
+
+	writeStatus(t, slot.statusPath, 42, "quality-gate", "PR open")
+
+	waitFor(t, 2*time.Second, func() bool {
+		return len(readLogEvents(t, logPath)) >= 1
+	})
+
+	events := readLogEvents(t, logPath)
+	if len(events) != 1 {
+		t.Fatalf("got %d log events, want 1: %+v", len(events), events)
+	}
+	got := events[0]
+	if got.Slot != "alpha" || got.NewPhase != "quality-gate" || got.OldPhase == nil || *got.OldPhase != "coding" {
+		t.Errorf("unexpected event: %+v", got)
+	}
+	if got.Issue != 42 || got.Summary != "PR open" {
+		t.Errorf("unexpected fields: %+v", got)
+	}
+
+	lines := stdoutLines(h.stdout)
+	if len(lines) != 1 {
+		t.Fatalf("got %d stdout lines, want 1: %v", len(lines), lines)
+	}
+	wantPrefix := "alpha (i42): coding → quality-gate"
+	if !strings.HasPrefix(lines[0], wantPrefix) {
+		t.Errorf("stdout %q does not start with %q", lines[0], wantPrefix)
+	}
+}
+
+func TestFirstReadIsBaselineNoEmit(t *testing.T) {
+	dir := t.TempDir()
+	slot := slotInfo{name: "alpha", statusPath: filepath.Join(dir, "alpha", epicStatusName)}
+	logPath := filepath.Join(dir, epicNotificationsName)
+
+	writeStatus(t, slot.statusPath, 1, "needs-human", "stuck")
+
+	h := startWatcher(t, []slotInfo{slot}, parsePhasesFilter(defaultEpicWatchPhases), logPath, 50*time.Millisecond)
+	time.Sleep(200 * time.Millisecond)
+	h.stop(t)
+
+	if events := readLogEvents(t, logPath); len(events) != 0 {
+		t.Fatalf("expected zero events, got: %+v", events)
+	}
+	if lines := stdoutLines(h.stdout); len(lines) != 0 {
+		t.Fatalf("expected zero stdout lines, got: %v", lines)
+	}
+}
+
+func TestNonMilestoneSuppressed(t *testing.T) {
+	dir := t.TempDir()
+	slot := slotInfo{name: "alpha", statusPath: filepath.Join(dir, "alpha", epicStatusName)}
+	logPath := filepath.Join(dir, epicNotificationsName)
+
+	writeStatus(t, slot.statusPath, 1, "exploring", "looking around")
+
+	h := startWatcher(t, []slotInfo{slot}, parsePhasesFilter(defaultEpicWatchPhases), logPath, 50*time.Millisecond)
+	defer h.stop(t)
+
+	time.Sleep(150 * time.Millisecond)
+	writeStatus(t, slot.statusPath, 1, "coding", "making changes")
+	time.Sleep(250 * time.Millisecond)
+
+	if events := readLogEvents(t, logPath); len(events) != 0 {
+		t.Fatalf("expected zero events for non-milestone transition, got: %+v", events)
+	}
+}
+
+func TestRepeatedWriteSamePhase(t *testing.T) {
+	dir := t.TempDir()
+	slot := slotInfo{name: "alpha", statusPath: filepath.Join(dir, "alpha", epicStatusName)}
+	logPath := filepath.Join(dir, epicNotificationsName)
+
+	writeStatus(t, slot.statusPath, 1, "coding", "v1")
+
+	h := startWatcher(t, []slotInfo{slot}, parsePhasesFilter(defaultEpicWatchPhases), logPath, 50*time.Millisecond)
+	defer h.stop(t)
+
+	time.Sleep(150 * time.Millisecond)
+
+	writeStatus(t, slot.statusPath, 1, "needs-human", "v1")
+	waitFor(t, 2*time.Second, func() bool {
+		return len(readLogEvents(t, logPath)) >= 1
+	})
+
+	writeStatus(t, slot.statusPath, 1, "needs-human", "v2")
+	writeStatus(t, slot.statusPath, 1, "needs-human", "v3")
+	time.Sleep(200 * time.Millisecond)
+
+	if got := len(readLogEvents(t, logPath)); got != 1 {
+		t.Fatalf("expected exactly one transition event, got %d", got)
+	}
+}
+
+// --- log format and persistence ---
+
+func TestLogLineIsValidJSON(t *testing.T) {
+	dir := t.TempDir()
+	slot := slotInfo{name: "alpha", statusPath: filepath.Join(dir, "alpha", epicStatusName)}
+	logPath := filepath.Join(dir, epicNotificationsName)
+
+	writeStatus(t, slot.statusPath, 7, "coding", "")
+
+	h := startWatcher(t, []slotInfo{slot}, parsePhasesFilter(defaultEpicWatchPhases), logPath, 50*time.Millisecond)
+	defer h.stop(t)
+
+	time.Sleep(150 * time.Millisecond)
+	gnarlySummary := "line1\nline2\twith\ttabs\nquoted: \"hello\" — emoji 🎉"
+	writeStatus(t, slot.statusPath, 7, "completed", gnarlySummary)
+	waitFor(t, 2*time.Second, func() bool {
+		return len(readLogEvents(t, logPath)) >= 1
+	})
+
+	events := readLogEvents(t, logPath)
+	if len(events) != 1 {
+		t.Fatalf("got %d events, want 1", len(events))
+	}
+	got := events[0]
+	if _, err := time.Parse(time.RFC3339, got.Ts); err != nil {
+		t.Errorf("ts %q is not RFC3339: %v", got.Ts, err)
+	}
+	if got.Summary != gnarlySummary {
+		t.Errorf("summary did not round-trip: got %q want %q", got.Summary, gnarlySummary)
+	}
+
+	// The stdout line must be a single line: tabs/newlines collapsed.
+	lines := stdoutLines(h.stdout)
+	if len(lines) != 1 {
+		t.Fatalf("expected single stdout line, got %d: %v", len(lines), lines)
+	}
+	if strings.ContainsAny(lines[0], "\t") {
+		t.Errorf("stdout line still contains tab: %q", lines[0])
+	}
+}
+
+func TestNotificationLogPersists(t *testing.T) {
+	dir := t.TempDir()
+	slot := slotInfo{name: "alpha", statusPath: filepath.Join(dir, "alpha", epicStatusName)}
+	logPath := filepath.Join(dir, epicNotificationsName)
+
+	writeStatus(t, slot.statusPath, 1, "coding", "")
+
+	h := startWatcher(t, []slotInfo{slot}, parsePhasesFilter(defaultEpicWatchPhases), logPath, 50*time.Millisecond)
+	time.Sleep(150 * time.Millisecond)
+	writeStatus(t, slot.statusPath, 1, "completed", "done")
+	waitFor(t, 2*time.Second, func() bool {
+		return len(readLogEvents(t, logPath)) >= 1
+	})
+	h.stop(t)
+
+	// After clean shutdown, the file is on disk and parses cleanly.
+	events := readLogEvents(t, logPath)
+	if len(events) != 1 {
+		t.Fatalf("got %d events, want 1", len(events))
+	}
+	if events[0].NewPhase != "completed" {
+		t.Errorf("unexpected phase: %s", events[0].NewPhase)
+	}
+}
+
+func TestStateRecoveryFromLog(t *testing.T) {
+	dir := t.TempDir()
+	slot := slotInfo{name: "alpha", statusPath: filepath.Join(dir, "alpha", epicStatusName)}
+	logPath := filepath.Join(dir, epicNotificationsName)
+
+	// Pre-seed the log with a quality-gate transition for alpha.
+	old := "coding"
+	seed := epicEvent{
+		Ts:       time.Now().UTC().Format(time.RFC3339),
+		Slot:     "alpha",
+		Issue:    99,
+		OldPhase: &old,
+		NewPhase: "quality-gate",
+		Summary:  "from prior watcher run",
+	}
+	b, _ := json.Marshal(seed)
+	if err := os.WriteFile(logPath, append(b, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Status file says the same phase the log already recorded.
+	writeStatus(t, slot.statusPath, 99, "quality-gate", "still here")
+
+	h := startWatcher(t, []slotInfo{slot}, parsePhasesFilter(defaultEpicWatchPhases), logPath, 50*time.Millisecond)
+	time.Sleep(200 * time.Millisecond)
+	h.stop(t)
+
+	events := readLogEvents(t, logPath)
+	if len(events) != 1 {
+		t.Fatalf("expected exactly the seeded event (no new ones), got %d: %+v", len(events), events)
+	}
+}
+
+// --- --since replay ---
+
+func TestSinceFlagReplaysFromLog(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, epicNotificationsName)
+
+	now := time.Now().UTC()
+	mkLine := func(offset time.Duration, phase string) string {
+		old := "coding"
+		ev := epicEvent{
+			Ts:       now.Add(offset).Format(time.RFC3339),
+			Slot:     "alpha",
+			Issue:    1,
+			OldPhase: &old,
+			NewPhase: phase,
+			Summary:  "x",
+		}
+		b, _ := json.Marshal(ev)
+		return string(b) + "\n"
+	}
+	body := mkLine(-2*time.Hour, "needs-human") +
+		mkLine(-30*time.Minute, "quality-gate") +
+		mkLine(-1*time.Minute, "completed")
+	if err := os.WriteFile(logPath, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	cutoff := time.Now().Add(-1 * time.Hour)
+	if err := replaySince(logPath, cutoff, &buf); err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 replayed lines, got %d: %v", len(lines), lines)
+	}
+
+	// Log file is unchanged.
+	after, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != body {
+		t.Errorf("log file was modified by replay")
+	}
+}
+
+func TestSinceBoundaryFuture(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, epicNotificationsName)
+
+	old := "coding"
+	ev := epicEvent{
+		Ts:       time.Now().UTC().Format(time.RFC3339),
+		Slot:     "alpha",
+		Issue:    1,
+		OldPhase: &old,
+		NewPhase: "completed",
+		Summary:  "x",
+	}
+	b, _ := json.Marshal(ev)
+	if err := os.WriteFile(logPath, append(b, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// --since=-1h pushes the cutoff one hour into the future.
+	dur, _ := time.ParseDuration("-1h")
+	cutoff := time.Now().Add(-dur)
+	var buf bytes.Buffer
+	if err := replaySince(logPath, cutoff, &buf); err != nil {
+		t.Fatal(err)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("expected no output for future cutoff, got: %q", buf.String())
+	}
+}
+
+func TestSinceBoundaryAll(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, epicNotificationsName)
+
+	now := time.Now().UTC()
+	var body strings.Builder
+	for i, off := range []time.Duration{-3 * time.Hour, -2 * time.Hour, -1 * time.Hour} {
+		old := "coding"
+		ev := epicEvent{
+			Ts:       now.Add(off).Format(time.RFC3339),
+			Slot:     fmt.Sprintf("slot%d", i),
+			Issue:    i,
+			OldPhase: &old,
+			NewPhase: "completed",
+			Summary:  "x",
+		}
+		b, _ := json.Marshal(ev)
+		body.Write(b)
+		body.WriteByte('\n')
+	}
+	if err := os.WriteFile(logPath, []byte(body.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	if err := replaySince(logPath, time.Now().Add(-1000*time.Hour), &buf); err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 replayed lines, got %d: %v", len(lines), lines)
+	}
+}
+
+// --- config discovery and error handling ---
+
+func TestConfigDiscoveryCloneMode(t *testing.T) {
+	dir := t.TempDir()
+	cfg := map[string]any{
+		"clone_root":  filepath.Join(dir, "clones"),
+		"clone_names": []string{"alpha", "beta"},
+	}
+	cfgBytes, _ := json.Marshal(cfg)
+	if err := os.WriteFile(filepath.Join(dir, epicConfigName), cfgBytes, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	parsed, err := loadEpicConfig(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	slots, err := resolveSlots(dir, parsed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(slots) != 2 {
+		t.Fatalf("expected 2 slots, got %d", len(slots))
+	}
+	wantPaths := map[string]string{
+		"alpha": filepath.Join(dir, "clones", "alpha", epicStatusName),
+		"beta":  filepath.Join(dir, "clones", "beta", epicStatusName),
+	}
+	for _, s := range slots {
+		if want := wantPaths[s.name]; s.statusPath != want {
+			t.Errorf("slot %q path = %q, want %q", s.name, s.statusPath, want)
+		}
+	}
+}
+
+func TestConfigDiscoveryWorktreeMode(t *testing.T) {
+	dir := t.TempDir()
+	cloneRoot := filepath.Join(dir, "workers")
+	for _, sub := range []string{"issue-100", "issue-200", "scratch"} {
+		if err := os.MkdirAll(filepath.Join(cloneRoot, sub), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cfg := map[string]any{
+		"clone_root":      cloneRoot,
+		"local_worktrees": true,
+	}
+	cfgBytes, _ := json.Marshal(cfg)
+	if err := os.WriteFile(filepath.Join(dir, epicConfigName), cfgBytes, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	parsed, err := loadEpicConfig(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	slots, err := resolveSlots(dir, parsed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(slots) != 2 {
+		t.Fatalf("expected 2 issue-* slots, got %d (%+v)", len(slots), slots)
+	}
+	names := map[string]bool{}
+	for _, s := range slots {
+		names[s.name] = true
+	}
+	if !names["issue-100"] || !names["issue-200"] {
+		t.Errorf("expected issue-100 and issue-200, got %+v", names)
+	}
+	if names["scratch"] {
+		t.Errorf("non-issue subdirectory was included")
+	}
+}
+
+func TestMissingConfigFailsFast(t *testing.T) {
+	dir := t.TempDir()
+	_, err := loadEpicConfig(dir)
+	if err == nil {
+		t.Fatal("expected error for missing config, got nil")
+	}
+	if !strings.Contains(err.Error(), epicConfigName) {
+		t.Errorf("error %q does not name %q", err, epicConfigName)
+	}
+}
+
+func TestMutuallyExclusiveModes(t *testing.T) {
+	dir := t.TempDir()
+	cfg := map[string]any{
+		"clone_root":      "/tmp",
+		"clone_names":     []string{"a"},
+		"local_worktrees": true,
+	}
+	b, _ := json.Marshal(cfg)
+	if err := os.WriteFile(filepath.Join(dir, epicConfigName), b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadEpicConfig(dir); err == nil {
+		t.Fatal("expected error for clone_names + local_worktrees, got nil")
+	}
+}
+
+func TestMalformedStatusFileSkipped(t *testing.T) {
+	dir := t.TempDir()
+	slot := slotInfo{name: "alpha", statusPath: filepath.Join(dir, "alpha", epicStatusName)}
+	logPath := filepath.Join(dir, epicNotificationsName)
+
+	if err := os.MkdirAll(filepath.Dir(slot.statusPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(slot.statusPath, []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	h := startWatcher(t, []slotInfo{slot}, parsePhasesFilter(defaultEpicWatchPhases), logPath, 50*time.Millisecond)
+	time.Sleep(200 * time.Millisecond)
+
+	// Now write a valid file: baseline read happens, then a transition.
+	writeStatus(t, slot.statusPath, 1, "coding", "")
+	time.Sleep(150 * time.Millisecond)
+	writeStatus(t, slot.statusPath, 1, "completed", "done")
+	waitFor(t, 2*time.Second, func() bool {
+		return len(readLogEvents(t, logPath)) >= 1
+	})
+
+	h.stop(t)
+
+	if h.stderr.String() == "" {
+		t.Errorf("expected a parse warning on stderr, got empty")
+	}
+	if events := readLogEvents(t, logPath); len(events) != 1 {
+		t.Fatalf("expected exactly 1 event after recovery, got %d", len(events))
+	}
+}
+
+func TestStatusFileDeletedDuringWatch(t *testing.T) {
+	dir := t.TempDir()
+	slot := slotInfo{name: "alpha", statusPath: filepath.Join(dir, "alpha", epicStatusName)}
+	logPath := filepath.Join(dir, epicNotificationsName)
+
+	writeStatus(t, slot.statusPath, 1, "coding", "")
+
+	h := startWatcher(t, []slotInfo{slot}, parsePhasesFilter(defaultEpicWatchPhases), logPath, 50*time.Millisecond)
+	defer h.stop(t)
+
+	time.Sleep(150 * time.Millisecond)
+	if err := os.Remove(slot.statusPath); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(150 * time.Millisecond)
+
+	// Recreate with a milestone phase and verify a transition is emitted.
+	writeStatus(t, slot.statusPath, 1, "completed", "back")
+	waitFor(t, 2*time.Second, func() bool {
+		return len(readLogEvents(t, logPath)) >= 1
+	})
+	events := readLogEvents(t, logPath)
+	if len(events) != 1 || events[0].NewPhase != "completed" {
+		t.Fatalf("unexpected events after recreate: %+v", events)
+	}
+}
+
+func TestParentDirectoryWatched(t *testing.T) {
+	dir := t.TempDir()
+	slot := slotInfo{name: "alpha", statusPath: filepath.Join(dir, "alpha", epicStatusName)}
+	logPath := filepath.Join(dir, epicNotificationsName)
+
+	writeStatus(t, slot.statusPath, 1, "coding", "")
+
+	// Use fsnotify (pollInterval=0).
+	h := startWatcher(t, []slotInfo{slot}, parsePhasesFilter(defaultEpicWatchPhases), logPath, 0)
+	defer h.stop(t)
+
+	time.Sleep(200 * time.Millisecond)
+
+	// Delete and recreate: a watch on the file alone would now be dead.
+	if err := os.Remove(slot.statusPath); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(100 * time.Millisecond)
+	writeStatus(t, slot.statusPath, 1, "completed", "back")
+
+	waitFor(t, 3*time.Second, func() bool {
+		return len(readLogEvents(t, logPath)) >= 1
+	})
+}
+
+// --- filter and poll ---
+
+func TestPhasesFlagOverride(t *testing.T) {
+	dir := t.TempDir()
+	slot := slotInfo{name: "alpha", statusPath: filepath.Join(dir, "alpha", epicStatusName)}
+	logPath := filepath.Join(dir, epicNotificationsName)
+
+	writeStatus(t, slot.statusPath, 1, "exploring", "")
+	h := startWatcher(t, []slotInfo{slot}, parsePhasesFilter("coding,testing"), logPath, 50*time.Millisecond)
+	defer h.stop(t)
+
+	time.Sleep(150 * time.Millisecond)
+
+	// Transition to coding (in the override list) — should emit.
+	writeStatus(t, slot.statusPath, 1, "coding", "")
+	waitFor(t, 2*time.Second, func() bool {
+		return len(readLogEvents(t, logPath)) >= 1
+	})
+
+	// Transition to needs-human (NOT in the override list) — should NOT emit.
+	writeStatus(t, slot.statusPath, 1, "needs-human", "")
+	time.Sleep(250 * time.Millisecond)
+
+	events := readLogEvents(t, logPath)
+	if len(events) != 1 {
+		t.Fatalf("expected exactly 1 event (coding only), got %d: %+v", len(events), events)
+	}
+	if events[0].NewPhase != "coding" {
+		t.Errorf("unexpected event phase: %s", events[0].NewPhase)
+	}
+}
+
+func TestPollFallback(t *testing.T) {
+	dir := t.TempDir()
+	slot := slotInfo{name: "alpha", statusPath: filepath.Join(dir, "alpha", epicStatusName)}
+	logPath := filepath.Join(dir, epicNotificationsName)
+
+	writeStatus(t, slot.statusPath, 1, "coding", "")
+	h := startWatcher(t, []slotInfo{slot}, parsePhasesFilter(defaultEpicWatchPhases), logPath, 100*time.Millisecond)
+	defer h.stop(t)
+
+	time.Sleep(250 * time.Millisecond)
+	writeStatus(t, slot.statusPath, 1, "completed", "done")
+
+	waitFor(t, 2*time.Second, func() bool {
+		return len(readLogEvents(t, logPath)) >= 1
+	})
+}
+
+func TestSigtermFlushesLog(t *testing.T) {
+	// We can't actually send SIGTERM to the test process. Instead, simulate
+	// the same path: cancel the context mid-stream and confirm the log file
+	// has no torn lines and parses cleanly.
+	dir := t.TempDir()
+	slot := slotInfo{name: "alpha", statusPath: filepath.Join(dir, "alpha", epicStatusName)}
+	logPath := filepath.Join(dir, epicNotificationsName)
+
+	writeStatus(t, slot.statusPath, 1, "coding", "")
+	h := startWatcher(t, []slotInfo{slot}, parsePhasesFilter(defaultEpicWatchPhases), logPath, 30*time.Millisecond)
+	time.Sleep(80 * time.Millisecond)
+
+	// Trigger a transition then cancel almost immediately.
+	writeStatus(t, slot.statusPath, 1, "completed", "rapid shutdown")
+	time.Sleep(60 * time.Millisecond)
+	h.stop(t)
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, line := range strings.Split(strings.TrimRight(string(data), "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+		var ev epicEvent
+		if err := json.Unmarshal([]byte(line), &ev); err != nil {
+			t.Errorf("torn or unparseable line %q: %v", line, err)
+		}
+	}
+}
+
+// --- formatting helpers ---
+
+func TestFormatEventLineCollapsesWhitespace(t *testing.T) {
+	old := "coding"
+	ev := epicEvent{
+		Slot:     "alpha",
+		Issue:    1,
+		OldPhase: &old,
+		NewPhase: "completed",
+		Summary:  "line1\nline2\twith\ttabs",
+	}
+	got := formatEventLine(ev)
+	if strings.ContainsAny(got, "\n\t") {
+		t.Errorf("output still contains tab/newline: %q", got)
+	}
+}
+
+// Ensure io.Writer interface compliance for syncBuffer at compile time.
+var _ io.Writer = (*syncBuffer)(nil)

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 
 require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
+	github.com/fsnotify/fsnotify v1.10.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
+github.com/fsnotify/fsnotify v1.10.0 h1:Xx/5Ydg9CeBDX/wi4VJqStNtohYjitZhhlHt4h3St1M=
+github.com/fsnotify/fsnotify v1.10.0/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17kjQEVQ1XRhq2/JR1M3sGqeJoxs=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=

--- a/skills/bip.epic.poll/SKILL.md
+++ b/skills/bip.epic.poll/SKILL.md
@@ -9,12 +9,14 @@ Lightweight mid-session update. Checks what changed on GitHub and in
 active clones since last check. Use this instead of `/bip.epic` when
 you already have context established.
 
-For continuous monitoring, prefer the **persistent slot monitor**
-started by `/bip.epic` (Step 8) — it uses `fswatch` to stream phase
-changes in real time. Use `/bip.epic.poll` for:
+For continuous monitoring, prefer `bip epic watch` (started by
+`/bip.epic` Step 8). It writes phase transitions to
+`.epic-notifications.log` in the conductor cwd; this poll skill reads
+new entries from that log to catch transitions the conductor may have
+missed. Use `/bip.epic.poll` for:
 - Full GitHub reconciliation (merged PRs, new issues, comments)
 - Slot cleanup and EPIC body updates
-- When the slot monitor isn't running
+- Catching up on log entries written while the conductor was idle
 
 For periodic auto-polling: `/loop 10m /bip.epic.poll`
 
@@ -82,6 +84,26 @@ For active slots, check recent commits:
 git -C <slot-path> log --oneline main..HEAD | head -5
 ```
 In worktree mode, `<slot-path>` is `$CLONE_ROOT/issue-<N>`.
+
+#### Notifications log tail
+
+If `bip epic watch` is running, it appends one JSONL line per phase
+transition to `.epic-notifications.log` in the conductor cwd. Read any
+entries that landed since the last poll so the conductor catches
+transitions even when both the watcher and Monitor were down. The
+state file `/tmp/.epic-poll-last-read` records the previous poll time
+as Unix seconds; pass the elapsed window to `--since`:
+
+```bash
+LAST=$(cat /tmp/.epic-poll-last-read 2>/dev/null || echo $(($(date +%s) - 3600)))
+NOW=$(date +%s)
+bip epic watch --since "$((NOW - LAST))s" 2>/dev/null
+echo "$NOW" > /tmp/.epic-poll-last-read
+```
+
+`--since` reads the log and replays matching entries to stdout without
+re-appending them. Surface any `needs-human` / `completed` transitions
+prominently per the section below.
 
 #### New status fields to display
 

--- a/skills/bip.epic.spawn/SKILL.md
+++ b/skills/bip.epic.spawn/SKILL.md
@@ -444,9 +444,12 @@ Target project repos should gitignore these files (add to `.gitignore`):
 ```
 .epic-status.json
 .epic-worklog.md
+.epic-notifications.log
 ```
 
-These files live in clones, not in bipartite itself.
+`.epic-status.json` and `.epic-worklog.md` live in each clone/worktree.
+`.epic-notifications.log` lives in the conductor cwd and is written by
+`bip epic watch`. None should be checked in.
 
 ## Conventions
 

--- a/skills/bip.epic/SKILL.md
+++ b/skills/bip.epic/SKILL.md
@@ -238,52 +238,42 @@ Wait for user confirmation, then run `/bip.epic.spawn` (do NOT improvise tmux/cl
 ### Step 8: Start slot monitor
 
 After the dashboard is built and any spawns are launched, offer to start
-a **persistent Monitor** that watches `.epic-status.json` across all
-active slots. This replaces `/loop 10m /bip.epic.poll` for the most
+the **persistent slot monitor** — `bip epic watch` — which observes
+every slot's `.epic-status.json` and writes phase-transition events to
+`.epic-notifications.log` (JSONL) in the conductor cwd. The log is the
+canonical record; transitions survive watcher restarts and conductor
+compaction. This replaces `/loop 10m /bip.epic.poll` for the most
 time-sensitive signals (phase transitions), while `/bip.epic.poll`
 remains available for full GitHub + slot reconciliation sweeps.
 
-Use the Monitor tool with `persistent: true`:
+Start the watcher in the background:
 
-```
-description: "EPIC slot phase changes"
-persistent: true
-command: |
-  CLONE_ROOT=$(jq -r .clone_root .epic-config.json)
-  LOCAL_WT=$(jq -r '.local_worktrees // false' .epic-config.json)
-  touch /tmp/.epic-monitor-baseline
-
-  if [ "$LOCAL_WT" = "true" ]; then
-    WATCH_DIR="$CLONE_ROOT"
-  else
-    WATCH_DIR="$CLONE_ROOT"
-  fi
-
-  fswatch --batch-marker=EOF -r "$WATCH_DIR" --include '.epic-status.json' --exclude '.*' | \
-    while read line; do
-      if [ "$line" = "EOF" ]; then
-        find "$WATCH_DIR" -name '.epic-status.json' -newer /tmp/.epic-monitor-baseline \
-          -exec sh -c '
-            SLOT=$(basename "$(dirname "$1")")
-            PHASE=$(jq -r .phase "$1" 2>/dev/null)
-            SUMMARY=$(jq -r .summary "$1" 2>/dev/null)
-            ISSUE=$(jq -r .issue "$1" 2>/dev/null)
-            echo "$SLOT (i$ISSUE): $PHASE — $SUMMARY"
-          ' _ {} \;
-        touch /tmp/.epic-monitor-baseline
-      fi
-    done
+```bash
+nohup bip epic watch >/dev/null 2>&1 &
 ```
 
-When a notification arrives showing `needs-human` or `completed`, the
+The watcher runs forever, exits cleanly on SIGTERM, and emits one event
+per real phase transition (default filter: `needs-human`, `completed`,
+`awaiting-results`, `quality-gate`). To also receive events as Claude
+Code notifications when that pipeline is reliable, additionally start a
+Monitor with `command: tail -F .epic-notifications.log` and
+`persistent: true`. The notifications log is the contract; Monitor is a
+latency optimization, not a correctness requirement.
+
+When a transition arrives showing `needs-human` or `completed`, the
 conductor should react immediately — read the slot's status, check the
 lead guidance, and either propose the next action or flag it for the user.
 
-> "Slot monitor started — you'll see phase changes as they happen.
-> Use `/bip.epic.poll` for a full reconciliation sweep when needed."
+> "Slot monitor started — phase transitions are streaming to
+> `.epic-notifications.log`. Use `/bip.epic.poll` for a full
+> reconciliation sweep when needed."
 
-**Prerequisites**: Requires `fswatch` (`brew install fswatch` on macOS).
-If not available, fall back to `/loop 10m /bip.epic.poll`.
+On NFS-mounted clone roots where inotify does not fire on remote writes,
+pass `--poll` (defaults to a 2 s stat-loop) instead of fsnotify:
+
+```bash
+nohup bip epic watch --poll >/dev/null 2>&1 &
+```
 
 ## EPIC body update pattern
 


### PR DESCRIPTION
🤖

Closes #136.

## Summary

- New `bip epic watch` Go subcommand replaces the macOS-only `fswatch` shell pipeline in `/bip.epic` Step 8 with a Linux-friendly fsnotify watcher (with `--poll` fallback for NFS clone roots).
- Watcher reads `.epic-config.json`, resolves slots in clone or worktree mode, and emits **only true phase transitions** (default filter: `needs-human`, `completed`, `awaiting-results`, `quality-gate`). Suppresses spurious wake-ups from worker writes that don't change `phase`.
- Two-channel delivery, file canonical: appends one JSONL line per event to `.epic-notifications.log` (durable, survives watcher restarts and Monitor flakiness) **and** mirrors a single human-readable line to stdout. Reading the log is sufficient — Monitor is a latency optimization, not a correctness requirement.
- `--since=DURATION` replays log entries newer than the cutoff to stdout (never re-appends), letting `/bip.epic.poll` catch transitions a previous watcher logged.
- State recovery: seeds `last_phase[slot]` from the most recent log entry per slot before activating the watcher.
- First read of any slot's status records the phase as baseline (no spurious "transition" event on startup against pre-existing files).

## Architecture

- `cmd/bip/epic.go` — parent `epic` Cobra command; registers itself in `init()`.
- `cmd/bip/epic_watch.go` — `epic watch` subcommand. Pure Go; the only new dep is `github.com/fsnotify/fsnotify` (no CGO).
- Watches the **parent directory** of each slot, not the file (so it survives status-file delete/recreate).

## Skill doc updates (same PR)

- `skills/bip.epic/SKILL.md` Step 8: replaces fswatch pipeline with `nohup bip epic watch >/dev/null 2>&1 &`. Drops `brew install fswatch` prerequisite. Adds `--poll` note for NFS.
- `skills/bip.epic.poll/SKILL.md`: rewrites the "persistent slot monitor" paragraph to point at `bip epic watch` + the notifications log. Adds a sub-step under Step 5 that replays new log entries via `bip epic watch --since` since the last poll.
- `skills/bip.epic.spawn/SKILL.md`: adds `.epic-notifications.log` to the gitignore reminder.

## Test plan

20 unit tests in `cmd/bip/epic_watch_test.go` cover all behaviors from the issue's test plan:

- Core transitions: emit on milestone change, suppress on non-milestone, suppress on baseline, suppress on repeated same-phase writes.
- Log format & persistence: JSONL is valid, RFC3339 ts, gnarly summaries (newlines, tabs, quotes, emoji) round-trip, log persists through clean shutdown, state recovery from log on restart.
- `--since` replay: replays correct slice, future cutoff returns nothing, large cutoff replays everything, log file is unchanged.
- Config discovery: clone mode, worktree mode, missing config error, mutually exclusive modes, malformed status file is logged and watcher continues, status file delete/recreate works (parent-dir watch).
- Filter & poll: `--phases` override works, `--poll=100ms` mode emits transitions without fsnotify, simulated SIGTERM produces no torn lines.

`go test ./...`, `go vet ./...`, `gofmt -l` all clean.

### Manual smoke test

End-to-end test in a tmpdir with two clones (`alpha`, `beta`) and atomic-write status updates:

```
$ /Users/matsen/re/bipartite/bip epic watch &
alpha (i42): coding → completed — PR merged       # milestone, emitted
beta (i7): coding → needs-human — stuck on api design   # milestone, emitted
                                                  # exploring → coding suppressed (non-milestone)
$ cat .epic-notifications.log
{"ts":"2026-05-02T12:59:10Z","slot":"alpha","issue":42,"old_phase":"coding","new_phase":"completed","summary":"PR merged"}
{"ts":"2026-05-02T12:59:10Z","slot":"beta","issue":7,"old_phase":"coding","new_phase":"needs-human","summary":"stuck on api design"}
$ /Users/matsen/re/bipartite/bip epic watch --since 1h
alpha (i42): coding → completed — PR merged
beta (i7): coding → needs-human — stuck on api design
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)