### PR TITLE
Auto-tag Paperpile imports with paperpile:incomplete when fallbacks fire

### DIFF
--- a/docs/guides/reference-management.md
+++ b/docs/guides/reference-management.md
@@ -16,6 +16,14 @@ Paperpile import preserves the `notes` field from your Paperpile library. Notes 
 
 By default, entries missing required fields (`title`, `author`, `published.year`) are imported with sentinel placeholders (`[no title]`, `Unknown`, year `0`) and surfaced under `warnings` in the import output, so eLife reviewed preprints and similar entries with incomplete metadata aren't silently dropped. Entries with none of `{title, author, year, doi}` are still skipped to avoid importing Paperpile's web-page auto-stubs. Pass `--strict` to drop any entry with a missing required field instead.
 
+Every reference whose import filled at least one sentinel is auto-tagged `paperpile:incomplete`, so the cleanup queue is queryable later without remembering the sentinel strings:
+
+```bash
+bip search --tag paperpile:incomplete
+```
+
+Fix the entry in Paperpile and re-import; the next update replaces the stored reference and the tag falls off automatically.
+
 `bip rebuild` builds the SQLite query index from the JSONL source files. Run it after pulling changes or if the database gets corrupted.
 
 ## Searching

--- a/internal/importer/paperpile.go
+++ b/internal/importer/paperpile.go
@@ -109,6 +109,13 @@ const UnknownAuthor = "Unknown"
 // mode.
 const UnknownTitle = "[no title]"
 
+// IncompleteTag is appended to Reference.Tags when any required field hit a
+// fallback in lenient mode, so users can find these entries later via
+// `bip search --tag paperpile:incomplete`. The colon-namespaced shape
+// (`<importer>:<condition>`) reserves room for future auto-tags and reduces
+// the chance of collision with user-defined Paperpile labels.
+const IncompleteTag = "paperpile:incomplete"
+
 // ParsePaperpile parses a Paperpile JSON export and returns references.
 //
 // When strict is true, entries missing any of {title, author, published.year}
@@ -241,6 +248,10 @@ func paperpileEntryToReference(entry PaperpileEntry, strict bool) (reference.Ref
 			tags = append(tags, folder)
 			seen[folder] = true
 		}
+	}
+	if len(fallbackFields) > 0 && !seen[IncompleteTag] {
+		tags = append(tags, IncompleteTag)
+		seen[IncompleteTag] = true
 	}
 
 	// Use citekey as ID, falling back to Paperpile ID if no citekey

--- a/internal/importer/paperpile_test.go
+++ b/internal/importer/paperpile_test.go
@@ -645,6 +645,165 @@ func TestParsePaperpile_LenientMixedArray(t *testing.T) {
 	}
 }
 
+func tagsContain(tags []string, want string) bool {
+	for _, t := range tags {
+		if t == want {
+			return true
+		}
+	}
+	return false
+}
+
+func countTag(tags []string, want string) int {
+	n := 0
+	for _, t := range tags {
+		if t == want {
+			n++
+		}
+	}
+	return n
+}
+
+func TestParsePaperpile_LenientFallbackAddsIncompleteTag(t *testing.T) {
+	cases := []struct {
+		name string
+		data string
+	}{
+		{
+			name: "missing year",
+			data: `[{"_id": "a", "citekey": "MissingYear", "title": "T", "author": [{"last": "S"}], "published": {}}]`,
+		},
+		{
+			name: "missing title",
+			data: `[{"_id": "a", "citekey": "MissingTitle", "author": [{"last": "S"}], "published": {"year": "2026"}}]`,
+		},
+		{
+			name: "missing author",
+			data: `[{"_id": "a", "citekey": "MissingAuthor", "title": "T", "published": {"year": "2026"}}]`,
+		},
+		{
+			name: "all three missing (DOI present)",
+			data: `[{"_id": "a", "citekey": "OnlyDOI", "doi": "10.1234/x", "published": {}}]`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			refs, _, errs := ParsePaperpile([]byte(tc.data), false)
+			if len(errs) > 0 {
+				t.Fatalf("unexpected errors: %v", errs)
+			}
+			if len(refs) != 1 {
+				t.Fatalf("got %d refs, want 1", len(refs))
+			}
+			if !tagsContain(refs[0].Tags, IncompleteTag) {
+				t.Errorf("Tags = %v, want to contain %q", refs[0].Tags, IncompleteTag)
+			}
+		})
+	}
+}
+
+func TestParsePaperpile_StrictCompleteEntryDoesNotGetIncompleteTag(t *testing.T) {
+	// In strict mode no fallbacks fire (entries with missing fields are
+	// dropped, complete entries import without sentinels), so the tag
+	// should never be set.
+	data := []byte(`[{
+		"_id": "abc",
+		"citekey": "Complete2026",
+		"title": "Complete paper",
+		"author": [{"last": "Smith"}],
+		"published": {"year": "2026"}
+	}]`)
+
+	refs, _, errs := ParsePaperpile(data, true)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("got %d refs, want 1", len(refs))
+	}
+	if tagsContain(refs[0].Tags, IncompleteTag) {
+		t.Errorf("Tags = %v, should not contain %q in strict mode", refs[0].Tags, IncompleteTag)
+	}
+}
+
+func TestParsePaperpile_ValidEntryDoesNotGetIncompleteTag(t *testing.T) {
+	data := []byte(`[{
+		"_id": "abc",
+		"citekey": "Complete2026",
+		"title": "Complete paper",
+		"author": [{"last": "Smith"}],
+		"published": {"year": "2026"}
+	}]`)
+
+	refs, _, errs := ParsePaperpile(data, false)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("got %d refs, want 1", len(refs))
+	}
+	if tagsContain(refs[0].Tags, IncompleteTag) {
+		t.Errorf("Tags = %v, should not contain %q for a complete entry", refs[0].Tags, IncompleteTag)
+	}
+}
+
+func TestParsePaperpile_LenientMixedArrayTagsRecoverableOnly(t *testing.T) {
+	data := []byte(`[
+		{"_id": "1", "citekey": "Good2026", "title": "Good", "author": [{"last": "G"}], "published": {"year": "2026"}},
+		{"_id": "2", "citekey": "Recoverable", "title": "Recoverable paper", "author": [{"last": "R"}], "published": {}}
+	]`)
+
+	refs, _, errs := ParsePaperpile(data, false)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(refs) != 2 {
+		t.Fatalf("got %d refs, want 2", len(refs))
+	}
+
+	var good, recoverable reference.Reference
+	for _, r := range refs {
+		switch r.ID {
+		case "Good2026":
+			good = r
+		case "Recoverable":
+			recoverable = r
+		}
+	}
+	if tagsContain(good.Tags, IncompleteTag) {
+		t.Errorf("complete entry Tags = %v, should not contain %q", good.Tags, IncompleteTag)
+	}
+	if !tagsContain(recoverable.Tags, IncompleteTag) {
+		t.Errorf("recoverable entry Tags = %v, want to contain %q", recoverable.Tags, IncompleteTag)
+	}
+}
+
+func TestParsePaperpile_LenientUserLabelDedupedWithIncompleteTag(t *testing.T) {
+	// If a Paperpile user has manually labeled an entry "paperpile:incomplete"
+	// AND the entry hits a fallback, the existing dedup `seen` map should
+	// collapse the two into a single occurrence in Tags.
+	data := []byte(`[{
+		"_id": "abc",
+		"citekey": "DoubleTagged",
+		"title": "T",
+		"author": [{"last": "S"}],
+		"published": {},
+		"labelsNamed": ["paperpile:incomplete"]
+	}]`)
+
+	refs, _, errs := ParsePaperpile(data, false)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("got %d refs, want 1", len(refs))
+	}
+	if got := countTag(refs[0].Tags, IncompleteTag); got != 1 {
+		t.Errorf("Tags = %v: %q occurs %d times, want 1", refs[0].Tags, IncompleteTag, got)
+	}
+}
+
 // Helper function for comparing references
 func refsEqual(a, b reference.Reference) bool {
 	if a.ID != b.ID || a.DOI != b.DOI || a.Title != b.Title {

--- a/internal/reference/reference.go
+++ b/internal/reference/reference.go
@@ -24,7 +24,11 @@ type Reference struct {
 	// Import Tracking
 	Source ImportSource `json:"source"`
 
-	// Tags are user-defined labels for organizing references.
+	// Tags are labels for organizing references. Most are user-defined
+	// (e.g. Paperpile labels and folders), but importers may auto-set
+	// namespaced tags of the form `<importer>:<condition>` (e.g.
+	// `paperpile:incomplete` when a required field was filled with a
+	// sentinel) so the entries are queryable via `bip search --tag`.
 	Tags []string `json:"tags,omitempty"`
 
 	// Relationships

--- a/skills/bip.lit.import/SKILL.md
+++ b/skills/bip.lit.import/SKILL.md
@@ -57,3 +57,13 @@ rm "<file>"
 ### 6. Report
 
 Summarize: new refs added, total count, file deleted. Notes from Paperpile are preserved and searchable via `bip search`.
+
+### 7. Recommend cleanup if warnings fired
+
+If the import reported a non-zero `warnings` count, recommend the cleanup query so the user can fix the upstream Paperpile records when convenient:
+
+```bash
+bip search --tag paperpile:incomplete
+```
+
+Every reference imported with a sentinel field (`[no title]`, `Unknown`, year `0`) is auto-tagged `paperpile:incomplete`. Once the user fixes the entry in Paperpile and re-imports, the next import replaces the stored reference and the tag disappears automatically, so the list shrinks until empty without any manual untagging step.


### PR DESCRIPTION
🤖

Closes #141.

## Summary

When `paperpileEntryToReference` fills any sentinel value in lenient mode (`title=[no title]`, `author=Unknown`, or `year=0`), append the namespaced tag `paperpile:incomplete` to `Reference.Tags` so the incomplete entries are queryable later via:

```bash
bip search --tag paperpile:incomplete
```

The colon-namespaced shape (`<importer>:<condition>`) leaves room for future auto-tags. Re-import of a fixed entry removes the tag automatically — `processImports` replaces the persisted reference wholesale, so once the upstream Paperpile entry is fixed and re-imported, the tag falls off without any manual untagging step.

## Files changed

- `internal/importer/paperpile.go` — added `IncompleteTag` constant; append it after the labels/folders loop using the existing `seen` dedup map so a user label of `paperpile:incomplete` and the auto-add collapse into one occurrence
- `internal/importer/paperpile_test.go` — five new tests covering each fallback path, the strict-mode + complete-entry case, the mixed-array case (tag on recoverable but not valid entry), and the user-label/auto-add dedup
- `internal/reference/reference.go` — extended the `Tags` field doc comment to note importer-set namespaced tags
- `skills/bip.lit.import/SKILL.md` — added a step recommending the cleanup query when warnings fire
- `docs/guides/reference-management.md` — documented the auto-tag

## Test plan

- [x] Unit: lenient fallback adds `paperpile:incomplete` (all four field-missing combinations)
- [x] Unit: strict mode + complete entry does not add the tag
- [x] Unit: lenient mode + fully-valid entry imports without the tag
- [x] Unit: lenient mode + user-set label of `paperpile:incomplete` produces exactly one occurrence (dedup via existing `seen` map)
- [x] `go fmt ./...`, `go vet ./...`, `go test ./...` — all green
- [ ] Manual: import a real Paperpile export, confirm `bip search --tag paperpile:incomplete` returns the warned entries

## Notes

A clean-code review pass produced four tightening edits (test naming/scope, doc-comment claim softened, namespace-rationale removed from user guide, internal function name removed from skill doc) which are folded into this PR.