### PR TITLE
Make worktrees a first-class, opt-in layout option across the bip surface

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,9 @@ new schema silently won't take.
   `~/.config/bip/config.yml`. Order — GitHub: `BIP_GITHUB_TOKEN` → `GITHUB_TOKEN` → `GH_TOKEN`
   → config; Slack: `BIP_SLACK_TOKEN` → `SLACK_BOT_TOKEN` → config. Prefer the `BIP_*` names,
   sourced from a secrets manager (e.g. 1Password `op run` / `op read`).
+- Per-issue git worktrees are opt-in via a `layout:` block in `~/.config/bip/config.yml`
+  (per-repo overrides in `sources.yml`). Absent block = today's clone-per-repo behavior.
+  Schema and precedence: `docs/guides/layout.md`. The resolver is `flow.ResolveRepoPath`.
 
 ## Paper lookups (guardrail)
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,9 @@ what you want `bip` to use.
 
 See the [Configuration Guide](https://matsen.github.io/bipartite/guides/configuration/) for all options.
 
+To opt into per-issue git worktrees for `bip spawn` (instead of one
+shared clone per repo), see [docs/guides/layout.md](docs/guides/layout.md).
+
 ## Who Is This For?
 
 Bipartite isn't just for people who hold the official PI title. It's for anyone who wants to work with a team of agents the way a PI works with a team of researchers — directing the science at a high level while detailed work runs across many parallel sessions.

--- a/cmd/bip/epic_watch.go
+++ b/cmd/bip/epic_watch.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/matsen/bipartite/internal/config"
+	"github.com/matsen/bipartite/internal/flow"
 	"github.com/spf13/cobra"
 )
 
@@ -200,32 +201,26 @@ func loadEpicConfig(dir string) (*epicConfig, error) {
 
 // resolveSlots returns the slots to watch given the config.
 // Clone mode: one slot per entry in clone_names.
-// Worktree mode: one slot per existing issue-* subdirectory of clone_root.
+// Worktree mode: one slot per existing issue-* subdirectory of clone_root,
+// discovered via flow.ListWorktreeSlots (which shares the slot-prefix
+// convention with flow.ResolveRepoPath — see issue #149).
 // Returns an empty slice (no error) if the worktree mode clone_root has no
 // issue-* subdirectories yet — the caller decides whether that is fatal.
 func resolveSlots(repoDir string, cfg *epicConfig) ([]slotInfo, error) {
-	cloneRoot, err := expandPath(cfg.CloneRoot)
-	if err != nil {
-		return nil, fmt.Errorf("expanding clone_root %q: %w", cfg.CloneRoot, err)
-	}
+	// config.ExpandTilde is the same expansion ResolveRepoPath uses for
+	// worktree.root, so EPIC and bip spawn agree on how "~/re/foo" resolves.
+	cloneRoot := config.ExpandTilde(cfg.CloneRoot)
 	if !filepath.IsAbs(cloneRoot) {
 		cloneRoot = filepath.Join(repoDir, cloneRoot)
 	}
 
 	if cfg.LocalWorktrees {
-		entries, err := os.ReadDir(cloneRoot)
+		names, err := flow.ListWorktreeSlots(cloneRoot)
 		if err != nil {
 			return nil, fmt.Errorf("reading clone_root %s: %w", cloneRoot, err)
 		}
 		var slots []slotInfo
-		for _, e := range entries {
-			name := e.Name()
-			// Share the issue-* prefix with flow.DefaultSlotTemplate so a
-			// change to the convention has a single edit point — see
-			// config.WorktreeSlotPrefix.
-			if !e.IsDir() || !strings.HasPrefix(name, config.WorktreeSlotPrefix) {
-				continue
-			}
+		for _, name := range names {
 			slots = append(slots, slotInfo{
 				name:       name,
 				statusPath: filepath.Join(cloneRoot, name, epicStatusName),
@@ -242,19 +237,6 @@ func resolveSlots(repoDir string, cfg *epicConfig) ([]slotInfo, error) {
 		})
 	}
 	return slots, nil
-}
-
-// expandPath expands a leading ~/ to the user's home directory.
-// Returns an error if the home directory cannot be resolved.
-func expandPath(p string) (string, error) {
-	if !strings.HasPrefix(p, "~/") {
-		return p, nil
-	}
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(home, p[2:]), nil
 }
 
 // parsePhasesFilter parses the comma-separated --phases value.

--- a/cmd/bip/epic_watch.go
+++ b/cmd/bip/epic_watch.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/fsnotify/fsnotify"
+	"github.com/matsen/bipartite/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -186,7 +187,10 @@ func loadEpicConfig(dir string) (*epicConfig, error) {
 		return nil, fmt.Errorf("%s: clone_root is required", path)
 	}
 	if cfg.LocalWorktrees && len(cfg.CloneNames) > 0 {
-		return nil, fmt.Errorf("%s: local_worktrees and clone_names are mutually exclusive", path)
+		// Deprecation hint: the `.epic-config.json` mutex case predates the
+		// global `layout:` block (issue #149). Existing EPICs keep working,
+		// but the error message points users toward the new YAML form.
+		return nil, fmt.Errorf("%s: local_worktrees and clone_names are mutually exclusive (deprecated: prefer the `layout:` block in ~/.config/bip/config.yml; see docs/guides/layout.md)", path)
 	}
 	if !cfg.LocalWorktrees && len(cfg.CloneNames) == 0 {
 		return nil, fmt.Errorf("%s: must set local_worktrees: true or clone_names: [...]", path)
@@ -216,7 +220,10 @@ func resolveSlots(repoDir string, cfg *epicConfig) ([]slotInfo, error) {
 		var slots []slotInfo
 		for _, e := range entries {
 			name := e.Name()
-			if !e.IsDir() || !strings.HasPrefix(name, "issue-") {
+			// Share the issue-* prefix with flow.DefaultSlotTemplate so a
+			// change to the convention has a single edit point — see
+			// config.WorktreeSlotPrefix.
+			if !e.IsDir() || !strings.HasPrefix(name, config.WorktreeSlotPrefix) {
 				continue
 			}
 			slots = append(slots, slotInfo{

--- a/cmd/bip/spawn.go
+++ b/cmd/bip/spawn.go
@@ -167,6 +167,16 @@ func runSpawn(cmd *cobra.Command, args []string) {
 			fmt.Fprintf(os.Stderr, "Note: worktree mode is configured but this spawn has no issue/PR context; using canonical clone %s\n", resolved.Path)
 		}
 		if resolved.Mode == config.LayoutModeWorktree && resolved.IsNew {
+			// IsNew is filesystem-based (the directory is absent). If git
+			// still has it registered as a worktree — e.g. the directory was
+			// deleted by hand instead of via `bip worktree remove` — then
+			// `git worktree add` would fail with an arcane message. Detect
+			// that and point the user at the fix.
+			if registered, _ := gitx.WorktreeExists(canonicalClone, resolved.Path); registered {
+				fmt.Fprintf(os.Stderr, "Error: %s is registered as a worktree but its directory is missing.\n", resolved.Path)
+				fmt.Fprintf(os.Stderr, "Run `git -C %s worktree prune` (or `bip worktree remove %s`) and retry.\n", canonicalClone, resolved.Path)
+				os.Exit(1)
+			}
 			fmt.Fprintf(os.Stderr, "Creating worktree at %s on branch %s\n", resolved.Path, resolved.Branch)
 			if err := gitx.AddWorktree(canonicalClone, resolved.Path, resolved.Branch); err != nil {
 				fmt.Fprintf(os.Stderr, "Error: %v\n", err)

--- a/cmd/bip/spawn.go
+++ b/cmd/bip/spawn.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -12,6 +13,7 @@ import (
 	"github.com/matsen/bipartite/internal/config"
 	"github.com/matsen/bipartite/internal/flow"
 	"github.com/matsen/bipartite/internal/flow/spawn"
+	"github.com/matsen/bipartite/internal/gitx"
 	"github.com/spf13/cobra"
 )
 
@@ -85,27 +87,38 @@ func runSpawn(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	// Resolve working directory
+	// Resolve working directory. Three paths:
+	//   --dir override: skip the resolver entirely.
+	//   default:        early-resolve to validate the repo is in sources.yml
+	//                   and the canonical clone exists on disk, then (after
+	//                   data fetch) re-resolve with a full context so
+	//                   worktree mode can pick a per-issue directory.
 	var repoPath string
+	var canonicalClone string // primary clone; equals repoPath in clone mode.
 	if spawnDir != "" {
 		repoPath = mustValidateDir(spawnDir)
+		canonicalClone = repoPath
 		fmt.Fprintf(os.Stderr, "Using custom directory: %s\n", repoPath)
 	} else {
-		// Validate repo is in sources.yml and has local clone
-		var found bool
-		repoPath, found = flow.GetRepoLocalPath(nexusPath, ref.Repo)
-		if !found {
-			fmt.Fprintf(os.Stderr, "Error: Repo %s not found in sources.yml\n", ref.Repo)
-			fmt.Fprintf(os.Stderr, "Add it to sources.yml under 'code' or 'writing' category\n")
+		earlyResolve, err := flow.ResolveRepoPath(nexusPath, ref.Repo, flow.ResolveContext{})
+		if err != nil {
+			if errors.Is(err, flow.ErrRepoNotInSources) {
+				fmt.Fprintf(os.Stderr, "Error: Repo %s not found in sources.yml\n", ref.Repo)
+				fmt.Fprintf(os.Stderr, "Add it to sources.yml under 'code' or 'writing' category\n")
+				os.Exit(1)
+			}
+			fmt.Fprintf(os.Stderr, "Error: resolving repo path: %v\n", err)
 			os.Exit(1)
 		}
-
-		// Check local clone exists
-		if _, err := os.Stat(repoPath); os.IsNotExist(err) {
-			fmt.Fprintf(os.Stderr, "Error: Local clone not found at %s\n", repoPath)
-			fmt.Fprintf(os.Stderr, "Clone it with: git clone git@github.com:%s.git %s\n", ref.Repo, repoPath)
+		// earlyResolve.Path is always the canonical clone (worktree mode
+		// with an empty context falls back to canonical).
+		canonicalClone = earlyResolve.Path
+		if _, err := os.Stat(canonicalClone); os.IsNotExist(err) {
+			fmt.Fprintf(os.Stderr, "Error: Local clone not found at %s\n", canonicalClone)
+			fmt.Fprintf(os.Stderr, "Clone it with: git clone git@github.com:%s.git %s\n", ref.Repo, canonicalClone)
 			os.Exit(1)
 		}
+		// repoPath is filled in below once we know the issue/PR context.
 	}
 
 	// Detect item type if not known from URL
@@ -132,6 +145,35 @@ func runSpawn(cmd *cobra.Command, args []string) {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
+	}
+
+	// Final path resolution: now we have a title (and so a slug) plus a
+	// confirmed item type. The resolver picks the canonical clone in clone
+	// mode (matching today's behavior) and worktree.root/issue-N in
+	// worktree mode. We only do this when --dir was not used.
+	if spawnDir == "" {
+		rctx := flow.ResolveContext{Slug: flow.SlugifyTitle(data.Title)}
+		if itemType == "pr" {
+			rctx.PRNumber = ref.Number
+		} else {
+			rctx.IssueNumber = ref.Number
+		}
+		resolved, err := flow.ResolveRepoPath(nexusPath, ref.Repo, rctx)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: resolving repo path: %v\n", err)
+			os.Exit(1)
+		}
+		if resolved.FellBack {
+			fmt.Fprintf(os.Stderr, "Note: worktree mode is configured but this spawn has no issue/PR context; using canonical clone %s\n", resolved.Path)
+		}
+		if resolved.Mode == config.LayoutModeWorktree && resolved.IsNew {
+			fmt.Fprintf(os.Stderr, "Creating worktree at %s on branch %s\n", resolved.Path, resolved.Branch)
+			if err := gitx.AddWorktree(canonicalClone, resolved.Path, resolved.Branch); err != nil {
+				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+				os.Exit(1)
+			}
+		}
+		repoPath = resolved.Path
 	}
 
 	// Build window name

--- a/cmd/bip/spawn_test.go
+++ b/cmd/bip/spawn_test.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/matsen/bipartite/internal/config"
+	"github.com/matsen/bipartite/internal/flow"
+	"github.com/matsen/bipartite/internal/gitx"
+)
+
+// TestSpawnWorktreeIntegration exercises the flow.ResolveRepoPath +
+// gitx.AddWorktree composition that bip spawn uses in worktree mode,
+// without invoking runSpawn (which shells out to gh and tmux). It covers
+// the two end-to-end behaviors the issue's test plan calls out:
+//
+//   - Worktree creation: resolver returns IsNew=true on a fresh path, and
+//     gitx.AddWorktree actually creates the directory on the named branch.
+//   - Reuse: resolving the same issue twice has IsNew=false on the second
+//     call, so spawn would skip the `git worktree add` invocation.
+func TestSpawnWorktreeIntegration(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not in PATH")
+	}
+
+	root := t.TempDir()
+	nexus := filepath.Join(root, "nexus")
+	if err := os.MkdirAll(nexus, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Initialize a primary clone with one commit so `git worktree add` works.
+	codeDir := filepath.Join(root, "code")
+	if err := os.MkdirAll(codeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	primary := filepath.Join(codeDir, "bipartite")
+	mustRun(t, "", "git", "init", "--quiet", "--initial-branch=main", primary)
+	mustRun(t, primary, "git", "config", "user.email", "test@example.com")
+	mustRun(t, primary, "git", "config", "user.name", "Test")
+	mustRun(t, primary, "git", "config", "commit.gpgsign", "false")
+	if err := os.WriteFile(filepath.Join(primary, "README.md"), []byte("hi\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustRun(t, primary, "git", "add", "README.md")
+	mustRun(t, primary, "git", "commit", "--quiet", "-m", "initial")
+
+	// Wire up sources.yml + flow config + global config in worktree mode.
+	wtRoot := filepath.Join(root, "workers")
+	sourcesYAML := `code:
+  - repo: matsen/bipartite
+`
+	if err := os.WriteFile(filepath.Join(nexus, "sources.yml"), []byte(sourcesYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	flowCfg := "paths:\n  code: " + codeDir + "\n"
+	if err := os.WriteFile(filepath.Join(nexus, "config.yml"), []byte(flowCfg), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfgHome := filepath.Join(root, "xdg")
+	if err := os.MkdirAll(filepath.Join(cfgHome, "bip"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	globalYAML := "layout:\n  mode: worktree\n  worktree:\n    root: " + wtRoot + "/{repo}-workers\n"
+	if err := os.WriteFile(filepath.Join(cfgHome, "bip", "config.yml"), []byte(globalYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("XDG_CONFIG_HOME", cfgHome)
+	config.ResetGlobalConfigCache()
+	t.Cleanup(config.ResetGlobalConfigCache)
+
+	ctx := flow.ResolveContext{IssueNumber: 149, Slug: "worktrees"}
+	resolved, err := flow.ResolveRepoPath(nexus, "matsen/bipartite", ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved.Mode != config.LayoutModeWorktree {
+		t.Fatalf("Mode = %q, want worktree", resolved.Mode)
+	}
+	if !resolved.IsNew {
+		t.Errorf("IsNew = false, want true for a fresh path")
+	}
+	if resolved.Branch != "149-worktrees" {
+		t.Errorf("Branch = %q, want 149-worktrees", resolved.Branch)
+	}
+
+	if err := gitx.AddWorktree(primary, resolved.Path, resolved.Branch); err != nil {
+		t.Fatalf("AddWorktree: %v", err)
+	}
+	if _, err := os.Stat(resolved.Path); err != nil {
+		t.Fatalf("worktree not created at %s: %v", resolved.Path, err)
+	}
+
+	// Reuse: second resolve must report IsNew=false now that the worktree
+	// is on disk. spawn keys off this to skip a redundant `git worktree add`.
+	resolved2, err := flow.ResolveRepoPath(nexus, "matsen/bipartite", ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved2.IsNew {
+		t.Errorf("second resolve: IsNew = true, want false (worktree already exists)")
+	}
+	if resolved2.Path != resolved.Path {
+		t.Errorf("second resolve path drift: %q vs %q", resolved2.Path, resolved.Path)
+	}
+}
+
+func mustRun(t *testing.T, dir, name string, args ...string) {
+	t.Helper()
+	cmd := exec.Command(name, args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("%s %s: %v\n%s", name, strings.Join(args, " "), err, out)
+	}
+}

--- a/cmd/bip/worktree.go
+++ b/cmd/bip/worktree.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/matsen/bipartite/internal/gitx"
+	"github.com/spf13/cobra"
+)
+
+// worktreeCmd is the hidden parent of the worktree plumbing subcommands.
+// These commands are not part of bip's user-facing surface — they exist so
+// the bip-pr-land skill can call tested Go (in internal/gitx) instead of
+// re-implementing primary-clone resolution and `git worktree remove --force`
+// as untested shell pipelines in markdown. The command stays Hidden=true so
+// it does not appear in `bip --help`, completions, or docs.
+var worktreeCmd = &cobra.Command{
+	Use:    "worktree",
+	Short:  "Plumbing for git worktree operations (used by skills, hidden)",
+	Hidden: true,
+}
+
+var worktreePrimaryCmd = &cobra.Command{
+	Use:   "primary [dir]",
+	Short: "Print the primary clone directory if [dir] is a linked worktree",
+	Long: `Print the primary clone directory for a linked worktree.
+
+Exit codes:
+  0  - [dir] (default: CWD) is a linked worktree; primary path is on stdout.
+  3  - [dir] is the primary clone (or not a worktree at all); no stdout.
+  1  - [dir] is not a git repository, or git itself failed.
+
+Designed for shell use:
+    if PRIMARY=$(bip worktree primary 2>/dev/null); then
+        cd "$PRIMARY"
+        ...
+    fi`,
+	Hidden: true,
+	Args:   cobra.MaximumNArgs(1),
+	RunE:   runWorktreePrimary,
+}
+
+var worktreeRemoveCmd = &cobra.Command{
+	Use:   "remove <path>",
+	Short: "Remove the worktree at <path> (auto-resolves the primary clone)",
+	Long: `Remove a linked worktree.
+
+Equivalent to running 'git worktree remove --force <path>' from the primary
+clone, but the primary is auto-resolved from <path> itself, so the caller
+does not need to know or cd into it.`,
+	Hidden: true,
+	Args:   cobra.ExactArgs(1),
+	RunE:   runWorktreeRemove,
+}
+
+var (
+	worktreeRemoveForce bool
+	worktreeRemoveFrom  string
+)
+
+func init() {
+	worktreeCmd.AddCommand(worktreePrimaryCmd)
+	worktreeCmd.AddCommand(worktreeRemoveCmd)
+	worktreeRemoveCmd.Flags().BoolVar(&worktreeRemoveForce, "force", true,
+		"Pass --force to git worktree remove (default true; required after squash merge)")
+	worktreeRemoveCmd.Flags().StringVar(&worktreeRemoveFrom, "from", "",
+		"Primary clone directory (default: auto-resolved from <path>)")
+	rootCmd.AddCommand(worktreeCmd)
+}
+
+func runWorktreePrimary(cmd *cobra.Command, args []string) error {
+	dir, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	if len(args) == 1 {
+		dir = args[0]
+	}
+	inWT, err := gitx.IsInWorktree(dir)
+	if err != nil {
+		// Not a git repository, or git failed. Surface as a normal error
+		// (exit 1) so the caller can distinguish "not in a worktree"
+		// (exit 3) from "not a repo at all."
+		return err
+	}
+	if !inWT {
+		os.Exit(3)
+	}
+	primary, err := gitx.PrimaryCloneDir(dir)
+	if err != nil {
+		return err
+	}
+	fmt.Println(primary)
+	return nil
+}
+
+func runWorktreeRemove(cmd *cobra.Command, args []string) error {
+	path := args[0]
+	primary := worktreeRemoveFrom
+	if primary == "" {
+		p, err := gitx.PrimaryCloneDir(path)
+		if err != nil {
+			return fmt.Errorf("could not resolve primary clone from %s: %w (pass --from)", path, err)
+		}
+		primary = p
+	}
+	return gitx.RemoveWorktree(primary, path, worktreeRemoveForce)
+}

--- a/docs/guides/layout.md
+++ b/docs/guides/layout.md
@@ -1,0 +1,148 @@
+# Repo layout configuration
+
+The `layout:` block tells `bip` *where on disk a repo's working tree
+lives*. It is opt-in: with no block configured anywhere, `bip` behaves
+exactly as it did before issue #149 — one canonical clone per repo,
+under `paths.code` (or `paths.writing`).
+
+This guide covers the schema, precedence, template variables, and a
+migration tip for EPIC users.
+
+## Schema
+
+There are two places `layout:` may appear:
+
+### 1. Global default — `~/.config/bip/config.yml`
+
+This is per-machine — your personal preference, not shared with others
+on the same nexus.
+
+```yaml
+nexus_path: ~/re/nexus
+# ...other global keys (api keys, tokens)...
+
+# Optional. Absent block = clone mode (today's behavior).
+layout:
+  mode: clone                       # clone | worktree   (default: clone)
+  worktree:
+    root: "~/re/{repo}-workers"     # template; {repo} = matsen/bipartite → "bipartite"
+    slot: "issue-{issue}"           # template; {issue}, {pr}, {branch}, {slug}
+  clone:
+    root: "~/re"                    # defaults to paths.code if absent
+    names: []                       # EPIC-style multi-clone pool; empty = single canonical clone
+```
+
+The nested-per-mode shape is deliberate: with `mode: clone` the
+`worktree:` block is inert, and vice versa. There is no
+conditional-field anti-pattern; both blocks may be present and only the
+selected mode's settings are consulted.
+
+### 2. Per-repo override — `sources.yml`
+
+`sources.yml` lives in the nexus (shared across users of that nexus),
+so per-repo overrides express **repo-specific** facts (this repo needs
+a different worktree root because it's huge, this repo opts out of
+worktree mode entirely), not personal preferences.
+
+```yaml
+code:
+  - repo: matsen/bipartite
+    channel: bip
+    # inherits global layout — most repos look like this
+
+  - repo: matsen/tiny-docs
+    channel: docs
+    layout:
+      mode: clone        # opt OUT of global worktree default for this repo
+
+  - repo: matsen/big-thing
+    channel: bt
+    layout:
+      worktree:
+        root: ~/re/bt-special-workers   # bigger drive
+```
+
+## Precedence
+
+Each leaf field resolves independently:
+
+```
+per-repo sources.yml layout  >  global config.yml layout  >  built-in default (clone)
+```
+
+Example. Global sets `mode: worktree` and `worktree.slot:
+"issue-{issue}"`. A per-repo entry overrides only `worktree.root`. The
+result for that repo:
+
+- `mode` — `worktree` (inherited from global)
+- `worktree.root` — the per-repo value
+- `worktree.slot` — `"issue-{issue}"` (inherited from global)
+
+## Template variables
+
+`worktree.root` supports:
+
+| Variable | Meaning |
+|----------|---------|
+| `{repo}` | The repo name (e.g. `matsen/bipartite` → `bipartite`) |
+| `{code}` | Expanded value of `paths.code` from `$NEXUS_PATH/config.yml` |
+
+`worktree.slot` supports:
+
+| Variable | Meaning |
+|----------|---------|
+| `{issue}` | Issue number (empty when called for a PR ref) |
+| `{pr}`    | PR number (empty when called for an issue ref) |
+| `{branch}` | Branch name (`<N>-<slug>` by default) |
+| `{slug}`  | Slugified GitHub issue/PR title (lowercase, ASCII, `-` separated, 40 chars max) |
+
+Unknown placeholders error at **resolve time** (not config-load time),
+so a typo in an opt-in template will not break read-only commands like
+`bip checkin` for users who never opt in.
+
+Tilde expansion runs after template substitution.
+
+## Defaults
+
+If `layout.mode: worktree` is set without further detail:
+
+- `worktree.root` defaults to `{code}/{repo}-workers`
+- `worktree.slot` defaults to `issue-{issue}`
+
+So a minimal opt-in is just:
+
+```yaml
+layout:
+  mode: worktree
+```
+
+## What happens when `bip spawn` runs in worktree mode
+
+1. `bip spawn matsen/bipartite#149` resolves the repo's canonical
+   clone (used for `git worktree add`).
+2. It fetches the issue title and slugifies it.
+3. It resolves the worktree path:
+   `worktree.root / worktree.slot` (with the variables filled in).
+4. If that path does not yet exist, it runs
+   `git worktree add <path> -b <N>-<slug>` from the canonical clone.
+5. The tmux window opens in the worktree.
+
+If `bip spawn` is invoked without an issue or PR ref (an adhoc session
+or one of the manual-`--dir` paths), worktree mode falls back to the
+canonical clone and prints a one-line note — there is no silent
+empty-string substitution into the slot template.
+
+When `bip pr-land` later runs from that worktree, it detects the
+worktree via `bip worktree primary`, runs the squash merge from the
+primary clone, and removes the worktree via `bip worktree remove`
+before deleting the branch.
+
+## Migration from `.epic-config.json`
+
+EPIC orchestration still reads `.epic-config.json` (its three
+fields — `clone_root`, `clone_names`, `local_worktrees` — are
+unchanged). The global `layout:` block is the preferred way to
+configure worktree mode for *non-EPIC* `bip spawn`. Existing EPICs keep
+working without any change. The EPIC config will be deprecated in favor
+of the YAML form in a future PR once the new form has been used in
+anger.

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -18,6 +18,11 @@ type GlobalConfig struct {
 	SlackBotToken string            `yaml:"slack_bot_token,omitempty"`
 	GitHubToken   string            `yaml:"github_token,omitempty"`
 	SlackWebhooks map[string]string `yaml:"slack_webhooks,omitempty"`
+
+	// Layout, when set, is the per-machine default for repo working-directory
+	// resolution. Read by flow.ResolveRepoPath. Optional; an absent block
+	// leaves bip in its pre-issue-149 clone-mode behavior.
+	Layout *LayoutConfig `yaml:"layout,omitempty"`
 }
 
 const (

--- a/internal/config/layout.go
+++ b/internal/config/layout.go
@@ -1,0 +1,60 @@
+package config
+
+// LayoutConfig describes how bip resolves working directories for repos.
+// It can appear in two places:
+//   - ~/.config/bip/config.yml under `layout:` (per-machine default; applies
+//     to every repo unless overridden).
+//   - sources.yml on a `RepoEntry` (per-repo override).
+//
+// Each leaf field resolves independently: per-repo settings override global,
+// and any field left zero inherits from the next tier. The block is opt-in;
+// when absent everywhere the resolver behaves identically to pre-issue-149.
+type LayoutConfig struct {
+	// Mode selects the layout: LayoutModeClone (default) or LayoutModeWorktree.
+	Mode string `yaml:"mode,omitempty"`
+
+	// Worktree configures worktree-mode resolution.
+	Worktree *WorktreeLayout `yaml:"worktree,omitempty"`
+
+	// Clone configures clone-mode resolution.
+	Clone *CloneLayout `yaml:"clone,omitempty"`
+}
+
+// WorktreeLayout configures worktree-mode resolution.
+//
+// Root is a template for the directory under which per-issue worktrees live.
+// Slot is a template for the per-issue directory name. See the package doc
+// on expandTemplate (in internal/flow) for the supported variables.
+type WorktreeLayout struct {
+	Root string `yaml:"root,omitempty"`
+	Slot string `yaml:"slot,omitempty"`
+}
+
+// CloneLayout configures clone-mode resolution.
+//
+// Root, when set, overrides paths.code as the parent directory of the
+// canonical clone. Names is an EPIC-style multi-clone pool (used by
+// epic_watch); an empty list means "single canonical clone."
+type CloneLayout struct {
+	Root  string   `yaml:"root,omitempty"`
+	Names []string `yaml:"names,omitempty"`
+}
+
+// Layout mode values.
+const (
+	LayoutModeClone    = "clone"
+	LayoutModeWorktree = "worktree"
+)
+
+// DefaultSlotTemplate is the slot template used when worktree.slot is unset.
+// It matches the EPIC convention of issue-<N> directories.
+const DefaultSlotTemplate = "issue-{issue}"
+
+// DefaultRootTemplate is the worktree.root template used when worktree.root
+// is unset. {code} expands to paths.code from $NEXUS_PATH/config.yml.
+const DefaultRootTemplate = "{code}/{repo}-workers"
+
+// WorktreeSlotPrefix is the directory-name prefix used by the default slot
+// template. EPIC's worktree-discovery scan (cmd/bip/epic_watch.go) keys off
+// this prefix when filtering issue-* subdirectories.
+const WorktreeSlotPrefix = "issue-"

--- a/internal/flow/cache.go
+++ b/internal/flow/cache.go
@@ -1,0 +1,76 @@
+package flow
+
+import (
+	"os"
+	"sync"
+)
+
+// File-level cache for sources.yml and the nexus config.yml. Both files are
+// read repeatedly from a single command invocation (every flow.LoadSources
+// helper, every flow.ResolveRepoPath call), and they never change mid-run.
+// We key on (path, mtime, size) so a hot reload — say a test that rewrites
+// the file in-place — invalidates automatically.
+//
+// The global ~/.config/bip/config.yml has its own cache in internal/config;
+// this cache covers the two nexus-relative files.
+
+type cacheEntry struct {
+	mtimeNS int64
+	size    int64
+	value   interface{}
+}
+
+var (
+	fileCacheMu sync.Mutex
+	fileCache   = map[string]cacheEntry{}
+)
+
+// cachedLoad returns a cached parse if the file's mtime+size match a prior
+// read, otherwise it invokes load, caches the result, and returns it. The
+// load closure is responsible for reading the file itself — cachedLoad does
+// not pass the bytes through, so the on-disk content has one canonical
+// parsing pathway. Any error from load is returned without caching.
+//
+// Callers must use a stable absolute path (or at least the same string each
+// time) — relative paths under different working directories will appear as
+// distinct cache keys.
+func cachedLoad(path string, load func() (interface{}, error)) (interface{}, error) {
+	info, statErr := os.Stat(path)
+	// If stat fails (missing file), skip the cache fast-path and let load()
+	// produce the canonical error. We do not negatively cache.
+	if statErr == nil {
+		fileCacheMu.Lock()
+		entry, ok := fileCache[path]
+		fileCacheMu.Unlock()
+		if ok && entry.mtimeNS == info.ModTime().UnixNano() && entry.size == info.Size() {
+			return entry.value, nil
+		}
+	}
+	val, err := load()
+	if err != nil {
+		return nil, err
+	}
+	// Re-stat after a successful read so the cache key reflects the file we
+	// actually parsed (between the first stat and the read, the file could
+	// have rotated).
+	info, statErr = os.Stat(path)
+	if statErr == nil {
+		fileCacheMu.Lock()
+		fileCache[path] = cacheEntry{
+			mtimeNS: info.ModTime().UnixNano(),
+			size:    info.Size(),
+			value:   val,
+		}
+		fileCacheMu.Unlock()
+	}
+	return val, nil
+}
+
+// ResetFileCache clears the flow-package file cache. Intended for tests that
+// rewrite sources.yml or config.yml in place at sub-second granularity (where
+// mtime+size may not distinguish the two versions).
+func ResetFileCache() {
+	fileCacheMu.Lock()
+	fileCache = map[string]cacheEntry{}
+	fileCacheMu.Unlock()
+}

--- a/internal/flow/config.go
+++ b/internal/flow/config.go
@@ -58,8 +58,21 @@ type sourcesYAML struct {
 }
 
 // LoadSources loads and parses sources.yml from the given nexus directory.
+// Result is cached by (path, mtime, size) — see internal/flow/cache.go.
 func LoadSources(nexusPath string) (*Sources, error) {
-	data, err := os.ReadFile(SourcesPath(nexusPath))
+	path := SourcesPath(nexusPath)
+	val, err := cachedLoad(path, func() (interface{}, error) {
+		return parseSourcesFile(path)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return val.(*Sources), nil
+}
+
+// parseSourcesFile is the un-cached read+parse pathway for sources.yml.
+func parseSourcesFile(path string) (*Sources, error) {
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("reading sources.yml: %w", err)
 	}
@@ -339,7 +352,23 @@ func GetBoardsMapping(nexusPath string) (map[string]string, error) {
 
 // LoadConfig loads config.yml from the given nexus directory.
 // Returns defaults if config.yml doesn't exist.
+// Result is cached by (path, mtime, size) — see internal/flow/cache.go.
+// The "missing file" defaults path is not cached (cachedLoad sees a stat
+// failure and skips the fast path), which is fine because os.ReadFile of a
+// missing file is already cheap.
 func LoadConfig(nexusPath string) (*Config, error) {
+	path := ConfigPath(nexusPath)
+	val, err := cachedLoad(path, func() (interface{}, error) {
+		return parseConfigFile(path)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return val.(*Config), nil
+}
+
+// parseConfigFile is the un-cached read+parse pathway for config.yml.
+func parseConfigFile(path string) (*Config, error) {
 	cfg := &Config{
 		Paths: ConfigPaths{
 			Code:    DefaultCodePath,
@@ -347,7 +376,7 @@ func LoadConfig(nexusPath string) (*Config, error) {
 		},
 	}
 
-	data, err := os.ReadFile(ConfigPath(nexusPath))
+	data, err := os.ReadFile(path)
 	if os.IsNotExist(err) {
 		return cfg, nil
 	}
@@ -373,12 +402,16 @@ func ExtractRepoName(orgRepo string) string {
 
 // GetRepoLocalPath maps a GitHub repo (org/name) to its canonical clone
 // path, ignoring any `layout:` configuration. Returns the path and whether
-// the repo was found in sources.yml.
+// the repo was found in sources.yml. All errors (missing sources.yml,
+// malformed YAML, repo absent) collapse to ok=false.
 //
-// Kept as a thin wrapper over ResolveRepoPath for read-only callers
-// (bip checkin, bip board, bip scout) that only need the canonical clone.
-// Worktree-aware callers should use ResolveRepoPath directly so they receive
-// the worktree path and the IsNew/Branch hints.
+// This is the legacy (string, bool) signature; it has no live in-tree
+// callers in cmd/bip — every command now resolves via ResolveRepoPath
+// directly so config-parse errors surface with detail rather than being
+// hidden behind a generic "not found in sources.yml" message. We keep it
+// for the backward-compat assertion in
+// TestResolveRepoPath_AbsentLayoutMatchesGetRepoLocalPath and for any
+// downstream consumer (a script or kaizen) that imports flow as a library.
 func GetRepoLocalPath(nexusPath, orgRepo string) (string, bool) {
 	rp, err := ResolveRepoPath(nexusPath, orgRepo, ResolveContext{})
 	if err != nil {

--- a/internal/flow/config.go
+++ b/internal/flow/config.go
@@ -111,13 +111,20 @@ func parseRepoEntriesYAML(items []interface{}) ([]RepoEntry, error) {
 			// Simple string entry: "matsengrp/repo"
 			entries = append(entries, RepoEntry{Repo: v})
 		case map[string]interface{}:
-			// Object entry: {repo: "...", channel: "..."}
+			// Object entry: {repo: "...", channel: "...", layout: {...}}
 			entry := RepoEntry{}
 			if repo, ok := v["repo"].(string); ok {
 				entry.Repo = repo
 			}
 			if channel, ok := v["channel"].(string); ok {
 				entry.Channel = channel
+			}
+			if raw, ok := v["layout"]; ok {
+				layout, err := parseLayoutMap(raw)
+				if err != nil {
+					return nil, fmt.Errorf("invalid layout for repo %q: %w", entry.Repo, err)
+				}
+				entry.Layout = layout
 			}
 			if entry.Repo == "" {
 				return nil, fmt.Errorf("invalid repo entry: missing 'repo' field")
@@ -129,6 +136,27 @@ func parseRepoEntriesYAML(items []interface{}) ([]RepoEntry, error) {
 	}
 
 	return entries, nil
+}
+
+// parseLayoutMap decodes the per-repo layout block from sources.yml. The
+// underlying value comes from yaml.v3's untyped interface{} decode, so we
+// round-trip via YAML to leverage standard struct decoding (and catch the
+// "layout: 7" / "layout: 'worktree'" malformed cases).
+func parseLayoutMap(raw interface{}) (*config.LayoutConfig, error) {
+	if _, ok := raw.(map[string]interface{}); !ok {
+		return nil, fmt.Errorf("expected mapping, got %T", raw)
+	}
+	data, err := yaml.Marshal(raw)
+	if err != nil {
+		return nil, err
+	}
+	var layout config.LayoutConfig
+	dec := yaml.NewDecoder(strings.NewReader(string(data)))
+	dec.KnownFields(true)
+	if err := dec.Decode(&layout); err != nil {
+		return nil, err
+	}
+	return &layout, nil
 }
 
 // LoadAllRepos returns all repos from sources.yml in the given nexus directory.
@@ -343,38 +371,24 @@ func ExtractRepoName(orgRepo string) string {
 	return orgRepo
 }
 
-// GetRepoLocalPath maps a GitHub repo (org/name) to its local path.
-// Returns the path and whether the repo was found in sources.yml.
+// GetRepoLocalPath maps a GitHub repo (org/name) to its canonical clone
+// path, ignoring any `layout:` configuration. Returns the path and whether
+// the repo was found in sources.yml.
+//
+// Kept as a thin wrapper over ResolveRepoPath for read-only callers
+// (bip checkin, bip board, bip scout) that only need the canonical clone.
+// Worktree-aware callers should use ResolveRepoPath directly so they receive
+// the worktree path and the IsNew/Branch hints.
 func GetRepoLocalPath(nexusPath, orgRepo string) (string, bool) {
-	sources, err := LoadSources(nexusPath)
+	rp, err := ResolveRepoPath(nexusPath, orgRepo, ResolveContext{})
 	if err != nil {
 		return "", false
 	}
-
-	cfg, err := LoadConfig(nexusPath)
-	if err != nil {
-		return "", false
-	}
-
-	repoName := ExtractRepoName(orgRepo)
-
-	// Check writing repos first
-	for _, entry := range sources.Writing {
-		if entry.Repo == orgRepo {
-			writingPath := config.ExpandTilde(cfg.Paths.Writing)
-			return filepath.Join(writingPath, repoName), true
-		}
-	}
-
-	// Check code repos
-	for _, entry := range sources.Code {
-		if entry.Repo == orgRepo {
-			codePath := config.ExpandTilde(cfg.Paths.Code)
-			return filepath.Join(codePath, repoName), true
-		}
-	}
-
-	return "", false
+	// With an empty ResolveContext, worktree mode falls back to the canonical
+	// clone (FellBack=true, Mode=clone); clone mode returns the canonical
+	// directly. Either way Path is the canonical clone — byte-identical to
+	// the pre-issue-149 behavior when no `layout:` block is configured.
+	return rp.Path, true
 }
 
 // GetRepoContextPath returns the context file path for a repo if defined.

--- a/internal/flow/layout_test.go
+++ b/internal/flow/layout_test.go
@@ -226,6 +226,79 @@ func TestResolveRepoPath_PerRepoPartialOverride(t *testing.T) {
 	}
 }
 
+func TestResolveRepoPath_UnknownModeErrors(t *testing.T) {
+	// A typo in layout.mode must error rather than silently falling through
+	// to the side-effecting worktree path.
+	sourcesYAML := `code:
+  - repo: matsen/bipartite
+`
+	flowCfgYAML := `paths:
+  code: /tmp/code
+`
+	globalYAML := `layout:
+  mode: wirktree
+`
+	nexus := setupResolverFixture(t, sourcesYAML, flowCfgYAML, globalYAML)
+	_, err := ResolveRepoPath(nexus, "matsen/bipartite", ResolveContext{IssueNumber: 1})
+	if err == nil {
+		t.Fatal("expected error for unknown mode, got nil")
+	}
+	if !strings.Contains(err.Error(), "wirktree") {
+		t.Errorf("error did not name the bad mode: %v", err)
+	}
+}
+
+func TestResolveRepoPath_PRWorktreeDefaultSlotErrors(t *testing.T) {
+	// Worktree mode + a PR context + the default issue-only slot template
+	// would expand to "issue-" (empty issue number). That must be a clear
+	// config error, not a silently-created directory named "issue-".
+	sourcesYAML := `code:
+  - repo: matsen/bipartite
+`
+	flowCfgYAML := `paths:
+  code: /tmp/code
+`
+	globalYAML := `layout:
+  mode: worktree
+`
+	nexus := setupResolverFixture(t, sourcesYAML, flowCfgYAML, globalYAML)
+	_, err := ResolveRepoPath(nexus, "matsen/bipartite", ResolveContext{PRNumber: 99, Slug: "fix"})
+	if err == nil {
+		t.Fatal("expected error for PR + issue-only slot, got nil")
+	}
+	if !strings.Contains(err.Error(), "issue") {
+		t.Errorf("error should name the empty {issue} variable: %v", err)
+	}
+}
+
+func TestResolveRepoPath_PRWorktreeBranchSlot(t *testing.T) {
+	// With a {branch}-based slot template, a PR spawn resolves cleanly —
+	// branch is always populated, so the empty-var guard does not trip.
+	sourcesYAML := `code:
+  - repo: matsen/bipartite
+`
+	flowCfgYAML := `paths:
+  code: /tmp/code
+`
+	globalYAML := `layout:
+  mode: worktree
+  worktree:
+    root: "/tmp/wt/{repo}-workers"
+    slot: "{branch}"
+`
+	nexus := setupResolverFixture(t, sourcesYAML, flowCfgYAML, globalYAML)
+	rp, err := ResolveRepoPath(nexus, "matsen/bipartite", ResolveContext{PRNumber: 99, Slug: "fix"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "/tmp/wt/bipartite-workers/pr-99-fix"; rp.Path != want {
+		t.Errorf("Path = %q, want %q", rp.Path, want)
+	}
+	if want := "pr-99-fix"; rp.Branch != want {
+		t.Errorf("Branch = %q, want %q", rp.Branch, want)
+	}
+}
+
 func TestResolveRepoPath_RepoNotInSources(t *testing.T) {
 	sourcesYAML := `code:
   - repo: matsen/bipartite

--- a/internal/flow/layout_test.go
+++ b/internal/flow/layout_test.go
@@ -41,7 +41,9 @@ func setupResolverFixture(t *testing.T, sourcesYAML, flowConfigYAML, globalYAML 
 	}
 	t.Setenv("XDG_CONFIG_HOME", cfgHome)
 	config.ResetGlobalConfigCache()
+	ResetFileCache()
 	t.Cleanup(config.ResetGlobalConfigCache)
+	t.Cleanup(ResetFileCache)
 	return nexus
 }
 
@@ -316,5 +318,129 @@ func TestParseLayoutUnknownField(t *testing.T) {
 	_, err := LoadSources(nexus)
 	if err == nil {
 		t.Fatal("expected error for unknown layout field, got nil")
+	}
+}
+
+func TestListWorktreeSlots(t *testing.T) {
+	// ListWorktreeSlots enumerates issue-* subdirs and ignores everything
+	// else (files, non-prefix dirs). Names are sorted for determinism so
+	// EPIC's slot list is stable across runs.
+	root := t.TempDir()
+	for _, sub := range []string{"issue-200", "issue-100", "scratch", "issue-150"} {
+		if err := os.MkdirAll(filepath.Join(root, sub), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(root, "issue-not-a-dir"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ListWorktreeSlots(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"issue-100", "issue-150", "issue-200"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i, g := range got {
+		if g != want[i] {
+			t.Errorf("slot[%d] = %q, want %q", i, g, want[i])
+		}
+	}
+}
+
+func TestListWorktreeSlots_MissingRoot(t *testing.T) {
+	// Reading a missing root is the caller's signal that the EPIC clone_root
+	// itself doesn't exist — surface as an error, not an empty slice.
+	_, err := ListWorktreeSlots(filepath.Join(t.TempDir(), "nope"))
+	if err == nil {
+		t.Fatal("expected error for missing root, got nil")
+	}
+}
+
+func TestResolveRepoPath_ParseErrorSurfacesDetail(t *testing.T) {
+	// Pre-#149, spawn called GetRepoLocalPath which swallowed config parse
+	// errors and reported "repo not found in sources.yml" — confusing when
+	// the real problem was malformed YAML. After #149, spawn calls
+	// ResolveRepoPath directly so the parse error reaches the user. This
+	// test pins that behavior: a malformed sources.yml must yield an error
+	// whose message names the file, distinct from ErrRepoNotInSources.
+	sourcesYAML := "code: [unterminated\n"
+	nexus := setupResolverFixture(t, sourcesYAML, "", "")
+
+	_, err := ResolveRepoPath(nexus, "matsen/bipartite", ResolveContext{})
+	if err == nil {
+		t.Fatal("expected parse error, got nil")
+	}
+	if errors.Is(err, ErrRepoNotInSources) {
+		t.Errorf("parse error must NOT collapse to ErrRepoNotInSources: %v", err)
+	}
+	if !strings.Contains(err.Error(), "sources.yml") {
+		t.Errorf("error %q should name sources.yml", err)
+	}
+}
+
+func TestLoadSources_CachedAcrossCalls(t *testing.T) {
+	// Repeated LoadSources for the same nexus must not re-parse the file
+	// (the resolver calls it on every bip spawn / bip checkin invocation
+	// and we want one read per command). We assert this by mutating the
+	// file in place to a *broken* YAML and verifying the second call
+	// returns the originally-cached value rather than the parse error.
+	sourcesYAML := `code:
+  - repo: matsen/bipartite
+`
+	nexus := setupResolverFixture(t, sourcesYAML, "", "")
+
+	first, err := LoadSources(nexus)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first.Code) != 1 || first.Code[0].Repo != "matsen/bipartite" {
+		t.Fatalf("first load: %+v", first)
+	}
+
+	// Overwrite with broken YAML but preserve mtime+size by writing the
+	// same number of bytes and resetting mtime. The cache key matches, so
+	// the broken read should never happen.
+	path := filepath.Join(nexus, "sources.yml")
+	info, _ := os.Stat(path)
+	broken := []byte("code: [\n") // 8 bytes; original is 31 bytes
+	// Pad to the same size so mtime+size key is unchanged. (Length match
+	// matters more than mtime for the cache hit assertion since file
+	// systems may coalesce sub-microsecond writes.)
+	for len(broken) < int(info.Size()) {
+		broken = append(broken, ' ')
+	}
+	if err := os.WriteFile(path, broken, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(path, info.ModTime(), info.ModTime()); err != nil {
+		t.Fatal(err)
+	}
+
+	second, err := LoadSources(nexus)
+	if err != nil {
+		t.Fatalf("expected cache hit, got parse error: %v", err)
+	}
+	if len(second.Code) != 1 || second.Code[0].Repo != "matsen/bipartite" {
+		t.Fatalf("second load returned stale-but-different parse: %+v", second)
+	}
+
+	// Sanity check: ResetFileCache must invalidate, surfacing the bad YAML.
+	ResetFileCache()
+	if _, err := LoadSources(nexus); err == nil {
+		t.Fatal("expected parse error after cache reset, got nil")
+	}
+}
+
+func TestListWorktreeSlots_EmptyRoot(t *testing.T) {
+	// An empty (but existing) root means EPIC has been configured but no
+	// workers have spawned yet — empty slice, no error.
+	got, err := ListWorktreeSlots(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected zero slots, got %v", got)
 	}
 }

--- a/internal/flow/layout_test.go
+++ b/internal/flow/layout_test.go
@@ -1,0 +1,320 @@
+package flow
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/matsen/bipartite/internal/config"
+)
+
+// setupResolverFixture writes a minimal nexus dir + global config dir and
+// returns the nexus path. The global config is written iff globalYAML != "";
+// XDG_CONFIG_HOME is pointed at the temp config dir so LoadGlobalConfig sees
+// it. The cache is reset on entry and on cleanup so back-to-back tests don't
+// see each other's config.
+func setupResolverFixture(t *testing.T, sourcesYAML, flowConfigYAML, globalYAML string) string {
+	t.Helper()
+	root := t.TempDir()
+	nexus := filepath.Join(root, "nexus")
+	if err := os.MkdirAll(nexus, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(nexus, "sources.yml"), []byte(sourcesYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if flowConfigYAML != "" {
+		if err := os.WriteFile(filepath.Join(nexus, "config.yml"), []byte(flowConfigYAML), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cfgHome := filepath.Join(root, "xdg")
+	if err := os.MkdirAll(filepath.Join(cfgHome, "bip"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if globalYAML != "" {
+		if err := os.WriteFile(filepath.Join(cfgHome, "bip", "config.yml"), []byte(globalYAML), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("XDG_CONFIG_HOME", cfgHome)
+	config.ResetGlobalConfigCache()
+	t.Cleanup(config.ResetGlobalConfigCache)
+	return nexus
+}
+
+func TestResolveRepoPath_AbsentLayoutMatchesGetRepoLocalPath(t *testing.T) {
+	// The headline backward-compat guarantee: with no `layout:` block
+	// anywhere, ResolveRepoPath returns byte-identical paths to the
+	// pre-issue-149 GetRepoLocalPath for both code and writing repos.
+	sourcesYAML := `code:
+  - repo: matsen/bipartite
+writing:
+  - repo: matsen/notes
+`
+	flowCfgYAML := `paths:
+  code: ~/myre
+  writing: ~/mywriting
+`
+	nexus := setupResolverFixture(t, sourcesYAML, flowCfgYAML, "")
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, c := range []struct {
+		repo string
+		want string
+	}{
+		{"matsen/bipartite", filepath.Join(home, "myre", "bipartite")},
+		{"matsen/notes", filepath.Join(home, "mywriting", "notes")},
+	} {
+		rp, err := ResolveRepoPath(nexus, c.repo, ResolveContext{})
+		if err != nil {
+			t.Fatalf("ResolveRepoPath(%q): %v", c.repo, err)
+		}
+		if rp.Path != c.want {
+			t.Errorf("ResolveRepoPath(%q).Path = %q, want %q", c.repo, rp.Path, c.want)
+		}
+		if rp.Mode != config.LayoutModeClone {
+			t.Errorf("ResolveRepoPath(%q).Mode = %q, want clone", c.repo, rp.Mode)
+		}
+		// And the wrapper must agree.
+		if got, ok := GetRepoLocalPath(nexus, c.repo); !ok || got != c.want {
+			t.Errorf("GetRepoLocalPath(%q) = %q,%v want %q,true", c.repo, got, ok, c.want)
+		}
+	}
+}
+
+func TestResolveRepoPath_WritingTakesPrecedenceOverCode(t *testing.T) {
+	// A repo listed under writing must resolve to paths.writing, not
+	// paths.code, even when also (hypothetically) shadowed by a code entry.
+	// This preserves the GetRepoLocalPath ordering that read-only callers
+	// (checkin, board, scout) depend on.
+	sourcesYAML := `code:
+  - repo: matsen/notes
+writing:
+  - repo: matsen/notes
+`
+	flowCfgYAML := `paths:
+  code: /tmp/code
+  writing: /tmp/writing
+`
+	nexus := setupResolverFixture(t, sourcesYAML, flowCfgYAML, "")
+	rp, err := ResolveRepoPath(nexus, "matsen/notes", ResolveContext{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := rp.Path, "/tmp/writing/notes"; got != want {
+		t.Errorf("writing-first precedence broken: got %q want %q", got, want)
+	}
+}
+
+func TestResolveRepoPath_GlobalWorktreeMode(t *testing.T) {
+	sourcesYAML := `code:
+  - repo: matsen/bipartite
+`
+	flowCfgYAML := `paths:
+  code: /tmp/code
+`
+	globalYAML := `layout:
+  mode: worktree
+  worktree:
+    root: "/tmp/wt/{repo}-workers"
+    slot: "issue-{issue}"
+`
+	nexus := setupResolverFixture(t, sourcesYAML, flowCfgYAML, globalYAML)
+	rp, err := ResolveRepoPath(nexus, "matsen/bipartite", ResolveContext{IssueNumber: 123, Slug: "fix-thing"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "/tmp/wt/bipartite-workers/issue-123"; rp.Path != want {
+		t.Errorf("Path = %q, want %q", rp.Path, want)
+	}
+	if rp.Mode != config.LayoutModeWorktree {
+		t.Errorf("Mode = %q, want worktree", rp.Mode)
+	}
+	if !rp.IsNew {
+		t.Errorf("IsNew = false, want true for a path that does not exist")
+	}
+	if want := "123-fix-thing"; rp.Branch != want {
+		t.Errorf("Branch = %q, want %q", rp.Branch, want)
+	}
+}
+
+func TestResolveRepoPath_WorktreeEmptyContextFallsBack(t *testing.T) {
+	sourcesYAML := `code:
+  - repo: matsen/bipartite
+`
+	flowCfgYAML := `paths:
+  code: /tmp/code
+`
+	globalYAML := `layout:
+  mode: worktree
+`
+	nexus := setupResolverFixture(t, sourcesYAML, flowCfgYAML, globalYAML)
+	rp, err := ResolveRepoPath(nexus, "matsen/bipartite", ResolveContext{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !rp.FellBack {
+		t.Errorf("FellBack = false, want true")
+	}
+	if rp.Mode != config.LayoutModeClone {
+		t.Errorf("Mode = %q, want clone (post-fallback)", rp.Mode)
+	}
+	if want := "/tmp/code/bipartite"; rp.Path != want {
+		t.Errorf("Path = %q, want %q", rp.Path, want)
+	}
+}
+
+func TestResolveRepoPath_PerRepoOverrideOptOut(t *testing.T) {
+	// Global says worktree, per-repo says clone — per-repo wins.
+	sourcesYAML := `code:
+  - repo: matsen/bipartite
+    layout:
+      mode: clone
+`
+	flowCfgYAML := `paths:
+  code: /tmp/code
+`
+	globalYAML := `layout:
+  mode: worktree
+`
+	nexus := setupResolverFixture(t, sourcesYAML, flowCfgYAML, globalYAML)
+	rp, err := ResolveRepoPath(nexus, "matsen/bipartite", ResolveContext{IssueNumber: 42})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rp.Mode != config.LayoutModeClone {
+		t.Errorf("per-repo opt-out failed: Mode = %q, want clone", rp.Mode)
+	}
+	if want := "/tmp/code/bipartite"; rp.Path != want {
+		t.Errorf("Path = %q, want %q", rp.Path, want)
+	}
+}
+
+func TestResolveRepoPath_PerRepoPartialOverride(t *testing.T) {
+	// Global sets mode and slot; per-repo overrides only worktree.root.
+	// Slot template must come from global; root must come from per-repo.
+	sourcesYAML := `code:
+  - repo: matsen/big-thing
+    layout:
+      worktree:
+        root: "/tmp/special/{repo}"
+`
+	flowCfgYAML := `paths:
+  code: /tmp/code
+`
+	globalYAML := `layout:
+  mode: worktree
+  worktree:
+    slot: "wt-{issue}"
+`
+	nexus := setupResolverFixture(t, sourcesYAML, flowCfgYAML, globalYAML)
+	rp, err := ResolveRepoPath(nexus, "matsen/big-thing", ResolveContext{IssueNumber: 7})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "/tmp/special/big-thing/wt-7"; rp.Path != want {
+		t.Errorf("Path = %q, want %q", rp.Path, want)
+	}
+}
+
+func TestResolveRepoPath_RepoNotInSources(t *testing.T) {
+	sourcesYAML := `code:
+  - repo: matsen/bipartite
+`
+	nexus := setupResolverFixture(t, sourcesYAML, "", "")
+	_, err := ResolveRepoPath(nexus, "someone-else/nope", ResolveContext{})
+	if !errors.Is(err, ErrRepoNotInSources) {
+		t.Errorf("expected ErrRepoNotInSources, got %v", err)
+	}
+}
+
+func TestExpandTemplate(t *testing.T) {
+	vars := map[string]string{"a": "1", "b": "two"}
+	if got, _ := expandTemplate("x{a}-{b}", vars); got != "x1-two" {
+		t.Errorf("substitution: got %q", got)
+	}
+	if _, err := expandTemplate("{a}-{nope}-{b}", vars); err == nil {
+		t.Errorf("expected error for unknown var")
+	} else if !strings.Contains(err.Error(), "nope") {
+		t.Errorf("error did not mention unknown var: %v", err)
+	}
+	// Identical unknown vars should not be duplicated in the message.
+	_, err := expandTemplate("{x}-{x}-{y}-{y}", map[string]string{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	msg := err.Error()
+	if strings.Count(msg, "x") != 1 || strings.Count(msg, "y") != 1 {
+		t.Errorf("error did not dedupe unknown vars: %v", err)
+	}
+}
+
+func TestParseLayoutInSourcesYAML(t *testing.T) {
+	// Round-trip an entry with a nested layout block; verify the struct.
+	sourcesYAML := `code:
+  - repo: matsen/big-thing
+    channel: bt
+    layout:
+      mode: worktree
+      worktree:
+        root: ~/re/bt-workers
+        slot: "issue-{issue}"
+`
+	nexus := setupResolverFixture(t, sourcesYAML, "", "")
+	sources, err := LoadSources(nexus)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sources.Code) != 1 {
+		t.Fatalf("expected 1 code entry, got %d", len(sources.Code))
+	}
+	entry := sources.Code[0]
+	if entry.Layout == nil {
+		t.Fatalf("Layout was nil; per-repo block did not round-trip")
+	}
+	if entry.Layout.Mode != "worktree" {
+		t.Errorf("Mode = %q, want worktree", entry.Layout.Mode)
+	}
+	if entry.Layout.Worktree == nil || entry.Layout.Worktree.Root != "~/re/bt-workers" {
+		t.Errorf("Worktree.Root not parsed: %+v", entry.Layout.Worktree)
+	}
+}
+
+func TestParseLayoutMalformed(t *testing.T) {
+	// A layout: that is not a mapping (e.g. a bare string) must produce a
+	// clear parse error rather than silently being ignored.
+	sourcesYAML := `code:
+  - repo: matsen/bipartite
+    layout: "worktree"
+`
+	nexus := setupResolverFixture(t, sourcesYAML, "", "")
+	_, err := LoadSources(nexus)
+	if err == nil {
+		t.Fatal("expected error for non-mapping layout, got nil")
+	}
+	if !strings.Contains(err.Error(), "layout") {
+		t.Errorf("error did not mention layout: %v", err)
+	}
+}
+
+func TestParseLayoutUnknownField(t *testing.T) {
+	// KnownFields(true) in the decoder catches typos in the layout block.
+	sourcesYAML := `code:
+  - repo: matsen/bipartite
+    layout:
+      mode: worktree
+      worktrees: {root: "/oops"}
+`
+	nexus := setupResolverFixture(t, sourcesYAML, "", "")
+	_, err := LoadSources(nexus)
+	if err == nil {
+		t.Fatal("expected error for unknown layout field, got nil")
+	}
+}

--- a/internal/flow/resolve.go
+++ b/internal/flow/resolve.go
@@ -88,6 +88,15 @@ func ResolveRepoPath(nexusPath, orgRepo string, ctx ResolveContext) (ResolvedPat
 	if mode == "" {
 		mode = config.LayoutModeClone
 	}
+	// Reject typos rather than letting any unrecognized string fall through
+	// to worktree mode (the non-default, side-effecting path).
+	switch mode {
+	case config.LayoutModeClone, config.LayoutModeWorktree:
+		// valid
+	default:
+		return ResolvedPath{}, fmt.Errorf("unknown layout mode %q (valid: %q, %q)",
+			mode, config.LayoutModeClone, config.LayoutModeWorktree)
+	}
 
 	if mode == config.LayoutModeClone {
 		return ResolvedPath{
@@ -151,6 +160,16 @@ func ResolveRepoPath(nexusPath, orgRepo string, ctx ResolveContext) (ResolvedPat
 		"pr":     prStr,
 		"slug":   ctx.Slug,
 		"branch": branch,
+	}
+	// Guard against a slot template whose referenced variable is empty in
+	// this context — e.g. the default "issue-{issue}" applied to a PR (no
+	// issue number) would otherwise silently create a directory named
+	// "issue-". Surface it as an actionable config error instead.
+	if empty := emptyReferencedVars(slotTmpl, slotVars); len(empty) > 0 {
+		return ResolvedPath{}, fmt.Errorf(
+			"worktree slot template %q references variable(s) %s that are empty in this context; "+
+				"configure layout.worktree.slot (e.g. \"{branch}\") for this kind of spawn",
+			slotTmpl, strings.Join(empty, ", "))
 	}
 	slotExpanded, err := expandTemplate(slotTmpl, slotVars)
 	if err != nil {
@@ -287,6 +306,20 @@ func expandTemplate(tmpl string, vars map[string]string) (string, error) {
 		return "", fmt.Errorf("unknown template variable(s): %s", strings.Join(dedupSorted(unknown), ", "))
 	}
 	return out, nil
+}
+
+// emptyReferencedVars returns the names of variables that tmpl references via
+// {name} but whose value in vars is the empty string. A referenced-but-empty
+// variable would expand to a malformed path component, so callers reject it.
+func emptyReferencedVars(tmpl string, vars map[string]string) []string {
+	var empty []string
+	for _, m := range templateVarRE.FindAllStringSubmatch(tmpl, -1) {
+		if v, ok := vars[m[1]]; ok && v == "" {
+			empty = append(empty, m[1])
+		}
+	}
+	sort.Strings(empty)
+	return dedupSorted(empty)
 }
 
 // dedupSorted removes consecutive duplicates from an already-sorted slice.

--- a/internal/flow/resolve.go
+++ b/internal/flow/resolve.go
@@ -235,6 +235,35 @@ func pathExists(p string) bool {
 	return err == nil
 }
 
+// ListWorktreeSlots scans root and returns the names of immediate
+// subdirectories that match the worktree slot convention
+// (config.WorktreeSlotPrefix, e.g. "issue-"). Results are sorted for
+// deterministic test ordering.
+//
+// This is the inverse of the forward mapping ResolveRepoPath performs
+// in worktree mode: ResolveRepoPath builds <root>/<slot> for a known
+// issue, ListWorktreeSlots enumerates what is actually on disk. EPIC
+// watch composes both: ResolveRepoPath (eventually, once .epic-config.json
+// is deprecated) provides the root, ListWorktreeSlots enumerates the
+// active issues.
+//
+// Returns an empty slice (no error) when root has no matching subdirs;
+// returns an error when root cannot be read.
+func ListWorktreeSlots(root string) ([]string, error) {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil, err
+	}
+	var names []string
+	for _, e := range entries {
+		if e.IsDir() && strings.HasPrefix(e.Name(), config.WorktreeSlotPrefix) {
+			names = append(names, e.Name())
+		}
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
 // templateVarRE matches {name} placeholders where name is a Go-identifier.
 var templateVarRE = regexp.MustCompile(`\{([a-zA-Z_][a-zA-Z0-9_]*)\}`)
 

--- a/internal/flow/resolve.go
+++ b/internal/flow/resolve.go
@@ -1,0 +1,275 @@
+package flow
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/matsen/bipartite/internal/config"
+)
+
+// ErrRepoNotInSources is returned by ResolveRepoPath when orgRepo is not
+// listed in sources.yml under code or writing. Callers use errors.Is.
+var ErrRepoNotInSources = errors.New("repo not in sources.yml")
+
+// ResolveContext carries the optional caller info that ResolveRepoPath uses
+// to build a worktree slot path. Zero values mean "not applicable."
+type ResolveContext struct {
+	IssueNumber int
+	PRNumber    int
+	Slug        string
+	Branch      string
+}
+
+// ResolvedPath is the result of ResolveRepoPath.
+type ResolvedPath struct {
+	// Path is the absolute working directory the caller should use.
+	Path string
+	// Mode is the effective layout mode after any fallback ("clone" or "worktree").
+	Mode string
+	// IsNew is true when Path does not yet exist on disk and the caller
+	// must create it (e.g. via `git worktree add` for worktree mode).
+	IsNew bool
+	// Branch is the branch name to use when creating a new worktree.
+	// Empty for clone-mode resolutions.
+	Branch string
+	// FellBack is true when worktree mode was configured but the resolver
+	// fell back to the canonical clone (e.g. ResolveContext had no
+	// IssueNumber or PRNumber). Callers can use this to print a one-line note.
+	FellBack bool
+}
+
+// ResolveRepoPath maps a GitHub repo (org/name) plus optional context to a
+// working-directory layout decision. It is the single source of truth for
+// "where does this repo's working tree live?"
+//
+// Precedence, each leaf field independently: per-repo sources.yml layout >
+// global ~/.config/bip/config.yml layout > built-in default (clone mode).
+//
+// In clone mode (the default) the returned Path matches GetRepoLocalPath
+// byte-for-byte. In worktree mode with a non-empty ResolveContext, Path is
+// the expanded worktree.root/worktree.slot template. Worktree mode with an
+// empty context falls back to the canonical clone and sets FellBack=true.
+func ResolveRepoPath(nexusPath, orgRepo string, ctx ResolveContext) (ResolvedPath, error) {
+	sources, err := LoadSources(nexusPath)
+	if err != nil {
+		return ResolvedPath{}, err
+	}
+	cfg, err := LoadConfig(nexusPath)
+	if err != nil {
+		return ResolvedPath{}, err
+	}
+	// Tolerate a missing/unreadable global config — that's the "absent
+	// block = today's behavior" guarantee.
+	gcfg, _ := config.LoadGlobalConfig()
+	if gcfg == nil {
+		gcfg = &config.GlobalConfig{}
+	}
+
+	repoName := ExtractRepoName(orgRepo)
+
+	// Locate the repo entry. Writing is checked first to match the existing
+	// GetRepoLocalPath order — a regression here would silently break
+	// every read-only consumer (bip checkin, bip board, bip scout).
+	entry, categoryRoot, ok := findRepoEntry(sources, cfg, orgRepo)
+	if !ok {
+		return ResolvedPath{}, fmt.Errorf("%w: %s", ErrRepoNotInSources, orgRepo)
+	}
+
+	layout := mergeLayouts(gcfg.Layout, entry.Layout)
+	canonical := filepath.Join(categoryRoot, repoName)
+
+	mode := layout.Mode
+	if mode == "" {
+		mode = config.LayoutModeClone
+	}
+
+	if mode == config.LayoutModeClone {
+		return ResolvedPath{
+			Path:  canonical,
+			Mode:  config.LayoutModeClone,
+			IsNew: !pathExists(canonical),
+		}, nil
+	}
+
+	// Worktree mode. Empty context falls back to the canonical clone —
+	// callers print a note so the degradation is visible.
+	if ctx.IssueNumber == 0 && ctx.PRNumber == 0 {
+		return ResolvedPath{
+			Path:     canonical,
+			Mode:     config.LayoutModeClone,
+			IsNew:    !pathExists(canonical),
+			FellBack: true,
+		}, nil
+	}
+
+	rootTmpl := config.DefaultRootTemplate
+	if layout.Worktree != nil && layout.Worktree.Root != "" {
+		rootTmpl = layout.Worktree.Root
+	}
+	rootVars := map[string]string{
+		"repo": repoName,
+		"code": config.ExpandTilde(cfg.Paths.Code),
+	}
+	rootExpanded, err := expandTemplate(rootTmpl, rootVars)
+	if err != nil {
+		return ResolvedPath{}, fmt.Errorf("expanding worktree.root template %q: %w", rootTmpl, err)
+	}
+	root := config.ExpandTilde(rootExpanded)
+
+	slotTmpl := config.DefaultSlotTemplate
+	if layout.Worktree != nil && layout.Worktree.Slot != "" {
+		slotTmpl = layout.Worktree.Slot
+	}
+	issueStr, prStr := "", ""
+	if ctx.IssueNumber != 0 {
+		issueStr = strconv.Itoa(ctx.IssueNumber)
+	}
+	if ctx.PRNumber != 0 {
+		prStr = strconv.Itoa(ctx.PRNumber)
+	}
+	branch := ctx.Branch
+	if branch == "" {
+		switch {
+		case ctx.IssueNumber != 0 && ctx.Slug != "":
+			branch = fmt.Sprintf("%d-%s", ctx.IssueNumber, ctx.Slug)
+		case ctx.IssueNumber != 0:
+			branch = strconv.Itoa(ctx.IssueNumber)
+		case ctx.PRNumber != 0 && ctx.Slug != "":
+			branch = fmt.Sprintf("pr-%d-%s", ctx.PRNumber, ctx.Slug)
+		case ctx.PRNumber != 0:
+			branch = fmt.Sprintf("pr-%d", ctx.PRNumber)
+		}
+	}
+	slotVars := map[string]string{
+		"issue":  issueStr,
+		"pr":     prStr,
+		"slug":   ctx.Slug,
+		"branch": branch,
+	}
+	slotExpanded, err := expandTemplate(slotTmpl, slotVars)
+	if err != nil {
+		return ResolvedPath{}, fmt.Errorf("expanding worktree.slot template %q: %w", slotTmpl, err)
+	}
+
+	path := filepath.Join(root, slotExpanded)
+	return ResolvedPath{
+		Path:   path,
+		Mode:   config.LayoutModeWorktree,
+		IsNew:  !pathExists(path),
+		Branch: branch,
+	}, nil
+}
+
+// findRepoEntry returns a pointer to the matching RepoEntry plus the
+// category root (paths.writing for writing, paths.code for code). Writing is
+// checked first to match the existing GetRepoLocalPath order.
+func findRepoEntry(sources *Sources, cfg *Config, orgRepo string) (*RepoEntry, string, bool) {
+	for i := range sources.Writing {
+		if sources.Writing[i].Repo == orgRepo {
+			return &sources.Writing[i], config.ExpandTilde(cfg.Paths.Writing), true
+		}
+	}
+	for i := range sources.Code {
+		if sources.Code[i].Repo == orgRepo {
+			return &sources.Code[i], config.ExpandTilde(cfg.Paths.Code), true
+		}
+	}
+	return nil, "", false
+}
+
+// mergeLayouts overlays a per-repo layout on top of a global layout, leaf by
+// leaf. The result is always non-nil and never aliases either input.
+func mergeLayouts(global, perRepo *config.LayoutConfig) config.LayoutConfig {
+	var out config.LayoutConfig
+	if global != nil {
+		out.Mode = global.Mode
+		if global.Worktree != nil {
+			wt := *global.Worktree
+			out.Worktree = &wt
+		}
+		if global.Clone != nil {
+			cl := *global.Clone
+			cl.Names = append([]string(nil), global.Clone.Names...)
+			out.Clone = &cl
+		}
+	}
+	if perRepo == nil {
+		return out
+	}
+	if perRepo.Mode != "" {
+		out.Mode = perRepo.Mode
+	}
+	if perRepo.Worktree != nil {
+		if out.Worktree == nil {
+			out.Worktree = &config.WorktreeLayout{}
+		}
+		if perRepo.Worktree.Root != "" {
+			out.Worktree.Root = perRepo.Worktree.Root
+		}
+		if perRepo.Worktree.Slot != "" {
+			out.Worktree.Slot = perRepo.Worktree.Slot
+		}
+	}
+	if perRepo.Clone != nil {
+		if out.Clone == nil {
+			out.Clone = &config.CloneLayout{}
+		}
+		if perRepo.Clone.Root != "" {
+			out.Clone.Root = perRepo.Clone.Root
+		}
+		if len(perRepo.Clone.Names) > 0 {
+			out.Clone.Names = append([]string(nil), perRepo.Clone.Names...)
+		}
+	}
+	return out
+}
+
+func pathExists(p string) bool {
+	_, err := os.Stat(p)
+	return err == nil
+}
+
+// templateVarRE matches {name} placeholders where name is a Go-identifier.
+var templateVarRE = regexp.MustCompile(`\{([a-zA-Z_][a-zA-Z0-9_]*)\}`)
+
+// expandTemplate substitutes {name} placeholders using vars. Unknown
+// placeholders yield an error; this is the lazy validation hook — callers
+// only invoke expandTemplate when a template is actually used, so a typo in
+// an opt-in worktree.slot does not break read-only commands.
+func expandTemplate(tmpl string, vars map[string]string) (string, error) {
+	var unknown []string
+	out := templateVarRE.ReplaceAllStringFunc(tmpl, func(m string) string {
+		name := m[1 : len(m)-1]
+		v, ok := vars[name]
+		if !ok {
+			unknown = append(unknown, name)
+			return m
+		}
+		return v
+	})
+	if len(unknown) > 0 {
+		sort.Strings(unknown)
+		return "", fmt.Errorf("unknown template variable(s): %s", strings.Join(dedupSorted(unknown), ", "))
+	}
+	return out, nil
+}
+
+// dedupSorted removes consecutive duplicates from an already-sorted slice.
+func dedupSorted(s []string) []string {
+	if len(s) <= 1 {
+		return s
+	}
+	out := s[:1]
+	for _, x := range s[1:] {
+		if x != out[len(out)-1] {
+			out = append(out, x)
+		}
+	}
+	return out
+}

--- a/internal/flow/slug.go
+++ b/internal/flow/slug.go
@@ -16,7 +16,8 @@ var slugMultiDash = regexp.MustCompile(`-+`)
 // Rules: ASCII letters are lowercased; ASCII digits are kept; everything else
 // (whitespace, punctuation, non-ASCII) becomes "-"; runs of "-" collapse to a
 // single dash; leading and trailing dashes are trimmed; the result is
-// truncated to slugMaxLen runes (with any trailing dash trimmed again).
+// truncated to slugMaxLen bytes — the output is ASCII, so bytes equal
+// characters (with any trailing dash trimmed again).
 // Empty input returns "".
 func SlugifyTitle(s string) string {
 	if s == "" {

--- a/internal/flow/slug.go
+++ b/internal/flow/slug.go
@@ -1,0 +1,44 @@
+package flow
+
+import (
+	"regexp"
+	"strings"
+)
+
+const slugMaxLen = 40
+
+var slugMultiDash = regexp.MustCompile(`-+`)
+
+// SlugifyTitle converts a free-form title (e.g. a GitHub issue title) into a
+// short, filesystem-safe slug suitable for branch names and worktree slot
+// templates.
+//
+// Rules: ASCII letters are lowercased; ASCII digits are kept; everything else
+// (whitespace, punctuation, non-ASCII) becomes "-"; runs of "-" collapse to a
+// single dash; leading and trailing dashes are trimmed; the result is
+// truncated to slugMaxLen runes (with any trailing dash trimmed again).
+// Empty input returns "".
+func SlugifyTitle(s string) string {
+	if s == "" {
+		return ""
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(r + ('a' - 'A'))
+		default:
+			b.WriteByte('-')
+		}
+	}
+	out := slugMultiDash.ReplaceAllString(b.String(), "-")
+	out = strings.Trim(out, "-")
+	if len(out) > slugMaxLen {
+		out = out[:slugMaxLen]
+		out = strings.TrimRight(out, "-")
+	}
+	return out
+}

--- a/internal/flow/slug_test.go
+++ b/internal/flow/slug_test.go
@@ -1,0 +1,37 @@
+package flow
+
+import "testing"
+
+func TestSlugifyTitle(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"plain", "Fix the parser", "fix-the-parser"},
+		{"uppercase only", "ABC", "abc"},
+		{"punctuation runs", "Hello,  world!!!", "hello-world"},
+		{"leading and trailing punctuation", "  !hello!  ", "hello"},
+		{"underscore is non-alphanumeric", "snake_case_thing", "snake-case-thing"},
+		{"unicode replaced", "café münch", "caf-m-nch"},
+		{"emoji replaced", "ship it 🚀 today", "ship-it-today"},
+		{"digits kept", "v2 update 3", "v2-update-3"},
+		{"length cap", "this is a very long title that should be truncated at the configured slug limit", "this-is-a-very-long-title-that-should-be"},
+		// "abc-def-ghi-jkl-mno-pqr-stu-vwx-yz1-234-" lands exactly at length 40
+		// with a trailing dash; the trim removes it, leaving 39 chars.
+		{"length cap trims trailing dash", "abc def ghi jkl mno pqr stu vwx yz1 234 567", "abc-def-ghi-jkl-mno-pqr-stu-vwx-yz1-234"},
+		{"only punctuation collapses to empty", "!!! --- ???", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := SlugifyTitle(c.in)
+			if got != c.want {
+				t.Errorf("SlugifyTitle(%q) = %q, want %q", c.in, got, c.want)
+			}
+			if len(got) > slugMaxLen {
+				t.Errorf("slug exceeds max length: len=%d max=%d", len(got), slugMaxLen)
+			}
+		})
+	}
+}

--- a/internal/flow/types.go
+++ b/internal/flow/types.go
@@ -3,7 +3,11 @@
 // as part of the bip CLI.
 package flow
 
-import "time"
+import (
+	"time"
+
+	"github.com/matsen/bipartite/internal/config"
+)
 
 // Sources represents the sources.yml configuration file.
 type Sources struct {
@@ -30,9 +34,15 @@ type SlackChannelConfig struct {
 
 // RepoEntry represents a repository entry in sources.yml.
 // It can be either a string (repo name only) or an object with channel info.
+//
+// Layout is an optional per-repo override of the global layout block in
+// ~/.config/bip/config.yml; a non-nil pointer means "this repo opted in
+// (or opted out) explicitly," and a nil pointer means "inherit from
+// global." Each leaf field overrides independently — see flow.ResolveRepoPath.
 type RepoEntry struct {
-	Repo    string `yaml:"repo"`
-	Channel string `yaml:"channel,omitempty"`
+	Repo    string               `yaml:"repo"`
+	Channel string               `yaml:"channel,omitempty"`
+	Layout  *config.LayoutConfig `yaml:"layout,omitempty"`
 }
 
 // GitHubRef represents a parsed GitHub reference.

--- a/internal/gitx/worktree.go
+++ b/internal/gitx/worktree.go
@@ -119,17 +119,19 @@ func realpath(p string) string {
 }
 
 // runGit invokes git in dir and returns trimmed stdout, with stderr folded
-// into the returned error on failure.
+// into the returned error on failure. The working directory is passed via
+// git's own `-C` flag (matching the convention in internal/git) rather than
+// cmd.Dir, so the failing command is fully reconstructable from the args.
 func runGit(dir string, args ...string) (string, error) {
-	cmd := exec.Command("git", args...)
-	cmd.Dir = dir
+	fullArgs := append([]string{"-C", dir}, args...)
+	cmd := exec.Command("git", fullArgs...)
 	out, err := cmd.Output()
 	if err != nil {
 		stderr := ""
 		if ee, ok := err.(*exec.ExitError); ok {
 			stderr = strings.TrimSpace(string(ee.Stderr))
 		}
-		return "", fmt.Errorf("git %s: %w (%s)", strings.Join(args, " "), err, stderr)
+		return "", fmt.Errorf("git %s: %w (%s)", strings.Join(fullArgs, " "), err, stderr)
 	}
 	return strings.TrimSpace(string(out)), nil
 }
@@ -137,8 +139,8 @@ func runGit(dir string, args ...string) (string, error) {
 // runGitCombined returns combined stdout+stderr as a single string, useful
 // when reporting the failure context for write operations.
 func runGitCombined(dir string, args ...string) (string, error) {
-	cmd := exec.Command("git", args...)
-	cmd.Dir = dir
+	fullArgs := append([]string{"-C", dir}, args...)
+	cmd := exec.Command("git", fullArgs...)
 	out, err := cmd.CombinedOutput()
 	return strings.TrimSpace(string(out)), err
 }

--- a/internal/gitx/worktree.go
+++ b/internal/gitx/worktree.go
@@ -1,0 +1,144 @@
+// Package gitx provides small, tested wrappers over the git porcelain
+// commands bip needs for its worktree integration. The point of this
+// package is not to reimplement git — it is to keep the dangerous paths
+// (worktree creation, --force removal, primary-clone resolution) in tested
+// Go so they are not duplicated as untested shell pipelines inside skill
+// markdown files.
+package gitx
+
+import (
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// IsInWorktree returns true if dir sits inside a linked worktree (one that
+// was added via `git worktree add`). It returns false if dir is the primary
+// working tree. An error here means dir is not a git repository at all, or
+// git itself failed.
+func IsInWorktree(dir string) (bool, error) {
+	common, err := runGit(dir, "rev-parse", "--path-format=absolute", "--git-common-dir")
+	if err != nil {
+		return false, err
+	}
+	gitDir, err := runGit(dir, "rev-parse", "--path-format=absolute", "--git-dir")
+	if err != nil {
+		return false, err
+	}
+	// In a primary working tree, --git-dir and --git-common-dir point at
+	// the same .git directory. In a linked worktree, --git-dir is the
+	// per-worktree .git/worktrees/<name> directory, while --git-common-dir
+	// is still the primary's .git.
+	return filepath.Clean(common) != filepath.Clean(gitDir), nil
+}
+
+// PrimaryCloneDir returns the canonical clone directory (the parent of the
+// primary .git directory) for dir, which may itself be either the primary
+// or a linked worktree.
+func PrimaryCloneDir(dir string) (string, error) {
+	common, err := runGit(dir, "rev-parse", "--path-format=absolute", "--git-common-dir")
+	if err != nil {
+		return "", err
+	}
+	// `--git-common-dir` resolves to "<primary>/.git" (or to the bare repo
+	// itself for a bare clone). For non-bare clones the primary working
+	// tree is its parent.
+	return filepath.Dir(filepath.Clean(common)), nil
+}
+
+// AddWorktree runs `git worktree add` from primaryClone, creating a new
+// worktree at path on a new branch. An empty branch checks out HEAD's
+// current branch (uncommon in our usage; we always pass a branch name).
+func AddWorktree(primaryClone, path, branch string) error {
+	args := []string{"worktree", "add"}
+	if branch != "" {
+		args = append(args, "-b", branch)
+	}
+	args = append(args, path)
+	out, err := runGitCombined(primaryClone, args...)
+	if err != nil {
+		return fmt.Errorf("git worktree add: %w\n%s", err, out)
+	}
+	return nil
+}
+
+// RemoveWorktree runs `git worktree remove` from primaryClone. force=true
+// passes --force, required after a squash merge leaves the worktree with
+// commits unreachable from the merged branch.
+func RemoveWorktree(primaryClone, path string, force bool) error {
+	args := []string{"worktree", "remove"}
+	if force {
+		args = append(args, "--force")
+	}
+	args = append(args, path)
+	out, err := runGitCombined(primaryClone, args...)
+	if err != nil {
+		return fmt.Errorf("git worktree remove: %w\n%s", err, out)
+	}
+	return nil
+}
+
+// WorktreeExists returns true if path is currently registered as a worktree
+// of primaryClone. Useful for the "spawn the same issue twice" reuse case.
+//
+// Comparison is symlink-resolving: macOS reports t.TempDir() paths as
+// /var/... while git emits the realpath /private/var/..., so a raw
+// filepath.Clean would miss the match.
+func WorktreeExists(primaryClone, path string) (bool, error) {
+	out, err := runGit(primaryClone, "worktree", "list", "--porcelain")
+	if err != nil {
+		return false, fmt.Errorf("git worktree list: %w", err)
+	}
+	target := realpath(path)
+	for _, line := range strings.Split(out, "\n") {
+		if !strings.HasPrefix(line, "worktree ") {
+			continue
+		}
+		wt := strings.TrimPrefix(line, "worktree ")
+		if realpath(wt) == target {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// realpath resolves symlinks and makes p absolute. On any error it falls
+// back to filepath.Clean(p) — callers want a best-effort canonical form,
+// not a hard failure.
+func realpath(p string) string {
+	abs, err := filepath.Abs(p)
+	if err != nil {
+		return filepath.Clean(p)
+	}
+	resolved, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		return filepath.Clean(abs)
+	}
+	return filepath.Clean(resolved)
+}
+
+// runGit invokes git in dir and returns trimmed stdout, with stderr folded
+// into the returned error on failure.
+func runGit(dir string, args ...string) (string, error) {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		stderr := ""
+		if ee, ok := err.(*exec.ExitError); ok {
+			stderr = strings.TrimSpace(string(ee.Stderr))
+		}
+		return "", fmt.Errorf("git %s: %w (%s)", strings.Join(args, " "), err, stderr)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// runGitCombined returns combined stdout+stderr as a single string, useful
+// when reporting the failure context for write operations.
+func runGitCombined(dir string, args ...string) (string, error) {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}

--- a/internal/gitx/worktree_test.go
+++ b/internal/gitx/worktree_test.go
@@ -1,0 +1,150 @@
+package gitx
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// initRepo creates a fresh git repo at dir with one commit on a branch
+// called "main" and returns the directory. We pin user.name/email and
+// init.defaultBranch via local config so the test does not pick up the
+// developer's global git settings.
+func initRepo(t *testing.T) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available in PATH")
+	}
+	dir := t.TempDir()
+	mustGit(t, dir, "init", "--quiet", "--initial-branch=main")
+	mustGit(t, dir, "config", "user.email", "test@example.com")
+	mustGit(t, dir, "config", "user.name", "Test User")
+	mustGit(t, dir, "config", "commit.gpgsign", "false")
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("hi\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustGit(t, dir, "add", "README.md")
+	mustGit(t, dir, "commit", "--quiet", "-m", "initial")
+	return dir
+}
+
+func mustGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+}
+
+func TestIsInWorktree_Primary(t *testing.T) {
+	primary := initRepo(t)
+	got, err := IsInWorktree(primary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got {
+		t.Errorf("IsInWorktree(primary) = true, want false")
+	}
+}
+
+func TestIsInWorktree_Linked(t *testing.T) {
+	primary := initRepo(t)
+	// Place the linked worktree as a sibling of the primary so the worktree
+	// path is never a subdirectory of the primary's working tree.
+	wt := filepath.Join(filepath.Dir(primary), "wt-feature")
+	if err := AddWorktree(primary, wt, "feature"); err != nil {
+		t.Fatalf("AddWorktree: %v", err)
+	}
+	got, err := IsInWorktree(wt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got {
+		t.Errorf("IsInWorktree(linked) = false, want true")
+	}
+}
+
+func TestPrimaryCloneDir(t *testing.T) {
+	primary := initRepo(t)
+	wt := filepath.Join(filepath.Dir(primary), "wt-feature")
+	if err := AddWorktree(primary, wt, "feature"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Resolve from inside the worktree — must walk back to the primary.
+	got, err := PrimaryCloneDir(wt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantAbs, _ := filepath.EvalSymlinks(primary)
+	gotAbs, _ := filepath.EvalSymlinks(got)
+	if gotAbs != wantAbs {
+		t.Errorf("PrimaryCloneDir(linked) = %q, want %q", gotAbs, wantAbs)
+	}
+
+	// Resolve from inside the primary itself — must return the primary.
+	got, err = PrimaryCloneDir(primary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotAbs, _ = filepath.EvalSymlinks(got)
+	if gotAbs != wantAbs {
+		t.Errorf("PrimaryCloneDir(primary) = %q, want %q", gotAbs, wantAbs)
+	}
+}
+
+func TestAddAndRemoveWorktree(t *testing.T) {
+	primary := initRepo(t)
+	wt := filepath.Join(filepath.Dir(primary), "wt-149")
+	if err := AddWorktree(primary, wt, "149-test"); err != nil {
+		t.Fatalf("AddWorktree: %v", err)
+	}
+	if _, err := os.Stat(wt); err != nil {
+		t.Fatalf("worktree dir not created: %v", err)
+	}
+	exists, err := WorktreeExists(primary, wt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !exists {
+		t.Errorf("WorktreeExists after add = false, want true")
+	}
+	if err := RemoveWorktree(primary, wt, false); err != nil {
+		t.Fatalf("RemoveWorktree: %v", err)
+	}
+	if _, err := os.Stat(wt); !os.IsNotExist(err) {
+		t.Errorf("worktree dir still exists after remove: err=%v", err)
+	}
+	exists, err = WorktreeExists(primary, wt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exists {
+		t.Errorf("WorktreeExists after remove = true, want false")
+	}
+}
+
+func TestRemoveWorktree_ForceOnDirty(t *testing.T) {
+	// A worktree with uncommitted changes can only be removed with --force.
+	// This is the post-squash-merge state pr-land lands in.
+	primary := initRepo(t)
+	wt := filepath.Join(filepath.Dir(primary), "wt-dirty")
+	if err := AddWorktree(primary, wt, "dirty-branch"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(wt, "uncommitted.txt"), []byte("dirt\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := RemoveWorktree(primary, wt, false); err == nil {
+		t.Fatal("expected non-force removal of dirty worktree to fail")
+	}
+	if err := RemoveWorktree(primary, wt, true); err != nil {
+		t.Fatalf("forced removal of dirty worktree failed: %v", err)
+	}
+	if _, err := os.Stat(wt); !os.IsNotExist(err) {
+		t.Errorf("worktree dir survived forced removal: err=%v", err)
+	}
+}

--- a/skills/bip-epic-handoff/SKILL.md
+++ b/skills/bip-epic-handoff/SKILL.md
@@ -194,3 +194,9 @@ the conductor handle cleanup.
 Same as `/bip-epic`: `iN`/`pN` prefixes, full URLs on first mention.
 Tmux windows named `NNN-YYY` where NNN is the issue number and YYY is the
 clone/slot name (e.g. `281-cedar` in clone mode, `281-issue-281` in worktree mode).
+
+## Layout config (issue #149)
+
+`.epic-config.json` keeps working. The newer global `layout:` block in
+`~/.config/bip/config.yml` configures worktree mode for non-EPIC `bip
+spawn`; see `docs/guides/layout.md`.

--- a/skills/bip-epic-poll/SKILL.md
+++ b/skills/bip-epic-poll/SKILL.md
@@ -185,3 +185,9 @@ update the clone assignments table.
 Same as `/bip-epic`: `iN`/`pN` prefixes, full URLs on first mention.
 Tmux windows named `NNN-YYY` where NNN is the issue number and YYY is the
 clone/slot name (e.g. `281-cedar` in clone mode, `281-issue-281` in worktree mode).
+
+## Layout config (issue #149)
+
+`.epic-config.json` keeps working. The newer global `layout:` block in
+`~/.config/bip/config.yml` configures worktree mode for non-EPIC `bip
+spawn`; see `docs/guides/layout.md`.

--- a/skills/bip-epic-spawn/SKILL.md
+++ b/skills/bip-epic-spawn/SKILL.md
@@ -456,3 +456,9 @@ Target project repos should gitignore these files (add to `.gitignore`):
 Same as `/bip-epic`: `iN`/`pN` prefixes. Tmux windows named `NNN-YYY`
 where NNN is the issue number and YYY is the clone/slot name
 (e.g. `281-cedar` in clone mode, `281-issue-281` in worktree mode).
+
+## Layout config (issue #149)
+
+`.epic-config.json` keeps working. The newer global `layout:` block in
+`~/.config/bip/config.yml` configures worktree mode for non-EPIC `bip
+spawn`; see `docs/guides/layout.md`.

--- a/skills/bip-epic/SKILL.md
+++ b/skills/bip-epic/SKILL.md
@@ -415,3 +415,11 @@ Legacy phases from older `.epic-status.json` files:
 - **Not in tmux**: Warn — tmux required for spawning
 - **No EPIC issues found**: Report and offer to create one
 - **gh not authenticated**: Suggest `gh auth login`
+
+## Layout config (issue #149)
+
+`.epic-config.json`'s `clone_root` / `clone_names` / `local_worktrees`
+keep working untouched. The newer way to configure worktree mode (for
+non-EPIC `bip spawn` use) is the `layout:` block in
+`~/.config/bip/config.yml` — see `docs/guides/layout.md`. EPIC
+orchestration still reads `.epic-config.json` for now.

--- a/skills/bip-pr-land/SKILL.md
+++ b/skills/bip-pr-land/SKILL.md
@@ -14,6 +14,16 @@ Squash-merge the current branch's PR and clean up.
 /bip-pr-land #42       # Land PR #42 (if not on that branch)
 ```
 
+## Worktree mode
+
+If `bip spawn` created the working tree as a linked git worktree (because
+the user opted into the global `layout: { mode: worktree }` block in
+`~/.config/bip/config.yml`), this skill detects that in Step 7a and
+performs the base-branch pull from the primary clone, then removes the
+worktree in Step 8 before deleting the branch. In the common clone-mode
+case (no `layout:` block) every step runs as it always has — the worktree
+detection is a no-op.
+
 ## Workflow
 
 ### Step 1: Check for uncommitted work
@@ -97,6 +107,27 @@ gh pr merge --squash --body ""
 
 Follow the squash merge conventions from global CLAUDE.md — PR title becomes the commit message, body is minimal.
 
+### Step 7a: Detect worktree mode
+
+Before pulling the base branch, check whether you are landing from a
+linked git worktree (created by `bip spawn` in worktree mode):
+
+```bash
+LAND_DIR=$(pwd -P)
+if PRIMARY=$(bip worktree primary 2>/dev/null); then
+    echo "Landing from worktree $LAND_DIR (primary: $PRIMARY)"
+    cd "$PRIMARY"
+fi
+```
+
+`bip worktree primary` exits 0 and prints the primary clone path **only**
+when the current directory is a linked worktree. In every other case
+(primary clone, non-bip checkout, non-git directory) it exits non-zero
+with no stdout — `$PRIMARY` remains empty and the `cd` is skipped.
+
+If `$PRIMARY` was set, Steps 7 and 7.5 below run in the primary clone;
+otherwise they run in `$LAND_DIR` exactly as today.
+
 ### Step 7: Return to base branch and pull
 
 ```bash
@@ -104,12 +135,15 @@ git checkout <base>
 git pull
 ```
 
-### Step 7.5: Sync the primary clone
+### Step 7.5: Sync the primary clone (clone-mode only)
 
-If you landed from a scratch clone (EPIC worker, `bip spawn`, or any
-working copy that isn't the canonical one in `sources.yml`), the primary
-clone is now behind `origin/<base>`. Pull it forward so the canonical
-checkout matches `main`.
+**Skip this step if Step 7a already `cd`'d to the primary** — Step 7 has
+already pulled it.
+
+If you landed from a scratch clone (EPIC worker, `bip spawn` without
+worktree mode, or any working copy that isn't the canonical one in
+`sources.yml`), the primary clone is now behind `origin/<base>`. Pull
+it forward so the canonical checkout matches `main`.
 
 1. Resolve the primary clone path the way `bip spawn` does (mirrors
    `flow.GetRepoLocalPath`: `nexus_path` from `~/.config/bip/config.yml`,
@@ -123,7 +157,21 @@ checkout matches `main`.
 
 3. Report what you did in Step 10.
 
-### Step 8: Delete local branch
+### Step 8: Remove worktree (if applicable) and delete branch
+
+If Step 7a found that you were landing from a linked worktree, remove
+the worktree **before** deleting its branch — git refuses to delete a
+branch that still has a worktree checked out on it:
+
+```bash
+if [ -n "$PRIMARY" ] && [ -n "$LAND_DIR" ] && [ "$LAND_DIR" != "$PRIMARY" ]; then
+    bip worktree remove "$LAND_DIR"
+fi
+```
+
+`bip worktree remove` defaults to `--force`, which is required because
+the squash-merge leaves the worktree carrying commits unreachable from
+the merged branch. Then delete the local branch:
 
 ```bash
 git branch -d <branch>
@@ -159,3 +207,5 @@ Report: "Landed #42. On `<base>`, up to date, worktree clean. Branch `<branch>` 
 If any files were moved to `_ignore/`, list them.
 If the primary clone was synced in Step 7.5, say so:
 "Primary clone `<path>` pulled."
+If Step 8 removed a linked worktree, say so:
+"Worktree `<path>` removed."

--- a/skills/bip-pr-land/SKILL.md
+++ b/skills/bip-pr-land/SKILL.md
@@ -146,7 +146,7 @@ worktree mode, or any working copy that isn't the canonical one in
 it forward so the canonical checkout matches `main`.
 
 1. Resolve the primary clone path the way `bip spawn` does (mirrors
-   `flow.GetRepoLocalPath`: `nexus_path` from `~/.config/bip/config.yml`,
+   `flow.ResolveRepoPath`: `nexus_path` from `~/.config/bip/config.yml`,
    repo from `git remote get-url origin`, then `sources.yml` +
    `config.yml` paths). If `$(pwd -P)` already equals it, or the repo
    isn't listed, skip this step.

--- a/skills/bip-spawn/SKILL.md
+++ b/skills/bip-spawn/SKILL.md
@@ -51,3 +51,26 @@ context, the handoff form is almost always what you want.
 ## Options
 
 - `--prompt "..."` — Custom prompt instead of default review prompt
+
+## Worktree mode (opt-in)
+
+By default, `bip spawn` opens its tmux window in the canonical clone of
+the repo — every spawn shares one working tree. To get one linked git
+worktree per issue instead (so concurrent spawns don't share a branch
+checkout), add a `layout:` block to `~/.config/bip/config.yml`:
+
+```yaml
+layout:
+  mode: worktree
+  worktree:
+    root: "~/re/{repo}-workers"   # {repo} = matsen/bipartite -> "bipartite"
+    slot: "issue-{issue}"          # supports {issue}, {pr}, {branch}, {slug}
+```
+
+Per-repo overrides live in `sources.yml` (see `docs/guides/layout.md`).
+With no `layout:` block, behavior is identical to before issue #149.
+
+When worktree mode fires, `bip spawn` runs `git worktree add` from the
+canonical clone on a fresh branch named `<N>-<slug>`, and the spawned
+tmux window opens in the new worktree. `bip pr-land` later detects the
+worktree, lands the PR from the primary clone, and removes the worktree.


### PR DESCRIPTION
🤖

Closes #149.

Adds an opt-in `layout:` block that lets `bip spawn` create one linked
git worktree per issue instead of sharing a canonical clone, and wires
`bip pr-land` to remove the worktree on land. With no `layout:` block
configured anywhere, every existing code path is **byte-identical** to
before — `TestResolveRepoPath_AbsentLayoutMatchesGetRepoLocalPath`
asserts this directly, including the writing-before-code precedence
that `bip checkin` / `board` / `scout` depend on.

## Decisions that diverge from the issue (please scrutinize these)

After a counter-opinion round with a sub-agent, I deviated from the
issue's literal text in four places. Each one is called out here for
review:

**1. `gitx` is consumed by the skill via hidden plumbing subcommands,
not raw git in markdown.** The issue says "spawn.go and the pr-land
skill both consume them," but a markdown skill can't call Go directly.
The dangerous path (`git worktree remove --force` then `git branch -d`)
ships in tested Go (`internal/gitx`) and the pr-land skill calls it via
hidden `bip worktree primary` / `bip worktree remove` subcommands
(`Hidden: true` in cobra — invisible in `bip --help`, completions, and
docs; surface unchanged for users). This was the single point the
counter-opinion pushed back hardest on, citing your "dogfood thoroughly"
note: raw-git in untested markdown is exactly the wrong place for a
forced-removal path on a feature you won't exercise.

**2. EPIC `resolveSlots` stays behavior-preserving rather than being
"rewritten in terms of `ResolveRepoPath`."** The two operations are
genuinely different shapes (EPIC scans disk to *discover* which issues
exist; the resolver maps a *known* issue → path, the inverse direction).
A literal rewrite would either force a single-path API onto a multi-slot
scan or change EPIC test pins. Instead I share only the
`config.WorktreeSlotPrefix` constant — one symbol edit if the
`issue-N` convention ever changes. All existing `epic_watch_test.go`
tests pass **unmodified** (the issue's #1 acceptance criterion).

**3. Lazy template validation.** The issue says unknown `{var}` errors
"at config load → bip refuses to start." Implemented as resolve-time
instead, so a typo in an opt-in `worktree.slot` template doesn't take
down `bip checkin` / `board` / `scout` for users who never opt in.

**4. `gitx` is broader than the issue specced.** Added `AddWorktree`
and `WorktreeExists` (real Go callers in `spawn.go`) on top of the
issue's `IsInWorktree` / `PrimaryCloneDir` / `RemoveWorktree`. Every
function has end-to-end tests against a temp `git init` + `git worktree
add`, including the `--force` dirty-tree case.

## Test coverage

```
internal/flow         TestResolveRepoPath_AbsentLayoutMatchesGetRepoLocalPath
                      TestResolveRepoPath_WritingTakesPrecedenceOverCode
                      TestResolveRepoPath_GlobalWorktreeMode
                      TestResolveRepoPath_WorktreeEmptyContextFallsBack
                      TestResolveRepoPath_PerRepoOverrideOptOut
                      TestResolveRepoPath_PerRepoPartialOverride
                      TestResolveRepoPath_RepoNotInSources
                      TestExpandTemplate
                      TestParseLayoutInSourcesYAML
                      TestParseLayoutMalformed
                      TestParseLayoutUnknownField
                      TestSlugifyTitle (table-driven; 12 cases)
internal/gitx         TestIsInWorktree_Primary / _Linked
                      TestPrimaryCloneDir
                      TestAddAndRemoveWorktree
                      TestRemoveWorktree_ForceOnDirty
cmd/bip               TestSpawnWorktreeIntegration  (resolver + AddWorktree
                                                    end-to-end, including reuse)
                      All existing epic_watch_test.go tests pass UNMODIFIED.
```

Manual smoke I ran in this session:

```
# from primary clone:    bip worktree primary  →  exit 3, no stdout
# from linked worktree:  bip worktree primary  →  exit 0, "<primary>"
# bip worktree remove $WT  →  worktree gone
# bip --help shows no "worktree" command (hidden working)
# go fmt/vet/test ./... all clean
```

What I can't run from this session: `bip spawn` inside an actual tmux
session against a real GitHub issue, and `bip pr-land` from inside a
spawned worktree. Those are the dogfood smokes for you (or @jaredgalloway).

## Files touched

```
Go (~1100 lines)
  cmd/bip/spawn.go                — call ResolveRepoPath, AddWorktree on IsNew worktree
  cmd/bip/epic_watch.go           — deprecation hint, share WorktreeSlotPrefix
  cmd/bip/worktree.go             — hidden plumbing subcommands
  cmd/bip/spawn_test.go           — resolver + gitx end-to-end
  internal/config/global.go       — GlobalConfig.Layout field
  internal/config/layout.go       — LayoutConfig types + constants
  internal/flow/config.go         — parseLayoutMap, GetRepoLocalPath wrapper
  internal/flow/resolve.go        — ResolveRepoPath, mergeLayouts, expandTemplate
  internal/flow/types.go          — RepoEntry.Layout
  internal/flow/slug.go           — SlugifyTitle
  internal/flow/{slug,layout}_test.go
  internal/gitx/worktree.go       — IsInWorktree / PrimaryCloneDir / Add / Remove / Exists
  internal/gitx/worktree_test.go

Skills (Article III — same-PR rule)
  skills/bip-pr-land/SKILL.md     — Step 7a worktree detect; revised 7.5 + 8
  skills/bip-spawn/SKILL.md       — opt-in section
  skills/bip-epic/SKILL.md        — one-line note
  skills/bip-epic-spawn/SKILL.md  — one-line note
  skills/bip-epic-poll/SKILL.md   — one-line note
  skills/bip-epic-handoff/SKILL.md — one-line note

Docs
  docs/guides/layout.md           — new schema/precedence/examples
  README.md                       — link to guide
  CLAUDE.md                       — one-line Repo facts entry
```

## What you should judge

- **Hidden plumbing subcommands.** `bip worktree primary` / `remove`
  are `Hidden: true` so they don't appear in `bip --help` — but they
  are still callable from any shell. If you'd rather they be invoked
  via an underscore-prefixed name (`bip _worktree-primary`) or live as
  unexported helpers somewhere else, this is the place to push back.
- **The `globalConfigCache` test wrinkle.** `internal/config` has a
  package-level cache (`globalConfigCache`) reset only by
  `ResetGlobalConfigCache()`. Every new resolver test sets
  `XDG_CONFIG_HOME` to a temp dir and calls `ResetGlobalConfigCache()`
  on entry + via `t.Cleanup`. Worth noting in case future tests touch
  layout and forget to reset.
- **Spawn error semantics.** Today's `GetRepoLocalPath` swallows config
  parse errors and returns `ok=false`; the new spawn path surfaces them
  with diagnostic detail via `flow.ResolveRepoPath`. This is arguably
  an improvement, but it's a user-visible change to error messages.

## DEFERRED

- The issue floats deprecating `.epic-config.json` "in a future PR once
  the new YAML form has been used in anger." Out of scope here.
- Migration tooling that translates an existing `.epic-config.json` to
  a `layout:` block. Out of scope here — `.epic-config.json` keeps
  working untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
