### PR TITLE
Preserve PMCID and other resolved fields on re-import

### DIFF
--- a/cmd/bip/import.go
+++ b/cmd/bip/import.go
@@ -311,20 +311,20 @@ func classifyImport(existing []reference.Reference, newRef reference.Reference) 
 	return importAction{action: "new"}
 }
 
-// persistImports writes the import results to the refs file.
+// persistImports writes the import results to the refs file. Updates use
+// reference.MergeUpdate to preserve fields the importer didn't populate
+// (notably PMCID/PMID/ArXivID/S2ID from `bip ncbi backfill` and `bip s2`),
+// rather than wholesale-replacing the existing entry.
 func persistImports(path string, existing []reference.Reference, actions []storage.RefWithAction) error {
-	// Build new refs list
 	newRefs := make([]reference.Reference, len(existing))
 	copy(newRefs, existing)
 
-	// Apply updates first
 	for _, a := range actions {
 		if a.Action == "update" {
-			newRefs[a.ExistingIdx] = a.Ref
+			newRefs[a.ExistingIdx] = reference.MergeUpdate(newRefs[a.ExistingIdx], a.Ref)
 		}
 	}
 
-	// Append new entries
 	for _, a := range actions {
 		if a.Action == "new" {
 			newRefs = append(newRefs, a.Ref)

--- a/cmd/bip/import_test.go
+++ b/cmd/bip/import_test.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/matsen/bipartite/internal/reference"
+	"github.com/matsen/bipartite/internal/storage"
 )
 
 func TestClassifyImport(t *testing.T) {
@@ -123,5 +125,67 @@ func TestClassifyImportEmptyExistingList(t *testing.T) {
 
 	if got.action != "new" {
 		t.Errorf("action = %q, want %q", got.action, "new")
+	}
+}
+
+func TestPersistImports_PreservesPostImportFields(t *testing.T) {
+	// Locks in the cross-cutting fix for issue #145: an existing ref's
+	// externally-resolved fields (PMCID, PMID, ArXivID, S2ID) and any PDF
+	// path additions survive a re-import that doesn't carry those fields.
+	// Without reference.MergeUpdate this would regress to the old wholesale
+	// replace, silently wiping every `bip ncbi backfill` result.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "refs.jsonl")
+
+	existing := []reference.Reference{
+		{
+			ID:      "Smith2024-aa",
+			DOI:     "10.1038/foo",
+			Title:   "Foo",
+			Source:  reference.ImportSource{Type: "paperpile", ID: "uuid-1"},
+			PMCID:   "PMC123",
+			PMID:    "456",
+			S2ID:    "abc",
+			PDFPath: "Smith/2024/Smith2024-aa.pdf",
+		},
+	}
+
+	incoming := reference.Reference{
+		ID:     "Smith2024-aa",
+		DOI:    "10.1038/foo",
+		Title:  "Foo (Paperpile re-export)",
+		Source: reference.ImportSource{Type: "paperpile", ID: "uuid-1"},
+	}
+
+	actions := []storage.RefWithAction{
+		{Ref: incoming, Action: "update", ExistingIdx: 0},
+	}
+
+	if err := persistImports(path, existing, actions); err != nil {
+		t.Fatalf("persistImports: %v", err)
+	}
+
+	got, err := storage.ReadAll(path)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 ref, got %d", len(got))
+	}
+	r := got[0]
+	if r.PMCID != "PMC123" {
+		t.Errorf("PMCID wiped: %q", r.PMCID)
+	}
+	if r.PMID != "456" {
+		t.Errorf("PMID wiped: %q", r.PMID)
+	}
+	if r.S2ID != "abc" {
+		t.Errorf("S2ID wiped: %q", r.S2ID)
+	}
+	if r.PDFPath != "Smith/2024/Smith2024-aa.pdf" {
+		t.Errorf("PDFPath wiped: %q", r.PDFPath)
+	}
+	if r.Title != "Foo (Paperpile re-export)" {
+		t.Errorf("Title should update from incoming: %q", r.Title)
 	}
 }

--- a/internal/reference/merge.go
+++ b/internal/reference/merge.go
@@ -1,0 +1,68 @@
+package reference
+
+// MergeUpdate produces an updated Reference from an incoming import and the
+// existing on-disk version. For every field other than ID and Source, an
+// incoming zero value falls back to the existing value. This preserves
+// post-import edits (e.g., PMCIDs added by `bip ncbi backfill`, or PDF paths
+// linked via `bip s2 linkpub`) when the import format doesn't carry that
+// field at all.
+//
+// ID and Source are always taken from incoming because they describe this
+// import event itself: ID is the citekey the importer chose, and Source.Type
+// / Source.ID identify which external system this came from.
+//
+// Trade-off: if a user clears a field in their import source (e.g., removes
+// a tag in Paperpile), the import sends a zero value, and the merge keeps
+// the old value. That's the price of preserving externally-resolved fields.
+// Users who want a true wipe should edit refs.jsonl directly.
+func MergeUpdate(existing, incoming Reference) Reference {
+	out := incoming
+
+	if out.DOI == "" {
+		out.DOI = existing.DOI
+	}
+	if out.Title == "" {
+		out.Title = existing.Title
+	}
+	if len(out.Authors) == 0 {
+		out.Authors = existing.Authors
+	}
+	if out.Abstract == "" {
+		out.Abstract = existing.Abstract
+	}
+	if out.Venue == "" {
+		out.Venue = existing.Venue
+	}
+	if out.Note == "" {
+		out.Note = existing.Note
+	}
+	if out.Published.Year == 0 {
+		out.Published = existing.Published
+	}
+	if out.PDFPath == "" {
+		out.PDFPath = existing.PDFPath
+	}
+	if len(out.SupplementPaths) == 0 {
+		out.SupplementPaths = existing.SupplementPaths
+	}
+	if len(out.Tags) == 0 {
+		out.Tags = existing.Tags
+	}
+	if out.Supersedes == "" {
+		out.Supersedes = existing.Supersedes
+	}
+	if out.PMID == "" {
+		out.PMID = existing.PMID
+	}
+	if out.PMCID == "" {
+		out.PMCID = existing.PMCID
+	}
+	if out.ArXivID == "" {
+		out.ArXivID = existing.ArXivID
+	}
+	if out.S2ID == "" {
+		out.S2ID = existing.S2ID
+	}
+
+	return out
+}

--- a/internal/reference/merge_test.go
+++ b/internal/reference/merge_test.go
@@ -137,6 +137,28 @@ func TestMergeUpdate_PreservesYearOnUndatedImport(t *testing.T) {
 	}
 }
 
+func TestMergeUpdate_IncomingYearReplacesFullExistingDate(t *testing.T) {
+	// Flip side of PreservesYearOnUndatedImport: if incoming has a year (the
+	// merge sentinel for "has a date"), the entire Published struct from
+	// incoming wins — even if it lacks the month/day that existing carried.
+	// Locks in the current behavior: Year is the all-or-nothing trigger; we
+	// do not merge fields within PublicationDate.
+	existing := Reference{
+		ID:        "x",
+		Published: PublicationDate{Year: 2024, Month: 6, Day: 15},
+	}
+	incoming := Reference{
+		ID:        "x",
+		Source:    ImportSource{Type: "paperpile", ID: "uuid"},
+		Published: PublicationDate{Year: 2024}, // year only, no month/day
+	}
+
+	got := MergeUpdate(existing, incoming)
+	if got.Published.Month != 0 || got.Published.Day != 0 {
+		t.Errorf("Month/Day should reset to incoming's zero values, got %+v", got.Published)
+	}
+}
+
 func TestMergeUpdate_NoChangeWhenIncomingMatchesExisting(t *testing.T) {
 	// Stability check: if existing and incoming are equal, the merge result
 	// must be byte-identical when marshaled. Guards against accidental

--- a/internal/reference/merge_test.go
+++ b/internal/reference/merge_test.go
@@ -1,0 +1,160 @@
+package reference
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestMergeUpdate_PreservesExternalIdentifiers(t *testing.T) {
+	// Real case: refs.jsonl has a PMCID from `bip ncbi backfill`. A
+	// Paperpile re-import sends the same ref with no PMCID field. The merge
+	// must keep the existing PMCID.
+	existing := Reference{
+		ID:    "Smith2024-aa",
+		DOI:   "10.1038/foo",
+		Title: "Foo",
+		PMCID: "PMC123",
+		PMID:  "456",
+		S2ID:  "abc",
+	}
+	incoming := Reference{
+		ID:     "Smith2024-aa",
+		DOI:    "10.1038/foo",
+		Title:  "Foo (updated title)",
+		Source: ImportSource{Type: "paperpile", ID: "uuid-1"},
+		// No PMCID/PMID/S2ID — Paperpile doesn't carry these.
+	}
+
+	got := MergeUpdate(existing, incoming)
+	if got.PMCID != "PMC123" {
+		t.Errorf("PMCID lost: got %q, want PMC123", got.PMCID)
+	}
+	if got.PMID != "456" {
+		t.Errorf("PMID lost: got %q, want 456", got.PMID)
+	}
+	if got.S2ID != "abc" {
+		t.Errorf("S2ID lost: got %q, want abc", got.S2ID)
+	}
+	if got.Title != "Foo (updated title)" {
+		t.Errorf("incoming Title should win when non-empty: got %q", got.Title)
+	}
+	if got.Source.Type != "paperpile" {
+		t.Errorf("Source should be taken from incoming: got %+v", got.Source)
+	}
+}
+
+func TestMergeUpdate_IncomingOverridesWhenNonZero(t *testing.T) {
+	// If both existing and incoming have a value for a field, the incoming
+	// wins. This is the standard "update" behavior — the new import is more
+	// recent and the user presumably edited it intentionally.
+	existing := Reference{
+		ID:       "x",
+		Title:    "old title",
+		Note:     "old note",
+		Abstract: "old abstract",
+		Tags:     []string{"old"},
+	}
+	incoming := Reference{
+		ID:       "x",
+		Title:    "new title",
+		Note:     "new note",
+		Abstract: "new abstract",
+		Tags:     []string{"new1", "new2"},
+		Source:   ImportSource{Type: "paperpile", ID: "uuid"},
+	}
+
+	got := MergeUpdate(existing, incoming)
+	if got.Title != "new title" || got.Note != "new note" || got.Abstract != "new abstract" {
+		t.Errorf("incoming should override existing for non-empty fields: %+v", got)
+	}
+	if len(got.Tags) != 2 || got.Tags[0] != "new1" {
+		t.Errorf("incoming Tags should override: got %v", got.Tags)
+	}
+}
+
+func TestMergeUpdate_IDAndSourceAlwaysFromIncoming(t *testing.T) {
+	// ID and Source describe the import event, not the ref's content. They
+	// must always come from the incoming side, even when the existing values
+	// look "more complete."
+	existing := Reference{
+		ID:     "OldKey2020-ab",
+		Source: ImportSource{Type: "manual", ID: "manual-1"},
+	}
+	incoming := Reference{
+		ID:     "NewKey2024-cd",
+		Source: ImportSource{Type: "paperpile", ID: "uuid-new"},
+	}
+
+	got := MergeUpdate(existing, incoming)
+	if got.ID != "NewKey2024-cd" {
+		t.Errorf("ID should be from incoming: got %q", got.ID)
+	}
+	if got.Source.Type != "paperpile" || got.Source.ID != "uuid-new" {
+		t.Errorf("Source should be from incoming: got %+v", got.Source)
+	}
+}
+
+func TestMergeUpdate_PreservesPDFAndSupplementPaths(t *testing.T) {
+	// PDFPath is often added or updated post-import (e.g., by `bip s2 linkpub`)
+	// or set by Paperpile itself. Either way, if incoming doesn't carry it,
+	// preserve.
+	existing := Reference{
+		ID:              "x",
+		PDFPath:         "Smith/2024/Smith2024-aa.pdf",
+		SupplementPaths: []string{"Smith/2024/Smith2024-aa-supp.pdf"},
+	}
+	incoming := Reference{
+		ID:     "x",
+		Source: ImportSource{Type: "paperpile", ID: "uuid"},
+	}
+
+	got := MergeUpdate(existing, incoming)
+	if got.PDFPath != "Smith/2024/Smith2024-aa.pdf" {
+		t.Errorf("PDFPath lost: got %q", got.PDFPath)
+	}
+	if len(got.SupplementPaths) != 1 {
+		t.Errorf("SupplementPaths lost: got %v", got.SupplementPaths)
+	}
+}
+
+func TestMergeUpdate_PreservesYearOnUndatedImport(t *testing.T) {
+	// A Paperpile entry without a year imports as `Published.Year: 0` (with
+	// a `paperpile:incomplete` tag). The merge must not blow away an existing
+	// real year — that would be a regression on data quality.
+	existing := Reference{
+		ID:        "x",
+		Published: PublicationDate{Year: 2020, Month: 6, Day: 15},
+	}
+	incoming := Reference{
+		ID:     "x",
+		Source: ImportSource{Type: "paperpile", ID: "uuid"},
+		// Year: 0
+	}
+
+	got := MergeUpdate(existing, incoming)
+	if got.Published.Year != 2020 || got.Published.Month != 6 || got.Published.Day != 15 {
+		t.Errorf("Published date lost: got %+v", got.Published)
+	}
+}
+
+func TestMergeUpdate_NoChangeWhenIncomingMatchesExisting(t *testing.T) {
+	// Stability check: if existing and incoming are equal, the merge result
+	// must be byte-identical when marshaled. Guards against accidental
+	// transformations (e.g., normalizing slice ordering).
+	r := Reference{
+		ID:        "x",
+		DOI:       "10.1/A",
+		Title:     "Foo",
+		Tags:      []string{"a", "b"},
+		Authors:   []Author{{First: "J", Last: "S"}},
+		Published: PublicationDate{Year: 2024},
+		Source:    ImportSource{Type: "paperpile", ID: "uuid"},
+		PMCID:     "PMC1",
+	}
+	got := MergeUpdate(r, r)
+	a, _ := json.Marshal(r)
+	b, _ := json.Marshal(got)
+	if string(a) != string(b) {
+		t.Errorf("identity merge changed bytes:\n  in:  %s\n  out: %s", a, b)
+	}
+}


### PR DESCRIPTION
🤖

## Summary

`bip import --format paperpile` previously did a wholesale replace on every matched ref, silently wiping any field the Paperpile export didn't carry — notably `PMCID`, `PMID`, `ArXivID`, `S2ID`, and PDF paths added by `bip s2 linkpub`. Surfaced while building #146 (`bip ncbi backfill`): the freshly-backfilled PMCIDs would all evaporate on the next routine re-import.

Reproduced live on the real nexus library: **12 freshly-backfilled PMCIDs → 0 after one `bip import` re-run**.

## Fix

New `reference.MergeUpdate(existing, incoming) Reference`. On update, an incoming non-zero field wins (standard update behavior); an incoming zero field falls back to the existing value. `ID` and `Source` are always taken from incoming because they describe the import event itself, not the ref's content.

Wired into `persistImports` at the single update site (`cmd/bip/import.go`).

## Trade-off worth knowing

The merge preserves a field whenever the incoming side is empty. So if you clear a tag in Paperpile, the next re-import won't propagate that clearing — the incoming empty `Tags` falls back to the existing tags. Same for clearing a note, abstract, etc. This is the price of preserving externally-resolved fields. A true wipe now requires editing `refs.jsonl` directly. Given the alternative (silent loss of every backfilled PMCID), this is the right default.

## Verification

End-to-end on the real nexus, `git reset --hard` between runs:

**Before fix:**
```
PMCIDs before backfill:               4
After bip ncbi backfill --limit 20:  16   (+12)
After bip import re-run:              4   (-12, wiped)
```

**After fix:**
```
PMCIDs before backfill:               4
After bip ncbi backfill --limit 20:  16   (+12)
After bip import re-run:             16   (preserved)
```

## Test plan

- [x] `TestMergeUpdate_PreservesExternalIdentifiers` — PMCID, PMID, S2ID survive when incoming doesn't carry them.
- [x] `TestMergeUpdate_IncomingOverridesWhenNonZero` — standard update behavior when both sides have a value.
- [x] `TestMergeUpdate_IDAndSourceAlwaysFromIncoming` — ID/Source describe the import event, always from incoming.
- [x] `TestMergeUpdate_PreservesPDFAndSupplementPaths` — PDF paths added by `bip s2 linkpub` are preserved.
- [x] `TestMergeUpdate_PreservesYearOnUndatedImport` — `Published.Year: 0` in incoming doesn't wipe an existing real year.
- [x] `TestMergeUpdate_NoChangeWhenIncomingMatchesExisting` — identity merge is byte-stable.
- [x] `TestPersistImports_PreservesPostImportFields` — file-level integration: round-trip through `persistImports` and `storage.ReadAll` confirms the merge actually reaches disk.