### PR TITLE
Fall back instead of skip on missing Paperpile fields (#138)

### DIFF
--- a/cmd/bip/import.go
+++ b/cmd/bip/import.go
@@ -14,11 +14,13 @@ import (
 var (
 	importFormat string
 	importDryRun bool
+	importStrict bool
 )
 
 func init() {
 	importCmd.Flags().StringVar(&importFormat, "format", "", "Import format (paperpile)")
 	importCmd.Flags().BoolVar(&importDryRun, "dry-run", false, "Show what would be imported without writing")
+	importCmd.Flags().BoolVar(&importStrict, "strict", false, "Drop entries with missing required fields (title, author, year) instead of filling sentinels")
 	importCmd.MarkFlagRequired("format")
 	rootCmd.AddCommand(importCmd)
 }
@@ -40,18 +42,20 @@ Supported formats:
 
 // ImportResult represents the result of an import operation.
 type ImportResult struct {
-	New     int      `json:"new"`
-	Updated int      `json:"updated"`
-	Skipped int      `json:"skipped"`
-	Errors  []string `json:"errors"`
+	New      int                      `json:"new"`
+	Updated  int                      `json:"updated"`
+	Skipped  int                      `json:"skipped"`
+	Warnings []importer.ImportWarning `json:"warnings,omitempty"`
+	Errors   []string                 `json:"errors"`
 }
 
 // DryRunResult represents the result of a dry-run import.
 type DryRunResult struct {
-	WouldAdd    int            `json:"would_add"`
-	WouldUpdate int            `json:"would_update"`
-	WouldSkip   int            `json:"would_skip"`
-	Details     []ImportDetail `json:"details,omitempty"`
+	WouldAdd    int                      `json:"would_add"`
+	WouldUpdate int                      `json:"would_update"`
+	WouldSkip   int                      `json:"would_skip"`
+	Warnings    []importer.ImportWarning `json:"warnings,omitempty"`
+	Details     []ImportDetail           `json:"details,omitempty"`
 }
 
 // ImportDetail describes a single import action.
@@ -78,7 +82,7 @@ func runImport(cmd *cobra.Command, args []string) error {
 	}
 
 	// Parse input file
-	newRefs, parseErrors := parseImportFile(args[0])
+	newRefs, warnings, parseErrors := parseImportFile(args[0])
 
 	// Load existing references
 	refsPath := config.RefsPath(repoRoot)
@@ -96,7 +100,7 @@ func runImport(cmd *cobra.Command, args []string) error {
 
 	// Report results (dry-run or actual)
 	if importDryRun {
-		reportDryRun(stats, details, errStrs)
+		reportDryRun(stats, details, warnings, errStrs)
 		return nil
 	}
 
@@ -105,23 +109,23 @@ func runImport(cmd *cobra.Command, args []string) error {
 		exitWithError(ExitError, "writing refs: %v", err)
 	}
 
-	reportImportResults(stats, errStrs)
+	reportImportResults(stats, warnings, errStrs)
 	return nil
 }
 
 // parseImportFile reads and parses the import file.
-func parseImportFile(path string) ([]reference.Reference, []error) {
+func parseImportFile(path string) ([]reference.Reference, []importer.ImportWarning, []error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		exitWithError(ExitError, "reading file: %v", err)
 	}
 
-	newRefs, parseErrors := importer.ParsePaperpile(data)
+	newRefs, warnings, parseErrors := importer.ParsePaperpile(data, importStrict)
 	if len(parseErrors) > 0 && len(newRefs) == 0 {
 		exitWithError(ExitDataError, "failed to parse any references: %v", parseErrors[0])
 	}
 
-	return newRefs, parseErrors
+	return newRefs, warnings, parseErrors
 }
 
 // processImports classifies each reference and builds the action list.
@@ -182,12 +186,13 @@ func errorsToStrings(errs []error) []string {
 }
 
 // reportDryRun outputs the dry-run results.
-func reportDryRun(stats importStats, details []ImportDetail, errStrs []string) {
+func reportDryRun(stats importStats, details []ImportDetail, warnings []importer.ImportWarning, errStrs []string) {
 	if humanOutput {
 		fmt.Println("Dry run - would import from Paperpile export...")
 		fmt.Printf("  Would add:    %d new references\n", stats.newCount)
 		fmt.Printf("  Would update: %d existing references (matched by DOI or ID)\n", stats.updated)
 		fmt.Printf("  Would skip:   %d (errors or duplicates)\n", stats.skipped)
+		printWarnings(warnings)
 		if len(errStrs) > 0 {
 			fmt.Println("\nParse errors:")
 			for _, e := range errStrs {
@@ -195,22 +200,27 @@ func reportDryRun(stats importStats, details []ImportDetail, errStrs []string) {
 			}
 		}
 	} else {
+		// Emit warnings to stderr even in JSON mode so the user sees them at
+		// the terminal. The JSON output also carries them for programmatic use.
+		printWarnings(warnings)
 		outputJSON(DryRunResult{
 			WouldAdd:    stats.newCount,
 			WouldUpdate: stats.updated,
 			WouldSkip:   stats.skipped,
+			Warnings:    warnings,
 			Details:     details,
 		})
 	}
 }
 
 // reportImportResults outputs the actual import results.
-func reportImportResults(stats importStats, errStrs []string) {
+func reportImportResults(stats importStats, warnings []importer.ImportWarning, errStrs []string) {
 	if humanOutput {
 		fmt.Println("Imported from Paperpile export:")
 		fmt.Printf("  Added:   %d new references\n", stats.newCount)
 		fmt.Printf("  Updated: %d existing references (matched by DOI or ID)\n", stats.updated)
 		fmt.Printf("  Skipped: %d (errors or duplicates)\n", stats.skipped)
+		printWarnings(warnings)
 		if len(errStrs) > 0 {
 			fmt.Println("\nErrors:")
 			for _, e := range errStrs {
@@ -222,12 +232,27 @@ func reportImportResults(stats importStats, errStrs []string) {
 			fmt.Println("\nRun 'bip rebuild' to update the search index.")
 		}
 	} else {
+		printWarnings(warnings)
 		outputJSON(ImportResult{
-			New:     stats.newCount,
-			Updated: stats.updated,
-			Skipped: stats.skipped,
-			Errors:  errStrs,
+			New:      stats.newCount,
+			Updated:  stats.updated,
+			Skipped:  stats.skipped,
+			Warnings: warnings,
+			Errors:   errStrs,
 		})
+	}
+}
+
+// printWarnings writes a human-readable summary of fallback warnings to stderr.
+// Stderr is used so the warnings are visible even when stdout is consumed by
+// `jq` or similar; they're surfaced in both human and JSON modes.
+func printWarnings(warnings []importer.ImportWarning) {
+	if len(warnings) == 0 {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "\nImported %d entries with missing fields filled in (use --strict to drop them instead):\n", len(warnings))
+	for _, w := range warnings {
+		fmt.Fprintf(os.Stderr, "  - %s\n", w.String())
 	}
 }
 

--- a/cmd/bip/import.go
+++ b/cmd/bip/import.go
@@ -55,6 +55,7 @@ type DryRunResult struct {
 	WouldUpdate int                      `json:"would_update"`
 	WouldSkip   int                      `json:"would_skip"`
 	Warnings    []importer.ImportWarning `json:"warnings,omitempty"`
+	Errors      []string                 `json:"errors"`
 	Details     []ImportDetail           `json:"details,omitempty"`
 }
 
@@ -225,6 +226,7 @@ func reportDryRun(stats importStats, details []ImportDetail, warnings []importer
 			WouldUpdate: stats.updated,
 			WouldSkip:   stats.skipped,
 			Warnings:    warnings,
+			Errors:      errStrs,
 			Details:     details,
 		})
 	}

--- a/cmd/bip/import.go
+++ b/cmd/bip/import.go
@@ -113,6 +113,23 @@ func runImport(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+// printWarnings writes a human-readable summary of fallback warnings to stderr.
+// Stderr is used so the warnings are visible even when stdout is consumed by
+// `jq` or similar; they're surfaced in both human and JSON modes.
+func printWarnings(warnings []importer.ImportWarning, dryRun bool) {
+	if len(warnings) == 0 {
+		return
+	}
+	verb := "Imported"
+	if dryRun {
+		verb = "Would import"
+	}
+	fmt.Fprintf(os.Stderr, "\n%s %d entries with missing fields filled in (use --strict to drop them instead):\n", verb, len(warnings))
+	for _, w := range warnings {
+		fmt.Fprintf(os.Stderr, "  - %s\n", w.String())
+	}
+}
+
 // parseImportFile reads and parses the import file.
 func parseImportFile(path string) ([]reference.Reference, []importer.ImportWarning, []error) {
 	data, err := os.ReadFile(path)
@@ -192,7 +209,7 @@ func reportDryRun(stats importStats, details []ImportDetail, warnings []importer
 		fmt.Printf("  Would add:    %d new references\n", stats.newCount)
 		fmt.Printf("  Would update: %d existing references (matched by DOI or ID)\n", stats.updated)
 		fmt.Printf("  Would skip:   %d (errors or duplicates)\n", stats.skipped)
-		printWarnings(warnings)
+		printWarnings(warnings, true)
 		if len(errStrs) > 0 {
 			fmt.Println("\nParse errors:")
 			for _, e := range errStrs {
@@ -202,7 +219,7 @@ func reportDryRun(stats importStats, details []ImportDetail, warnings []importer
 	} else {
 		// Emit warnings to stderr even in JSON mode so the user sees them at
 		// the terminal. The JSON output also carries them for programmatic use.
-		printWarnings(warnings)
+		printWarnings(warnings, true)
 		outputJSON(DryRunResult{
 			WouldAdd:    stats.newCount,
 			WouldUpdate: stats.updated,
@@ -220,7 +237,7 @@ func reportImportResults(stats importStats, warnings []importer.ImportWarning, e
 		fmt.Printf("  Added:   %d new references\n", stats.newCount)
 		fmt.Printf("  Updated: %d existing references (matched by DOI or ID)\n", stats.updated)
 		fmt.Printf("  Skipped: %d (errors or duplicates)\n", stats.skipped)
-		printWarnings(warnings)
+		printWarnings(warnings, false)
 		if len(errStrs) > 0 {
 			fmt.Println("\nErrors:")
 			for _, e := range errStrs {
@@ -232,7 +249,7 @@ func reportImportResults(stats importStats, warnings []importer.ImportWarning, e
 			fmt.Println("\nRun 'bip rebuild' to update the search index.")
 		}
 	} else {
-		printWarnings(warnings)
+		printWarnings(warnings, false)
 		outputJSON(ImportResult{
 			New:      stats.newCount,
 			Updated:  stats.updated,
@@ -240,19 +257,6 @@ func reportImportResults(stats importStats, warnings []importer.ImportWarning, e
 			Warnings: warnings,
 			Errors:   errStrs,
 		})
-	}
-}
-
-// printWarnings writes a human-readable summary of fallback warnings to stderr.
-// Stderr is used so the warnings are visible even when stdout is consumed by
-// `jq` or similar; they're surfaced in both human and JSON modes.
-func printWarnings(warnings []importer.ImportWarning) {
-	if len(warnings) == 0 {
-		return
-	}
-	fmt.Fprintf(os.Stderr, "\nImported %d entries with missing fields filled in (use --strict to drop them instead):\n", len(warnings))
-	for _, w := range warnings {
-		fmt.Fprintf(os.Stderr, "  - %s\n", w.String())
 	}
 }
 

--- a/docs/guides/reference-management.md
+++ b/docs/guides/reference-management.md
@@ -14,6 +14,8 @@ bip rebuild
 
 Paperpile import preserves the `notes` field from your Paperpile library. Notes appear in `bip get` output and are searchable via `bip search`.
 
+By default, entries missing required fields (`title`, `author`, `published.year`) are imported with sentinel placeholders (`[no title]`, `Unknown`, year `0`) and surfaced under `warnings` in the import output, so eLife reviewed preprints and similar entries with incomplete metadata aren't silently dropped. Entries with none of `{title, author, year, doi}` are still skipped to avoid importing Paperpile's web-page auto-stubs. Pass `--strict` to drop any entry with a missing required field instead.
+
 `bip rebuild` builds the SQLite query index from the JSONL source files. Run it after pulling changes or if the database gets corrupted.
 
 ## Searching

--- a/internal/importer/paperpile.go
+++ b/internal/importer/paperpile.go
@@ -77,12 +77,15 @@ type PaperpileEntry struct {
 
 // ImportWarning describes a non-fatal issue with an imported entry.
 // In lenient mode, missing required fields are filled with sentinels and a
-// warning is recorded so the user can see what was defaulted.
+// warning is recorded so the user can see what was defaulted. ID is the
+// imported reference's ID (citekey when present, otherwise Paperpile _id);
+// Title carries the post-fallback title for human identification; Fields
+// names the required fields that hit fallbacks.
 type ImportWarning struct {
-	ID      string   `json:"id"`      // bip ID assigned to the imported reference
-	Citekey string   `json:"citekey"` // Paperpile citekey (may equal ID)
-	Title   string   `json:"title"`   // Title (post-fallback) for human identification
-	Fields  []string `json:"fields"`  // Names of required fields that hit fallbacks
+	ID      string   `json:"id"`
+	Citekey string   `json:"citekey"`
+	Title   string   `json:"title"`
+	Fields  []string `json:"fields"`
 }
 
 // String renders an ImportWarning for human-readable output.
@@ -94,12 +97,17 @@ func (w ImportWarning) String() string {
 	return fmt.Sprintf("entry %s (%q): defaulted %v", w.ID, title, w.Fields)
 }
 
-// Sentinel values used when a required field is missing in lenient mode.
-const (
-	UnknownYear   = 0            // PublicationDate.Year sentinel for "year unknown"
-	UnknownAuthor = "Unknown"    // Author.Last sentinel for "author unknown"
-	UnknownTitle  = "[no title]" // Title sentinel for "title unknown"
-)
+// UnknownYear is the PublicationDate.Year sentinel stored when published.year
+// is missing in lenient mode.
+const UnknownYear = 0
+
+// UnknownAuthor is the Author.Last sentinel stored when no authors are present
+// in lenient mode.
+const UnknownAuthor = "Unknown"
+
+// UnknownTitle is the Title sentinel stored when title is missing in lenient
+// mode.
+const UnknownTitle = "[no title]"
 
 // ParsePaperpile parses a Paperpile JSON export and returns references.
 //

--- a/internal/importer/paperpile.go
+++ b/internal/importer/paperpile.go
@@ -75,55 +75,122 @@ type PaperpileEntry struct {
 	FoldersNamed []string `json:"foldersNamed"`
 }
 
+// ImportWarning describes a non-fatal issue with an imported entry.
+// In lenient mode, missing required fields are filled with sentinels and a
+// warning is recorded so the user can see what was defaulted.
+type ImportWarning struct {
+	ID      string   `json:"id"`      // bip ID assigned to the imported reference
+	Citekey string   `json:"citekey"` // Paperpile citekey (may equal ID)
+	Title   string   `json:"title"`   // Title (post-fallback) for human identification
+	Fields  []string `json:"fields"`  // Names of required fields that hit fallbacks
+}
+
+// String renders an ImportWarning for human-readable output.
+func (w ImportWarning) String() string {
+	title := w.Title
+	if len(title) > 60 {
+		title = title[:57] + "..."
+	}
+	return fmt.Sprintf("entry %s (%q): defaulted %v", w.ID, title, w.Fields)
+}
+
+// Sentinel values used when a required field is missing in lenient mode.
+const (
+	UnknownYear   = 0            // PublicationDate.Year sentinel for "year unknown"
+	UnknownAuthor = "Unknown"    // Author.Last sentinel for "author unknown"
+	UnknownTitle  = "[no title]" // Title sentinel for "title unknown"
+)
+
 // ParsePaperpile parses a Paperpile JSON export and returns references.
-func ParsePaperpile(data []byte) ([]reference.Reference, []error) {
+//
+// When strict is true, entries missing any of {title, author, published.year}
+// are dropped and reported in errs. When strict is false, those entries are
+// imported with sentinel values and reported in warnings instead — except for
+// "junk" entries with no useful metadata at all (no title, author, year, or
+// DOI), which are still dropped to avoid flooding the nexus with placeholders.
+func ParsePaperpile(data []byte, strict bool) (refs []reference.Reference, warnings []ImportWarning, errs []error) {
 	var entries []PaperpileEntry
 	if err := json.Unmarshal(data, &entries); err != nil {
-		return nil, []error{fmt.Errorf("parsing Paperpile JSON: %w", err)}
+		return nil, nil, []error{fmt.Errorf("parsing Paperpile JSON: %w", err)}
 	}
 
-	var refs []reference.Reference
-	var errs []error
-
 	for i, entry := range entries {
-		ref, err := paperpileEntryToReference(entry)
+		ref, w, err := paperpileEntryToReference(entry, strict)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("entry %d (%s): %w", i+1, entry.Citekey, err))
 			continue
 		}
 		refs = append(refs, ref)
-	}
-
-	return refs, errs
-}
-
-// paperpileEntryToReference converts a Paperpile entry to our Reference type.
-func paperpileEntryToReference(entry PaperpileEntry) (reference.Reference, error) {
-	// Validate required fields
-	if entry.Title == "" {
-		return reference.Reference{}, fmt.Errorf("missing required field 'title'")
-	}
-	if len(entry.Author) == 0 {
-		return reference.Reference{}, fmt.Errorf("missing required field 'author'")
-	}
-	if entry.Published.Year.String() == "" {
-		return reference.Reference{}, fmt.Errorf("missing required field 'published.year'")
-	}
-
-	// Convert authors
-	authors := make([]reference.Author, len(entry.Author))
-	for i, a := range entry.Author {
-		authors[i] = reference.Author{
-			First: a.First,
-			Last:  a.Last,
-			ORCID: a.ORCID,
+		if w != nil {
+			warnings = append(warnings, *w)
 		}
 	}
 
-	// Convert publication date
-	year, err := strconv.Atoi(entry.Published.Year.String())
-	if err != nil {
-		return reference.Reference{}, fmt.Errorf("invalid year: %s", entry.Published.Year.String())
+	return refs, warnings, errs
+}
+
+// paperpileEntryToReference converts a Paperpile entry to our Reference type.
+//
+// Returns an error if the entry should be dropped. Returns a non-nil
+// ImportWarning when missing fields were filled with sentinels.
+func paperpileEntryToReference(entry PaperpileEntry, strict bool) (reference.Reference, *ImportWarning, error) {
+	missingTitle := entry.Title == ""
+	missingAuthor := len(entry.Author) == 0
+	missingYear := entry.Published.Year.String() == ""
+
+	if strict {
+		if missingTitle {
+			return reference.Reference{}, nil, fmt.Errorf("missing required field 'title'")
+		}
+		if missingAuthor {
+			return reference.Reference{}, nil, fmt.Errorf("missing required field 'author'")
+		}
+		if missingYear {
+			return reference.Reference{}, nil, fmt.Errorf("missing required field 'published.year'")
+		}
+	} else if missingTitle && missingAuthor && missingYear && entry.DOI == "" {
+		// Junk heuristic: no useful identifying metadata at all (e.g. Paperpile's
+		// auto-generated stubs for unparsed web pages). Skip rather than flood
+		// the nexus with "[no title] / Unknown / 0" placeholders.
+		return reference.Reference{}, nil, fmt.Errorf("entry has no usable metadata (no title, author, year, or DOI)")
+	}
+
+	var fallbackFields []string
+
+	// Title fallback
+	title := entry.Title
+	if missingTitle {
+		title = UnknownTitle
+		fallbackFields = append(fallbackFields, "title")
+	}
+
+	// Author fallback
+	var authors []reference.Author
+	if missingAuthor {
+		authors = []reference.Author{{Last: UnknownAuthor}}
+		fallbackFields = append(fallbackFields, "author")
+	} else {
+		authors = make([]reference.Author, len(entry.Author))
+		for i, a := range entry.Author {
+			authors[i] = reference.Author{
+				First: a.First,
+				Last:  a.Last,
+				ORCID: a.ORCID,
+			}
+		}
+	}
+
+	// Year fallback
+	var year int
+	if missingYear {
+		year = UnknownYear
+		fallbackFields = append(fallbackFields, "published.year")
+	} else {
+		var err error
+		year, err = strconv.Atoi(entry.Published.Year.String())
+		if err != nil {
+			return reference.Reference{}, nil, fmt.Errorf("invalid year: %s", entry.Published.Year.String())
+		}
 	}
 
 	pubDate := reference.PublicationDate{Year: year}
@@ -177,7 +244,7 @@ func paperpileEntryToReference(entry PaperpileEntry) (reference.Reference, error
 	ref := reference.Reference{
 		ID:              id,
 		DOI:             entry.DOI,
-		Title:           entry.Title,
+		Title:           title,
 		Authors:         authors,
 		Abstract:        entry.Abstract,
 		Venue:           entry.Journal,
@@ -192,5 +259,15 @@ func paperpileEntryToReference(entry PaperpileEntry) (reference.Reference, error
 		},
 	}
 
-	return ref, nil
+	var warning *ImportWarning
+	if len(fallbackFields) > 0 {
+		warning = &ImportWarning{
+			ID:      id,
+			Citekey: entry.Citekey,
+			Title:   title,
+			Fields:  fallbackFields,
+		}
+	}
+
+	return ref, warning, nil
 }

--- a/internal/importer/paperpile_test.go
+++ b/internal/importer/paperpile_test.go
@@ -73,7 +73,7 @@ func TestParsePaperpile_ValidEntry(t *testing.T) {
 		]
 	}]`)
 
-	refs, errs := ParsePaperpile(data)
+	refs, _, errs := ParsePaperpile(data, true)
 	if len(errs) > 0 {
 		t.Fatalf("ParsePaperpile() returned errors: %v", errs)
 	}
@@ -155,7 +155,7 @@ func TestParsePaperpile_WithoutNotes(t *testing.T) {
 		"author": [{"first": "John", "last": "Smith"}]
 	}]`)
 
-	refs, errs := ParsePaperpile(data)
+	refs, _, errs := ParsePaperpile(data, true)
 	if len(errs) > 0 {
 		t.Fatalf("ParsePaperpile() returned errors: %v", errs)
 	}
@@ -172,7 +172,7 @@ func TestParsePaperpile_NoCitekey(t *testing.T) {
 		"author": [{"first": "John", "last": "Smith"}]
 	}]`)
 
-	refs, errs := ParsePaperpile(data)
+	refs, _, errs := ParsePaperpile(data, true)
 	if len(errs) > 0 {
 		t.Fatalf("ParsePaperpile() returned errors: %v", errs)
 	}
@@ -207,7 +207,7 @@ func TestParsePaperpile_MissingRequiredFields(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			refs, errs := ParsePaperpile([]byte(tt.data))
+			refs, _, errs := ParsePaperpile([]byte(tt.data), true)
 			if len(errs) == 0 {
 				t.Errorf("ParsePaperpile() expected error for %s, got refs: %+v", tt.name, refs)
 			}
@@ -223,7 +223,7 @@ func TestParsePaperpile_InvalidYear(t *testing.T) {
 		"author": [{"first": "John", "last": "Smith"}]
 	}]`)
 
-	refs, errs := ParsePaperpile(data)
+	refs, _, errs := ParsePaperpile(data, true)
 	if len(errs) == 0 {
 		t.Errorf("ParsePaperpile() expected error for invalid year, got refs: %+v", refs)
 	}
@@ -238,7 +238,7 @@ func TestParsePaperpile_NumericYearMonth(t *testing.T) {
 		"author": [{"first": "John", "last": "Smith"}]
 	}]`)
 
-	refs, errs := ParsePaperpile(data)
+	refs, _, errs := ParsePaperpile(data, true)
 	if len(errs) > 0 {
 		t.Fatalf("ParsePaperpile() returned errors: %v", errs)
 	}
@@ -253,7 +253,7 @@ func TestParsePaperpile_NumericYearMonth(t *testing.T) {
 func TestParsePaperpile_InvalidJSON(t *testing.T) {
 	data := []byte(`not valid json`)
 
-	refs, errs := ParsePaperpile(data)
+	refs, _, errs := ParsePaperpile(data, true)
 	if len(errs) == 0 {
 		t.Errorf("ParsePaperpile() expected error for invalid JSON, got refs: %+v", refs)
 	}
@@ -262,7 +262,7 @@ func TestParsePaperpile_InvalidJSON(t *testing.T) {
 func TestParsePaperpile_EmptyArray(t *testing.T) {
 	data := []byte(`[]`)
 
-	refs, errs := ParsePaperpile(data)
+	refs, _, errs := ParsePaperpile(data, true)
 	if len(errs) > 0 {
 		t.Fatalf("ParsePaperpile() returned errors: %v", errs)
 	}
@@ -277,7 +277,7 @@ func TestParsePaperpile_MultipleEntries(t *testing.T) {
 		{"_id": "2", "citekey": "B2026", "title": "Paper B", "published": {"year": "2025"}, "author": [{"last": "B"}]}
 	]`)
 
-	refs, errs := ParsePaperpile(data)
+	refs, _, errs := ParsePaperpile(data, true)
 	if len(errs) > 0 {
 		t.Fatalf("ParsePaperpile() returned errors: %v", errs)
 	}
@@ -297,7 +297,7 @@ func TestParsePaperpile_PartialErrors(t *testing.T) {
 		{"_id": "3", "citekey": "AlsoValid2026", "title": "Also Valid", "published": {"year": "2025"}, "author": [{"last": "Also"}]}
 	]`)
 
-	refs, errs := ParsePaperpile(data)
+	refs, _, errs := ParsePaperpile(data, true)
 	if len(refs) != 2 {
 		t.Errorf("ParsePaperpile() returned %d valid refs, want 2", len(refs))
 	}
@@ -314,7 +314,7 @@ func TestParsePaperpile_RealTestData(t *testing.T) {
 		t.Skipf("Test data file not found: %v", err)
 	}
 
-	refs, errs := ParsePaperpile(data)
+	refs, _, errs := ParsePaperpile(data, true)
 	if len(errs) > 0 {
 		t.Errorf("ParsePaperpile() returned %d errors parsing real test data: %v", len(errs), errs)
 	}
@@ -352,7 +352,7 @@ func TestPaperpileEntry_AuthorWithOnlyLast(t *testing.T) {
 		"author": [{"last": "Corporation"}]
 	}]`)
 
-	refs, errs := ParsePaperpile(data)
+	refs, _, errs := ParsePaperpile(data, true)
 	if len(errs) > 0 {
 		t.Fatalf("ParsePaperpile() returned errors: %v", errs)
 	}
@@ -376,7 +376,7 @@ func TestParsePaperpile_WithLabelsAndFolders(t *testing.T) {
 		"foldersNamed": ["my papers"]
 	}]`)
 
-	refs, errs := ParsePaperpile(data)
+	refs, _, errs := ParsePaperpile(data, true)
 	if len(errs) > 0 {
 		t.Fatalf("ParsePaperpile() returned errors: %v", errs)
 	}
@@ -399,7 +399,7 @@ func TestParsePaperpile_DuplicateLabelAndFolder(t *testing.T) {
 		"foldersNamed": ["antibody"]
 	}]`)
 
-	refs, errs := ParsePaperpile(data)
+	refs, _, errs := ParsePaperpile(data, true)
 	if len(errs) > 0 {
 		t.Fatalf("ParsePaperpile() returned errors: %v", errs)
 	}
@@ -417,12 +417,155 @@ func TestParsePaperpile_NoLabelsOrFolders(t *testing.T) {
 		"author": [{"first": "John", "last": "Smith"}]
 	}]`)
 
-	refs, errs := ParsePaperpile(data)
+	refs, _, errs := ParsePaperpile(data, true)
 	if len(errs) > 0 {
 		t.Fatalf("ParsePaperpile() returned errors: %v", errs)
 	}
 	if len(refs[0].Tags) != 0 {
 		t.Errorf("Tags = %v, want empty", refs[0].Tags)
+	}
+}
+
+func TestParsePaperpile_LenientMissingYear(t *testing.T) {
+	// Real-world case from issue #138: eLife reviewed preprint with no year.
+	data := []byte(`[{
+		"_id": "abc123",
+		"citekey": "Sung2025-thrifty",
+		"title": "Thrifty wide-context models of B cell receptor somatic hypermutation",
+		"author": [{"first": "Kevin", "last": "Sung"}],
+		"published": {}
+	}]`)
+
+	refs, warnings, errs := ParsePaperpile(data, false)
+	if len(errs) > 0 {
+		t.Fatalf("ParsePaperpile(lenient) returned errors: %v", errs)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("got %d refs, want 1", len(refs))
+	}
+	if refs[0].Published.Year != UnknownYear {
+		t.Errorf("Year = %d, want %d (sentinel)", refs[0].Published.Year, UnknownYear)
+	}
+	if len(warnings) != 1 {
+		t.Fatalf("got %d warnings, want 1", len(warnings))
+	}
+	if len(warnings[0].Fields) != 1 || warnings[0].Fields[0] != "published.year" {
+		t.Errorf("warning fields = %v, want [published.year]", warnings[0].Fields)
+	}
+	if warnings[0].ID != "Sung2025-thrifty" {
+		t.Errorf("warning ID = %s, want Sung2025-thrifty", warnings[0].ID)
+	}
+}
+
+func TestParsePaperpile_LenientMissingTitle(t *testing.T) {
+	data := []byte(`[{
+		"_id": "abc123",
+		"citekey": "NoTitle2026",
+		"author": [{"last": "Smith"}],
+		"published": {"year": "2026"}
+	}]`)
+
+	refs, warnings, errs := ParsePaperpile(data, false)
+	if len(errs) > 0 {
+		t.Fatalf("returned errors: %v", errs)
+	}
+	if len(refs) != 1 || refs[0].Title != UnknownTitle {
+		t.Errorf("Title = %q, want %q", refs[0].Title, UnknownTitle)
+	}
+	if len(warnings) != 1 || warnings[0].Fields[0] != "title" {
+		t.Errorf("warning fields = %v, want [title]", warnings[0].Fields)
+	}
+}
+
+func TestParsePaperpile_LenientMissingAuthor(t *testing.T) {
+	data := []byte(`[{
+		"_id": "abc123",
+		"citekey": "NoAuthor2026",
+		"title": "Some paper",
+		"published": {"year": "2026"}
+	}]`)
+
+	refs, warnings, errs := ParsePaperpile(data, false)
+	if len(errs) > 0 {
+		t.Fatalf("returned errors: %v", errs)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("got %d refs, want 1", len(refs))
+	}
+	if len(refs[0].Authors) != 1 || refs[0].Authors[0].Last != UnknownAuthor {
+		t.Errorf("Authors = %+v, want one author with Last=%q", refs[0].Authors, UnknownAuthor)
+	}
+	if len(warnings) != 1 || warnings[0].Fields[0] != "author" {
+		t.Errorf("warning fields = %v, want [author]", warnings[0].Fields)
+	}
+}
+
+func TestParsePaperpile_LenientMultipleMissingFields(t *testing.T) {
+	// Has DOI, so not pure junk — should still import with all three sentinels.
+	data := []byte(`[{
+		"_id": "abc123",
+		"citekey": "OnlyDOI",
+		"doi": "10.1234/whatever",
+		"published": {}
+	}]`)
+
+	refs, warnings, errs := ParsePaperpile(data, false)
+	if len(errs) > 0 {
+		t.Fatalf("returned errors: %v", errs)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("got %d refs, want 1", len(refs))
+	}
+	if len(warnings) != 1 {
+		t.Fatalf("got %d warnings, want 1", len(warnings))
+	}
+	if len(warnings[0].Fields) != 3 {
+		t.Errorf("warning fields = %v, want all three (title, author, published.year)", warnings[0].Fields)
+	}
+}
+
+func TestParsePaperpile_LenientJunkEntryDropped(t *testing.T) {
+	// Pure junk: no title, no author, no year, no DOI. Paperpile auto-stub for
+	// an unparsed web page. Even in lenient mode this should be dropped to
+	// avoid flooding the nexus with placeholders.
+	data := []byte(`[{
+		"_id": "abc",
+		"citekey": "noauthor_undated-aa",
+		"published": {}
+	}]`)
+
+	refs, warnings, errs := ParsePaperpile(data, false)
+	if len(refs) != 0 {
+		t.Errorf("got %d refs, want 0 (junk should be dropped)", len(refs))
+	}
+	if len(warnings) != 0 {
+		t.Errorf("got %d warnings, want 0", len(warnings))
+	}
+	if len(errs) != 1 {
+		t.Errorf("got %d errors, want 1 (junk dropped with explanation)", len(errs))
+	}
+}
+
+func TestParsePaperpile_StrictDropsAllMissing(t *testing.T) {
+	// Verify strict mode preserves the original behavior: any missing required
+	// field drops the entry, no fallbacks.
+	data := []byte(`[{
+		"_id": "abc",
+		"citekey": "MissingYear",
+		"title": "Has title",
+		"author": [{"last": "Smith"}],
+		"published": {}
+	}]`)
+
+	refs, warnings, errs := ParsePaperpile(data, true)
+	if len(refs) != 0 {
+		t.Errorf("strict mode: got %d refs, want 0", len(refs))
+	}
+	if len(warnings) != 0 {
+		t.Errorf("strict mode should not produce warnings, got %d", len(warnings))
+	}
+	if len(errs) != 1 {
+		t.Errorf("strict mode: got %d errors, want 1", len(errs))
 	}
 }
 

--- a/internal/importer/paperpile_test.go
+++ b/internal/importer/paperpile_test.go
@@ -314,31 +314,51 @@ func TestParsePaperpile_RealTestData(t *testing.T) {
 		t.Skipf("Test data file not found: %v", err)
 	}
 
-	refs, _, errs := ParsePaperpile(data, true)
-	if len(errs) > 0 {
-		t.Errorf("ParsePaperpile() returned %d errors parsing real test data: %v", len(errs), errs)
+	strictRefs, _, strictErrs := ParsePaperpile(data, true)
+	if len(strictErrs) > 0 {
+		t.Errorf("strict mode returned %d errors parsing real test data: %v", len(strictErrs), strictErrs)
 	}
-	if len(refs) == 0 {
-		t.Error("ParsePaperpile() returned 0 refs from test data")
+	if len(strictRefs) == 0 {
+		t.Error("strict mode returned 0 refs from test data")
 	}
 
-	// Check that the first reference has expected structure
-	if len(refs) > 0 {
-		ref := refs[0]
+	// Check that the first reference has expected structure. The fixture
+	// contains complete entries, so strict-mode results should not contain
+	// sentinel values.
+	if len(strictRefs) > 0 {
+		ref := strictRefs[0]
 		if ref.ID == "" {
 			t.Error("First ref has empty ID")
 		}
-		if ref.Title == "" {
-			t.Error("First ref has empty Title")
+		if ref.Title == "" || ref.Title == UnknownTitle {
+			t.Errorf("First ref Title = %q (sentinel or empty)", ref.Title)
 		}
 		if len(ref.Authors) == 0 {
 			t.Error("First ref has no Authors")
 		}
-		if ref.Published.Year == 0 {
-			t.Error("First ref has zero Year")
+		if ref.Published.Year == UnknownYear {
+			t.Errorf("First ref Year = %d (sentinel)", ref.Published.Year)
 		}
 		if ref.Source.Type != "paperpile" {
 			t.Errorf("First ref Source.Type = %s, want paperpile", ref.Source.Type)
+		}
+	}
+
+	// Lenient mode should never drop more entries than strict and should
+	// produce structurally valid warnings for any entries that hit fallbacks.
+	lenientRefs, lenientWarnings, lenientErrs := ParsePaperpile(data, false)
+	if len(lenientErrs) > len(strictErrs) {
+		t.Errorf("lenient mode returned more errors (%d) than strict (%d)", len(lenientErrs), len(strictErrs))
+	}
+	if len(lenientRefs) < len(strictRefs) {
+		t.Errorf("lenient mode dropped more entries (%d refs) than strict (%d refs)", len(lenientRefs), len(strictRefs))
+	}
+	for i, w := range lenientWarnings {
+		if w.ID == "" {
+			t.Errorf("lenient warning %d has empty ID", i)
+		}
+		if len(w.Fields) == 0 {
+			t.Errorf("lenient warning %d (%s) has no Fields", i, w.ID)
 		}
 	}
 }
@@ -472,8 +492,14 @@ func TestParsePaperpile_LenientMissingTitle(t *testing.T) {
 	if len(refs) != 1 || refs[0].Title != UnknownTitle {
 		t.Errorf("Title = %q, want %q", refs[0].Title, UnknownTitle)
 	}
-	if len(warnings) != 1 || warnings[0].Fields[0] != "title" {
+	if len(warnings) != 1 {
+		t.Fatalf("got %d warnings, want 1", len(warnings))
+	}
+	if len(warnings[0].Fields) != 1 || warnings[0].Fields[0] != "title" {
 		t.Errorf("warning fields = %v, want [title]", warnings[0].Fields)
+	}
+	if warnings[0].ID != "NoTitle2026" {
+		t.Errorf("warning ID = %s, want NoTitle2026", warnings[0].ID)
 	}
 }
 
@@ -495,8 +521,14 @@ func TestParsePaperpile_LenientMissingAuthor(t *testing.T) {
 	if len(refs[0].Authors) != 1 || refs[0].Authors[0].Last != UnknownAuthor {
 		t.Errorf("Authors = %+v, want one author with Last=%q", refs[0].Authors, UnknownAuthor)
 	}
-	if len(warnings) != 1 || warnings[0].Fields[0] != "author" {
+	if len(warnings) != 1 {
+		t.Fatalf("got %d warnings, want 1", len(warnings))
+	}
+	if len(warnings[0].Fields) != 1 || warnings[0].Fields[0] != "author" {
 		t.Errorf("warning fields = %v, want [author]", warnings[0].Fields)
+	}
+	if warnings[0].ID != "NoAuthor2026" {
+		t.Errorf("warning ID = %s, want NoAuthor2026", warnings[0].ID)
 	}
 }
 
@@ -546,26 +578,70 @@ func TestParsePaperpile_LenientJunkEntryDropped(t *testing.T) {
 	}
 }
 
-func TestParsePaperpile_StrictDropsAllMissing(t *testing.T) {
-	// Verify strict mode preserves the original behavior: any missing required
-	// field drops the entry, no fallbacks.
-	data := []byte(`[{
-		"_id": "abc",
-		"citekey": "MissingYear",
-		"title": "Has title",
-		"author": [{"last": "Smith"}],
-		"published": {}
-	}]`)
-
-	refs, warnings, errs := ParsePaperpile(data, true)
-	if len(refs) != 0 {
-		t.Errorf("strict mode: got %d refs, want 0", len(refs))
+func TestParsePaperpile_StrictDropsAnyMissingField(t *testing.T) {
+	// Verify strict mode preserves the original behavior: any of the three
+	// required fields (title, author, year) being missing drops the entry,
+	// with no warnings produced.
+	cases := []struct {
+		name string
+		data string
+	}{
+		{
+			name: "missing year",
+			data: `[{"_id": "a", "citekey": "MissingYear", "title": "T", "author": [{"last": "S"}], "published": {}}]`,
+		},
+		{
+			name: "missing title",
+			data: `[{"_id": "a", "citekey": "MissingTitle", "author": [{"last": "S"}], "published": {"year": "2026"}}]`,
+		},
+		{
+			name: "missing author",
+			data: `[{"_id": "a", "citekey": "MissingAuthor", "title": "T", "published": {"year": "2026"}}]`,
+		},
 	}
-	if len(warnings) != 0 {
-		t.Errorf("strict mode should not produce warnings, got %d", len(warnings))
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			refs, warnings, errs := ParsePaperpile([]byte(tc.data), true)
+			if len(refs) != 0 {
+				t.Errorf("strict mode: got %d refs, want 0", len(refs))
+			}
+			if len(warnings) != 0 {
+				t.Errorf("strict mode should not produce warnings, got %d", len(warnings))
+			}
+			if len(errs) != 1 {
+				t.Errorf("strict mode: got %d errors, want 1", len(errs))
+			}
+		})
+	}
+}
+
+func TestParsePaperpile_LenientMixedArray(t *testing.T) {
+	// Realistic Paperpile shape: one valid entry, one recoverable (missing
+	// year only), one pure junk. Verify that the warning for the recoverable
+	// entry is emitted alongside an error for the junk entry without
+	// corrupting either, and that the valid entry imports cleanly.
+	data := []byte(`[
+		{"_id": "1", "citekey": "Good2026", "title": "Good", "author": [{"last": "G"}], "published": {"year": "2026"}},
+		{"_id": "2", "citekey": "Recoverable", "title": "Recoverable paper", "author": [{"last": "R"}], "published": {}},
+		{"_id": "3", "citekey": "noauthor_undated-zz", "published": {}}
+	]`)
+
+	refs, warnings, errs := ParsePaperpile(data, false)
+	if len(refs) != 2 {
+		t.Fatalf("got %d refs, want 2 (good + recoverable)", len(refs))
+	}
+	if len(warnings) != 1 {
+		t.Fatalf("got %d warnings, want 1 (recoverable only)", len(warnings))
+	}
+	if warnings[0].ID != "Recoverable" {
+		t.Errorf("warning attached to %s, want Recoverable", warnings[0].ID)
+	}
+	if len(warnings[0].Fields) != 1 || warnings[0].Fields[0] != "published.year" {
+		t.Errorf("warning fields = %v, want [published.year]", warnings[0].Fields)
 	}
 	if len(errs) != 1 {
-		t.Errorf("strict mode: got %d errors, want 1", len(errs))
+		t.Errorf("got %d errors, want 1 (junk drop)", len(errs))
 	}
 }
 

--- a/skills/bip.lit.import/SKILL.md
+++ b/skills/bip.lit.import/SKILL.md
@@ -34,7 +34,7 @@ Always dry-run first to show what will change:
 bip import --format paperpile "<file>" --dry-run --human
 ```
 
-Report the counts (new, updated, skipped) to the user. The skipped entries are typically old Paperpile records missing year or author — expected and not actionable.
+Report the counts (new, updated, skipped, warnings) to the user. By default, entries missing required fields (title, author, published.year) are imported with sentinel placeholders (`[no title]`, `Unknown`, year `0`) and listed under `warnings` so they're not silently dropped — review the warning list and fix the affected Paperpile records when convenient. Entries with no useful metadata at all (no title, author, year, or DOI — typically Paperpile auto-stubs for unparsed web pages) are still skipped and counted under `skipped`. Pass `--strict` to revert to the old behavior of dropping any entry with a missing required field.
 
 ### 3. Import
 


### PR DESCRIPTION
🤖 Closes #138.

## Summary

`bip import --format paperpile` was silently dropping entries with missing `title`, `author`, or `published.year` — including the Thrifty paper and other Matsen-group preprints that became invisible in the nexus until specifically searched for.

This PR switches the default to **soft fall-through with explicit warnings**:

- Missing `title` → `[no title]`
- Missing `author` → `[{Last: "Unknown"}]`
- Missing `published.year` → `0` (sentinel)
- Each filled-in entry is reported in a new `warnings` JSON field and printed to **stderr** in human-readable form, so the user sees them at the terminal even when stdout is `jq`-piped.
- `--strict` flag preserves the old behavior (drop on missing required field).
- Junk heuristic: entries with **none** of `{title, author, year, doi}` are still dropped, so the ~50 `noauthor_undated-*` Paperpile auto-stubs don't flood the nexus.

## Behavior matrix

| Entry has | Default (lenient) | `--strict` |
|-----------|-------------------|-----------|
| Missing year only (Thrifty) | imported, warning emitted | dropped |
| Missing title or author | imported with sentinel, warning | dropped |
| Has DOI but missing all of title/author/year | imported with all three sentinels, warning | dropped |
| None of title/author/year/DOI (junk stub) | dropped, error | dropped |

## Smoke test (lenient, dry run)

```
$ bip import --format paperpile test.json --dry-run
Imported 1 entries with missing fields filled in (use --strict to drop them instead):
  - entry Sung2025-thrifty ("Thrifty wide-context models"): defaulted [published.year]
{
  "would_add": 2, "would_update": 0, "would_skip": 1,
  "warnings": [{"id": "Sung2025-thrifty", ..., "fields": ["published.year"]}],
  ...
}
```

## Files

- `internal/importer/paperpile.go` — new `ImportWarning` type, `strict` parameter on `ParsePaperpile`, fallback logic, junk heuristic.
- `cmd/bip/import.go` — `--strict` flag, stderr warning printer, `warnings` field in JSON output.
- `internal/importer/paperpile_test.go` — updated existing tests to new signature, added 6 new tests covering each fallback path, multi-field fallbacks, the junk heuristic, and strict-mode preservation.
- `docs/guides/reference-management.md` and `skills/bip.lit.import/SKILL.md` — documented the new default and `--strict` flag.

## Test plan

- [x] `go fmt ./...`, `go vet ./...`, `go test ./...` all green
- [x] Manual smoke test with mixed-quality input (real paper, junk stub, complete paper) confirms the matrix above
- [x] `--strict` preserves the original drop-on-missing behavior
- [x] Stderr warnings visible in both human and JSON modes
- [ ] Run on a real Paperpile export and verify Thrifty + Matsen_undated-fg now land in the nexus