### PR TITLE
scout: fix CPU measurement — instantaneous per-user (/proc sampling) + overall (top delta)

### DIFF
--- a/docs/guides/server-scout.md
+++ b/docs/guides/server-scout.md
@@ -144,8 +144,11 @@ The skill runs `bip scout`, parses the JSON, and answers questions by reasoning 
 Scout connects to each server in parallel (max 5 concurrent) and runs:
 
 ```bash
-# Top CPU users (>1% usage; etimes>10 drops scout's own short-lived ssh procs)
-ps -eo user:20,%cpu,etimes --no-headers | awk '$3 > 10 {cpu[$1]+=$2} END {for (u in cpu) if (cpu[u]>1.0) printf "%s %.1f\n",u,cpu[u]}' | sort -k2 -rn
+# Top CPU users (>1% usage). Samples /proc/<pid>/stat twice 0.5s apart and
+# aggregates the (utime+stime) jiffy deltas by uid — a true instantaneous reading
+# (100% == one core), unlike `ps %cpu` which is a lifetime average. uids resolve via
+# `getent passwd` (LDAP-aware) and scout's own process group is excluded. See the
+# `topUsersCmd` awk program in internal/scout/metrics.go for the full sampler.
 
 # CPU usage (two iterations 0.5s apart so top reports a real delta, not since-boot)
 top -bn2 -d 0.5 | grep -i "cpu(s)" | tail -1 | awk '{print $2}' | cut -d'%' -f1

--- a/docs/guides/server-scout.md
+++ b/docs/guides/server-scout.md
@@ -144,11 +144,11 @@ The skill runs `bip scout`, parses the JSON, and answers questions by reasoning 
 Scout connects to each server in parallel (max 5 concurrent) and runs:
 
 ```bash
-# Top CPU users (>1% usage)
-ps -eo user:20,%cpu --no-headers | awk '{cpu[$1]+=$2} END {for (u in cpu) if (cpu[u]>1.0) printf "%s %.1f\n",u,cpu[u]}' | sort -k2 -rn
+# Top CPU users (>1% usage; etimes>10 drops scout's own short-lived ssh procs)
+ps -eo user:20,%cpu,etimes --no-headers | awk '$3 > 10 {cpu[$1]+=$2} END {for (u in cpu) if (cpu[u]>1.0) printf "%s %.1f\n",u,cpu[u]}' | sort -k2 -rn
 
-# CPU usage
-top -bn1 | grep -i "cpu(s)" | awk '{print $2}' | cut -d'%' -f1
+# CPU usage (two iterations 0.5s apart so top reports a real delta, not since-boot)
+top -bn2 -d 0.5 | grep -i "cpu(s)" | tail -1 | awk '{print $2}' | cut -d'%' -f1
 
 # Memory usage
 free -m | awk '/^Mem:/ {printf "%.1f", ($3/$2) * 100}'

--- a/docs/guides/server-scout.md
+++ b/docs/guides/server-scout.md
@@ -144,15 +144,12 @@ The skill runs `bip scout`, parses the JSON, and answers questions by reasoning 
 Scout connects to each server in parallel (max 5 concurrent) and runs:
 
 ```bash
-# Top CPU users (>1% usage). The remote command only dumps raw data — full
-# usernames via `stat -c %U` (untruncated, LDAP-aware) plus two snapshots of every
-# /proc/<pid>/stat 0.5s apart. Go (parseProcUserCPU in internal/scout/metrics.go)
-# differences the (utime+stime) jiffies per user for a true instantaneous reading
-# (100% == one core), unlike `ps %cpu` which is a lifetime average. Scout's own
-# session and serving sshd are excluded so its measurement overhead isn't counted.
-
-# CPU usage (two iterations 0.5s apart so top reports a real delta, not since-boot)
-top -bn2 -d 0.5 | grep -i "cpu(s)" | tail -1 | awk '{print $2}' | cut -d'%' -f1
+# Per-user CPU and overall CPU (one shared 0.5s sample). The remote command only
+# dumps raw data — full usernames via `stat -c %U` (untruncated, LDAP-aware) plus
+# two snapshots of /proc/stat and every /proc/<pid>/stat, 0.5s apart:
+echo "CLK $(getconf CLK_TCK) SID $(cut -d' ' -f6 /proc/$$/stat) SSHD $PPID"
+stat -c '%U %n' /proc/[0-9]*
+cat /proc/stat /proc/[0-9]*/stat ; sleep 0.5 ; cat /proc/stat /proc/[0-9]*/stat
 
 # Memory usage
 free -m | awk '/^Mem:/ {printf "%.1f", ($3/$2) * 100}'
@@ -165,4 +162,10 @@ nvidia-smi --query-gpu=utilization.gpu --format=csv,noheader,nounits
 nvidia-smi --query-gpu=memory.used,memory.total --format=csv,noheader,nounits
 ```
 
-GPU metrics are only collected for servers with `has_gpu: true`. Failed commands are non-fatal — partial output is still parsed.
+`parseProcSample` (in `internal/scout/metrics.go`) does all the arithmetic in Go:
+per-user CPU from each process's `(utime+stime)` jiffy delta (100% == one core,
+unlike `ps %cpu`'s lifetime average), and overall CPU from `/proc/stat`'s aggregate
+line as `(Δtotal − Δidle)/Δtotal` (total busy, including system/IO — not just the
+user fraction `top` reports). Scout's own session and serving sshd are excluded so
+its measurement overhead isn't counted. GPU metrics are only collected for servers
+with `has_gpu: true`. Failed commands are non-fatal — partial output is still parsed.

--- a/docs/guides/server-scout.md
+++ b/docs/guides/server-scout.md
@@ -144,11 +144,12 @@ The skill runs `bip scout`, parses the JSON, and answers questions by reasoning 
 Scout connects to each server in parallel (max 5 concurrent) and runs:
 
 ```bash
-# Top CPU users (>1% usage). Samples /proc/<pid>/stat twice 0.5s apart and
-# aggregates the (utime+stime) jiffy deltas by uid — a true instantaneous reading
-# (100% == one core), unlike `ps %cpu` which is a lifetime average. uids resolve via
-# `getent passwd` (LDAP-aware) and scout's own process group is excluded. See the
-# `topUsersCmd` awk program in internal/scout/metrics.go for the full sampler.
+# Top CPU users (>1% usage). The remote command only dumps raw data — full
+# usernames via `stat -c %U` (untruncated, LDAP-aware) plus two snapshots of every
+# /proc/<pid>/stat 0.5s apart. Go (parseProcUserCPU in internal/scout/metrics.go)
+# differences the (utime+stime) jiffies per user for a true instantaneous reading
+# (100% == one core), unlike `ps %cpu` which is a lifetime average. Scout's own
+# session and serving sshd are excluded so its measurement overhead isn't counted.
 
 # CPU usage (two iterations 0.5s apart so top reports a real delta, not since-boot)
 top -bn2 -d 0.5 | grep -i "cpu(s)" | tail -1 | awk '{print $2}' | cut -d'%' -f1

--- a/internal/scout/metrics.go
+++ b/internal/scout/metrics.go
@@ -2,6 +2,7 @@ package scout
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -13,57 +14,52 @@ const delimiter = "___SCOUT_DELIM___"
 // maxConcurrent is the bounded semaphore size for parallel server checks.
 const maxConcurrent = 5
 
-// topUsersCmd computes per-user CPU usage by sampling /proc/<pid>/stat twice
-// 0.5s apart and aggregating the (utime+stime) jiffy deltas by uid. This gives a
-// true instantaneous reading where 100% == one fully-used core (matching ps's
-// %cpu unit), without ps's two failure modes: ps %cpu is a lifetime average, so
-// (a) the short-lived sshd/systemd-user serving scout's own session report ~20%
-// each (tiny elapsed-time denominator), summing to a spurious "~220%" floor, and
-// (b) a process that ran hot hours ago but is now idle keeps over-reporting.
+// procSampleSeconds is the gap between the two /proc snapshots taken to measure
+// per-user CPU. It must match the `sleep` in topUsersCmd (both derive from it).
+const procSampleSeconds = 0.5
+
+// userCPUThreshold is the minimum per-user CPU percent (100 == one full core) to
+// report, dropping the long tail of near-idle accounts.
+const userCPUThreshold = 1.0
+
+// procSnapMarker separates the three blocks of topUsersCmd's output: the header
+// + uid→name map, then the two /proc snapshots. It must not contain the section
+// delimiter, and parseProcUserCPU splits the section on it.
+const procSnapMarker = "@@SCOUT_SNAP@@"
+
+// topUsersCmd dumps the raw data needed to compute true instantaneous per-user
+// CPU, doing no arithmetic on the remote host — parseProcUserCPU does that in Go.
+// It emits, in one section:
 //
-// Details that matter:
-//   - jiffies→percent: delta / (CLK_TCK * dt) * 100. CLK_TCK is read at runtime.
-//   - uid→name uses `getent passwd <uid>`, not /etc/passwd, so cluster users
-//     served by LDAP/SSS resolve (only the few users above threshold are looked up).
-//   - the comm field (field 2 of /proc/<pid>/stat) can contain spaces and ')',
-//     so we split on the text after the *last* ')'.
-//   - MYPGID is scout's own process-group id; processes in it are skipped. The
-//     awk reader itself burns CPU walking /proc during the interval, which would
-//     otherwise be charged to the scout user — the same self-measurement artifact,
-//     just smaller. Excluding the process group drops the whole scout pipeline.
-const topUsersCmd = `PGID=$(cut -d' ' -f5 /proc/self/stat); awk -v CLK=$(getconf CLK_TCK) -v DT=0.5 -v MYPGID=$PGID '
-function readstat(p,  line,i,pos,parts,n){
-  G_ok=0
-  if((getline line < ("/proc/" p "/stat"))<=0){close("/proc/" p "/stat");return}
-  close("/proc/" p "/stat")
-  pos=0; for(i=length(line);i>=1;i--) if(substr(line,i,1)==")"){pos=i;break}
-  n=split(substr(line,pos+2),parts," ")
-  G_pgrp=parts[3]; G_jiff=parts[12]+parts[13]; G_ok=1
-}
-function puid(p,  line,a){
-  while((getline line < ("/proc/" p "/status"))>0)
-    if(substr(line,1,4)=="Uid:"){split(line,a,/[ \t]+/);close("/proc/" p "/status");return a[2]}
-  close("/proc/" p "/status"); return "?"
-}
-function resolve(uid,  line,a,cmd){
-  cmd="getent passwd " uid
-  if((cmd|getline line)>0){close(cmd);split(line,a,":");return a[1]}
-  close(cmd); return uid
-}
-BEGIN{
-  while(("ls /proc"|getline p)>0) if(p~/^[0-9]+$/) pids[np++]=p
-  close("ls /proc")
-  for(i=0;i<np;i++){p=pids[i];readstat(p);if(G_ok){t0[p]=G_jiff;uid0[p]=puid(p)}}
-  system("sleep " DT)
-  for(i=0;i<np;i++){
-    p=pids[i]; if(!(p in t0)) continue
-    readstat(p); if(!G_ok) continue
-    if(G_pgrp==MYPGID) continue
-    d=G_jiff-t0[p]; if(d<=0) continue
-    cpu[uid0[p]]+=d
-  }
-  for(u in cpu){pct=cpu[u]/(CLK*DT)*100; if(pct>1.0) printf "%s %.1f\n",resolve(u),pct}
-}' | sort -k2 -rn`
+//	CLK <clk_tck> SID <our_session> SSHD <serving_sshd_pid>
+//	<user> /proc/<pid>        (one per process, full LDAP names via stat(1))
+//	@@SCOUT_SNAP@@
+//	<contents of every /proc/<pid>/stat>     (snapshot 1)
+//	@@SCOUT_SNAP@@
+//	<contents of every /proc/<pid>/stat>     (snapshot 2, taken sleep later)
+//
+// Sampling /proc/<pid>/stat twice and differencing (utime+stime) jiffies gives a
+// current reading (100% == one core, matching ps's %cpu unit) without ps's two
+// failure modes: ps %cpu is a lifetime average, so (a) the short-lived sshd the
+// SSH session spawns reports a large % from a tiny elapsed-time denominator,
+// summing to a spurious per-user floor, and (b) a process that ran hot hours ago
+// but is now idle keeps over-reporting. `stat -c %U` is used for names rather than
+// top's USER column because top truncates to 8 chars + '+', merging distinct users
+// (systemd-resolve/systemd-timesync both become "systemd+").
+//
+// SID and SSHD identify scout's own footprint so parseProcUserCPU can exclude it:
+// SID (our login session — field 6 of the shell's own /proc/$$/stat) covers the
+// shell and the cat/stat pipeline, and SSHD ($PPID) is the sshd serving the
+// connection. That sshd sits in a *different* session, so SID alone misses it, yet
+// the CPU it spends streaming this (sizeable) output back would otherwise be
+// mis-charged to the ssh user.
+var topUsersCmd = fmt.Sprintf(
+	`echo "CLK $(getconf CLK_TCK) SID $(cut -d' ' -f6 /proc/$$/stat) SSHD $PPID"; `+
+		`stat -c '%%U %%n' /proc/[0-9]* 2>/dev/null; echo '%s'; `+
+		`cat /proc/[0-9]*/stat 2>/dev/null; echo '%s'; `+
+		`sleep %.1f; cat /proc/[0-9]*/stat 2>/dev/null`,
+	procSnapMarker, procSnapMarker, procSampleSeconds,
+)
 
 // Section indices for ParseMetrics output splitting.
 // These must match the command order in BuildCommand.
@@ -80,7 +76,7 @@ const (
 // All metric commands are joined with delimiters for single-session execution.
 func BuildCommand(server Server) string {
 	cmds := []string{
-		// Top CPU users (true instantaneous, via /proc delta sampling).
+		// Top CPU users — raw /proc snapshots; parseProcUserCPU does the math.
 		topUsersCmd,
 		// CPU usage. Two iterations 0.5s apart so top reports a real delta; its
 		// first iteration has no prior sample and would report since-boot stats.
@@ -140,8 +136,8 @@ func ParseMetrics(output string, hasGPU bool) (*ServerMetrics, error) {
 	metrics := &ServerMetrics{}
 
 	// Parse top users — non-fatal on failure
-	// (topUsersCmd excludes scout's own process group via MYPGID)
-	if users, err := parseTopUsers(sections[sectionTopUsers]); err == nil {
+	// (the snapshot data identifies and excludes scout's own process group)
+	if users, err := parseProcUserCPU(sections[sectionTopUsers]); err == nil {
 		metrics.TopUsers = users
 	}
 
@@ -254,27 +250,122 @@ func parseGPUMemory(output string) ([][2]int, error) {
 	return vals, nil
 }
 
-// parseTopUsers parses "username 42.1" lines into a slice of UserCPU.
-// Returns nil slice for empty input (no users above threshold).
-func parseTopUsers(output string) ([]UserCPU, error) {
-	lines := splitNonEmpty(output)
-	if len(lines) == 0 {
-		return nil, nil
+// procStat is the subset of a /proc/<pid>/stat line we care about.
+type procStat struct {
+	session string
+	jiffies int64 // utime + stime, in clock ticks
+}
+
+// parseProcUserCPU turns topUsersCmd's output (header + uid→name map + two
+// /proc/<pid>/stat snapshots, separated by procSnapMarker) into per-user CPU.
+// For each process present in both snapshots and not part of scout's own session
+// or serving sshd, it differences the (utime+stime) jiffies; the per-user totals
+// become a percentage where 100 == one fully-used core (delta / (clkTck * dt) *
+// 100), matching ps's %cpu unit. Users at or below userCPUThreshold are dropped,
+// and results are sorted by CPU descending.
+func parseProcUserCPU(section string) ([]UserCPU, error) {
+	blocks := strings.Split(section, procSnapMarker)
+	if len(blocks) != 3 {
+		return nil, fmt.Errorf("expected 3 blocks separated by %q, got %d", procSnapMarker, len(blocks))
 	}
 
-	var users []UserCPU
-	for _, line := range lines {
-		fields := strings.Fields(line)
-		if len(fields) < 2 {
-			return nil, fmt.Errorf("parsing user CPU line: expected 2 fields, got %d (raw: %q)", len(fields), line)
-		}
-		pct, err := strconv.ParseFloat(fields[1], 64)
-		if err != nil {
-			return nil, fmt.Errorf("parsing user CPU percent: %w (raw: %q)", err, fields[1])
-		}
-		users = append(users, UserCPU{User: fields[0], CPUPercent: pct})
+	clkTck, ownSession, sshdPID, pidUser, err := parseProcHeader(blocks[0])
+	if err != nil {
+		return nil, err
 	}
+	before := parseProcSnapshot(blocks[1])
+	after := parseProcSnapshot(blocks[2])
+
+	jiffiesByUser := make(map[string]int64)
+	for pid, a := range after {
+		b, seenBefore := before[pid]
+		if !seenBefore || a.session == ownSession || pid == sshdPID {
+			continue
+		}
+		delta := a.jiffies - b.jiffies
+		if delta <= 0 {
+			continue
+		}
+		user := pidUser[pid]
+		if user == "" {
+			user = "?"
+		}
+		jiffiesByUser[user] += delta
+	}
+
+	denom := float64(clkTck) * procSampleSeconds
+	var users []UserCPU
+	for user, jiffies := range jiffiesByUser {
+		pct := float64(jiffies) * 100 / denom
+		if pct > userCPUThreshold {
+			users = append(users, UserCPU{User: user, CPUPercent: pct})
+		}
+	}
+	sort.Slice(users, func(i, j int) bool { return users[i].CPUPercent > users[j].CPUPercent })
 	return users, nil
+}
+
+// parseProcHeader parses the first block of topUsersCmd's output: a
+// "CLK <n> SID <n> SSHD <n>" line followed by "<user> /proc/<pid>" mapping lines.
+func parseProcHeader(block string) (clkTck int64, ownSession, sshdPID string, pidUser map[string]string, err error) {
+	lines := splitNonEmpty(block)
+	if len(lines) == 0 {
+		return 0, "", "", nil, fmt.Errorf("empty per-user CPU header")
+	}
+	hdr := strings.Fields(lines[0])
+	if len(hdr) != 6 || hdr[0] != "CLK" || hdr[2] != "SID" || hdr[4] != "SSHD" {
+		return 0, "", "", nil, fmt.Errorf("malformed per-user CPU header (raw: %q)", lines[0])
+	}
+	clkTck, err = strconv.ParseInt(hdr[1], 10, 64)
+	if err != nil {
+		return 0, "", "", nil, fmt.Errorf("parsing CLK_TCK: %w (raw: %q)", err, hdr[1])
+	}
+	if clkTck <= 0 {
+		return 0, "", "", nil, fmt.Errorf("non-positive CLK_TCK: %d", clkTck)
+	}
+	ownSession, sshdPID = hdr[3], hdr[5]
+
+	pidUser = make(map[string]string)
+	for _, line := range lines[1:] {
+		// "<user> /proc/<pid>" — usernames have no spaces, so two fields.
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			continue
+		}
+		pid := fields[1][strings.LastIndexByte(fields[1], '/')+1:]
+		pidUser[pid] = fields[0]
+	}
+	return clkTck, ownSession, sshdPID, pidUser, nil
+}
+
+// parseProcSnapshot parses a block of /proc/<pid>/stat lines into pid → procStat.
+// Malformed lines are skipped (processes come and go between snapshots).
+func parseProcSnapshot(block string) map[string]procStat {
+	out := make(map[string]procStat)
+	for _, line := range splitNonEmpty(block) {
+		// Format: "<pid> (comm) <state> <ppid> <pgrp> ... <utime> <stime> ...".
+		// comm can contain spaces and ')', so the pid is the text before the
+		// first space and the remaining fields start after the *last* ')'.
+		sp := strings.IndexByte(line, ' ')
+		rp := strings.LastIndexByte(line, ')')
+		if sp < 0 || rp < 0 || rp+1 >= len(line) {
+			continue
+		}
+		pid := line[:sp]
+		// Fields after comm (0-indexed): state(0) ppid(1) pgrp(2) session(3) ...
+		// utime(11) stime(12).
+		f := strings.Fields(line[rp+1:])
+		if len(f) < 13 {
+			continue
+		}
+		utime, err1 := strconv.ParseInt(f[11], 10, 64)
+		stime, err2 := strconv.ParseInt(f[12], 10, 64)
+		if err1 != nil || err2 != nil {
+			continue
+		}
+		out[pid] = procStat{session: f[3], jiffies: utime + stime}
+	}
+	return out
 }
 
 // splitNonEmpty splits a string by newlines and returns only non-empty lines.

--- a/internal/scout/metrics.go
+++ b/internal/scout/metrics.go
@@ -13,6 +13,58 @@ const delimiter = "___SCOUT_DELIM___"
 // maxConcurrent is the bounded semaphore size for parallel server checks.
 const maxConcurrent = 5
 
+// topUsersCmd computes per-user CPU usage by sampling /proc/<pid>/stat twice
+// 0.5s apart and aggregating the (utime+stime) jiffy deltas by uid. This gives a
+// true instantaneous reading where 100% == one fully-used core (matching ps's
+// %cpu unit), without ps's two failure modes: ps %cpu is a lifetime average, so
+// (a) the short-lived sshd/systemd-user serving scout's own session report ~20%
+// each (tiny elapsed-time denominator), summing to a spurious "~220%" floor, and
+// (b) a process that ran hot hours ago but is now idle keeps over-reporting.
+//
+// Details that matter:
+//   - jiffies→percent: delta / (CLK_TCK * dt) * 100. CLK_TCK is read at runtime.
+//   - uid→name uses `getent passwd <uid>`, not /etc/passwd, so cluster users
+//     served by LDAP/SSS resolve (only the few users above threshold are looked up).
+//   - the comm field (field 2 of /proc/<pid>/stat) can contain spaces and ')',
+//     so we split on the text after the *last* ')'.
+//   - MYPGID is scout's own process-group id; processes in it are skipped. The
+//     awk reader itself burns CPU walking /proc during the interval, which would
+//     otherwise be charged to the scout user — the same self-measurement artifact,
+//     just smaller. Excluding the process group drops the whole scout pipeline.
+const topUsersCmd = `PGID=$(cut -d' ' -f5 /proc/self/stat); awk -v CLK=$(getconf CLK_TCK) -v DT=0.5 -v MYPGID=$PGID '
+function readstat(p,  line,i,pos,parts,n){
+  G_ok=0
+  if((getline line < ("/proc/" p "/stat"))<=0){close("/proc/" p "/stat");return}
+  close("/proc/" p "/stat")
+  pos=0; for(i=length(line);i>=1;i--) if(substr(line,i,1)==")"){pos=i;break}
+  n=split(substr(line,pos+2),parts," ")
+  G_pgrp=parts[3]; G_jiff=parts[12]+parts[13]; G_ok=1
+}
+function puid(p,  line,a){
+  while((getline line < ("/proc/" p "/status"))>0)
+    if(substr(line,1,4)=="Uid:"){split(line,a,/[ \t]+/);close("/proc/" p "/status");return a[2]}
+  close("/proc/" p "/status"); return "?"
+}
+function resolve(uid,  line,a,cmd){
+  cmd="getent passwd " uid
+  if((cmd|getline line)>0){close(cmd);split(line,a,":");return a[1]}
+  close(cmd); return uid
+}
+BEGIN{
+  while(("ls /proc"|getline p)>0) if(p~/^[0-9]+$/) pids[np++]=p
+  close("ls /proc")
+  for(i=0;i<np;i++){p=pids[i];readstat(p);if(G_ok){t0[p]=G_jiff;uid0[p]=puid(p)}}
+  system("sleep " DT)
+  for(i=0;i<np;i++){
+    p=pids[i]; if(!(p in t0)) continue
+    readstat(p); if(!G_ok) continue
+    if(G_pgrp==MYPGID) continue
+    d=G_jiff-t0[p]; if(d<=0) continue
+    cpu[uid0[p]]+=d
+  }
+  for(u in cpu){pct=cpu[u]/(CLK*DT)*100; if(pct>1.0) printf "%s %.1f\n",resolve(u),pct}
+}' | sort -k2 -rn`
+
 // Section indices for ParseMetrics output splitting.
 // These must match the command order in BuildCommand.
 const (
@@ -28,11 +80,8 @@ const (
 // All metric commands are joined with delimiters for single-session execution.
 func BuildCommand(server Server) string {
 	cmds := []string{
-		// Top CPU users. The etimes>10 filter drops processes alive under 10s,
-		// excluding the sshd/systemd-user that serve scout's own session — their
-		// tiny elapsed-time denominator otherwise inflates ps's lifetime-average
-		// %cpu to ~20% each, summing to a spurious per-user "~220%" floor.
-		`ps -eo user:20,%cpu,etimes --no-headers | awk '$3 > 10 {cpu[$1]+=$2} END {for (u in cpu) if (cpu[u]>1.0) printf "%s %.1f\n",u,cpu[u]}' | sort -k2 -rn`,
+		// Top CPU users (true instantaneous, via /proc delta sampling).
+		topUsersCmd,
 		// CPU usage. Two iterations 0.5s apart so top reports a real delta; its
 		// first iteration has no prior sample and would report since-boot stats.
 		`top -bn2 -d 0.5 | grep -i "cpu(s)" | tail -1 | awk '{print $2}' | cut -d'%' -f1`,
@@ -91,7 +140,7 @@ func ParseMetrics(output string, hasGPU bool) (*ServerMetrics, error) {
 	metrics := &ServerMetrics{}
 
 	// Parse top users — non-fatal on failure
-	// (the etimes filter in BuildCommand excludes scout's own short-lived procs)
+	// (topUsersCmd excludes scout's own process group via MYPGID)
 	if users, err := parseTopUsers(sections[sectionTopUsers]); err == nil {
 		metrics.TopUsers = users
 	}

--- a/internal/scout/metrics.go
+++ b/internal/scout/metrics.go
@@ -28,10 +28,14 @@ const (
 // All metric commands are joined with delimiters for single-session execution.
 func BuildCommand(server Server) string {
 	cmds := []string{
-		// Top CPU users — runs first to avoid counting scout's own commands
-		`ps -eo user:20,%cpu --no-headers | awk '{cpu[$1]+=$2} END {for (u in cpu) if (cpu[u]>1.0) printf "%s %.1f\n",u,cpu[u]}' | sort -k2 -rn`,
-		// CPU usage
-		`top -bn1 | grep -i "cpu(s)" | awk '{print $2}' | cut -d'%' -f1`,
+		// Top CPU users. The etimes>10 filter drops processes alive under 10s,
+		// excluding the sshd/systemd-user that serve scout's own session — their
+		// tiny elapsed-time denominator otherwise inflates ps's lifetime-average
+		// %cpu to ~20% each, summing to a spurious per-user "~220%" floor.
+		`ps -eo user:20,%cpu,etimes --no-headers | awk '$3 > 10 {cpu[$1]+=$2} END {for (u in cpu) if (cpu[u]>1.0) printf "%s %.1f\n",u,cpu[u]}' | sort -k2 -rn`,
+		// CPU usage. Two iterations 0.5s apart so top reports a real delta; its
+		// first iteration has no prior sample and would report since-boot stats.
+		`top -bn2 -d 0.5 | grep -i "cpu(s)" | tail -1 | awk '{print $2}' | cut -d'%' -f1`,
 		// Memory usage
 		`free -m | awk '/^Mem:/ {printf "%.1f", ($3/$2) * 100}'`,
 		// Load average
@@ -87,7 +91,7 @@ func ParseMetrics(output string, hasGPU bool) (*ServerMetrics, error) {
 	metrics := &ServerMetrics{}
 
 	// Parse top users — non-fatal on failure
-	// (runs first on the server to avoid counting scout's own commands)
+	// (the etimes filter in BuildCommand excludes scout's own short-lived procs)
 	if users, err := parseTopUsers(sections[sectionTopUsers]); err == nil {
 		metrics.TopUsers = users
 	}

--- a/internal/scout/metrics.go
+++ b/internal/scout/metrics.go
@@ -14,73 +14,73 @@ const delimiter = "___SCOUT_DELIM___"
 // maxConcurrent is the bounded semaphore size for parallel server checks.
 const maxConcurrent = 5
 
-// procSampleSeconds is the gap between the two /proc snapshots taken to measure
-// per-user CPU. It must match the `sleep` in topUsersCmd (both derive from it).
+// procSampleSeconds is the gap between the two /proc snapshots. It must match the
+// `sleep` in procSampleCmd (both derive from it).
 const procSampleSeconds = 0.5
 
 // userCPUThreshold is the minimum per-user CPU percent (100 == one full core) to
 // report, dropping the long tail of near-idle accounts.
 const userCPUThreshold = 1.0
 
-// procSnapMarker separates the three blocks of topUsersCmd's output: the header
+// procSnapMarker separates the three blocks of procSampleCmd's output: the header
 // + uid→name map, then the two /proc snapshots. It must not contain the section
-// delimiter, and parseProcUserCPU splits the section on it.
+// delimiter, and parseProcSample splits the section on it.
 const procSnapMarker = "@@SCOUT_SNAP@@"
 
-// topUsersCmd dumps the raw data needed to compute true instantaneous per-user
-// CPU, doing no arithmetic on the remote host — parseProcUserCPU does that in Go.
+// procSampleCmd dumps the raw data needed to compute both per-user CPU and overall
+// CPU, doing no arithmetic on the remote host — parseProcSample does that in Go.
 // It emits, in one section:
 //
 //	CLK <clk_tck> SID <our_session> SSHD <serving_sshd_pid>
 //	<user> /proc/<pid>        (one per process, full LDAP names via stat(1))
 //	@@SCOUT_SNAP@@
-//	<contents of every /proc/<pid>/stat>     (snapshot 1)
+//	<contents of /proc/stat and every /proc/<pid>/stat>   (snapshot 1)
 //	@@SCOUT_SNAP@@
-//	<contents of every /proc/<pid>/stat>     (snapshot 2, taken sleep later)
+//	<contents of /proc/stat and every /proc/<pid>/stat>   (snapshot 2, sleep later)
 //
-// Sampling /proc/<pid>/stat twice and differencing (utime+stime) jiffies gives a
-// current reading (100% == one core, matching ps's %cpu unit) without ps's two
-// failure modes: ps %cpu is a lifetime average, so (a) the short-lived sshd the
-// SSH session spawns reports a large % from a tiny elapsed-time denominator,
-// summing to a spurious per-user floor, and (b) a process that ran hot hours ago
-// but is now idle keeps over-reporting. `stat -c %U` is used for names rather than
-// top's USER column because top truncates to 8 chars + '+', merging distinct users
-// (systemd-resolve/systemd-timesync both become "systemd+").
+// Two snapshots differenced over one window give both numbers:
+//   - Per-user: sum each process's (utime+stime) jiffy delta by user — a current
+//     reading (100% == one core, matching ps's %cpu unit) without ps's two failure
+//     modes: ps %cpu is a lifetime average, so the short-lived sshd serving the SSH
+//     session reports a large % from a tiny denominator (a spurious per-user floor),
+//     and a process that ran hot hours ago but is now idle keeps over-reporting.
+//   - Overall: from /proc/stat's aggregate "cpu" line, busy% = (Δtotal − Δidle) /
+//     Δtotal, where idle includes iowait. This replaces `top`, which both needs its
+//     own second sample (so we'd sleep twice) and, as we parsed it, reported only
+//     the user fraction — undercounting system/IO-heavy machines.
 //
-// SID and SSHD identify scout's own footprint so parseProcUserCPU can exclude it:
-// SID (our login session — field 6 of the shell's own /proc/$$/stat) covers the
-// shell and the cat/stat pipeline, and SSHD ($PPID) is the sshd serving the
-// connection. That sshd sits in a *different* session, so SID alone misses it, yet
-// the CPU it spends streaming this (sizeable) output back would otherwise be
-// mis-charged to the ssh user.
-var topUsersCmd = fmt.Sprintf(
+// `stat -c %U` is used for names rather than top's USER column because top truncates
+// to 8 chars + '+', merging distinct users (systemd-resolve/systemd-timesync both
+// become "systemd+"). SID and SSHD identify scout's own footprint so parseProcSample
+// can exclude it: SID (our login session — field 6 of the shell's own /proc/$$/stat)
+// covers the shell and the cat/stat pipeline, and SSHD ($PPID) is the sshd serving
+// the connection — it sits in a *different* session, so SID alone misses it, yet the
+// CPU it spends streaming this (sizeable) output back would otherwise be mis-charged
+// to the ssh user.
+var procSampleCmd = fmt.Sprintf(
 	`echo "CLK $(getconf CLK_TCK) SID $(cut -d' ' -f6 /proc/$$/stat) SSHD $PPID"; `+
 		`stat -c '%%U %%n' /proc/[0-9]* 2>/dev/null; echo '%s'; `+
-		`cat /proc/[0-9]*/stat 2>/dev/null; echo '%s'; `+
-		`sleep %.1f; cat /proc/[0-9]*/stat 2>/dev/null`,
+		`cat /proc/stat /proc/[0-9]*/stat 2>/dev/null; echo '%s'; `+
+		`sleep %.1f; cat /proc/stat /proc/[0-9]*/stat 2>/dev/null`,
 	procSnapMarker, procSnapMarker, procSampleSeconds,
 )
 
 // Section indices for ParseMetrics output splitting.
 // These must match the command order in BuildCommand.
 const (
-	sectionTopUsers = 0
-	sectionCPU      = 1
-	sectionMemory   = 2
-	sectionLoadAvg  = 3
-	sectionGPUUtil  = 4
-	sectionGPUMem   = 5
+	sectionSample  = 0 // per-user CPU and overall CPU (parseProcSample)
+	sectionMemory  = 1
+	sectionLoadAvg = 2
+	sectionGPUUtil = 3
+	sectionGPUMem  = 4
 )
 
 // BuildCommand constructs the combined command string for a server.
 // All metric commands are joined with delimiters for single-session execution.
 func BuildCommand(server Server) string {
 	cmds := []string{
-		// Top CPU users — raw /proc snapshots; parseProcUserCPU does the math.
-		topUsersCmd,
-		// CPU usage. Two iterations 0.5s apart so top reports a real delta; its
-		// first iteration has no prior sample and would report since-boot stats.
-		`top -bn2 -d 0.5 | grep -i "cpu(s)" | tail -1 | awk '{print $2}' | cut -d'%' -f1`,
+		// Per-user and overall CPU — raw /proc snapshots; parseProcSample does the math.
+		procSampleCmd,
 		// Memory usage
 		`free -m | awk '/^Mem:/ {printf "%.1f", ($3/$2) * 100}'`,
 		// Load average
@@ -125,9 +125,9 @@ func ParseMetrics(output string, hasGPU bool) (*ServerMetrics, error) {
 		sections[i] = strings.TrimSpace(sections[i])
 	}
 
-	expectedSections := 4
+	expectedSections := 3
 	if hasGPU {
-		expectedSections = 6
+		expectedSections = 5
 	}
 	if len(sections) < expectedSections {
 		return nil, fmt.Errorf("expected %d metric sections, got %d", expectedSections, len(sections))
@@ -135,17 +135,13 @@ func ParseMetrics(output string, hasGPU bool) (*ServerMetrics, error) {
 
 	metrics := &ServerMetrics{}
 
-	// Parse top users — non-fatal on failure
-	// (the snapshot data identifies and excludes scout's own process group)
-	if users, err := parseProcUserCPU(sections[sectionTopUsers]); err == nil {
-		metrics.TopUsers = users
-	}
-
-	// Parse CPU
-	cpu, err := parseFloatMetric(sections[sectionCPU], "CPU")
+	// Parse per-user and overall CPU from the /proc snapshots (one sample window).
+	// The snapshot data identifies and excludes scout's own session and sshd.
+	users, cpu, err := parseProcSample(sections[sectionSample])
 	if err != nil {
 		return nil, err
 	}
+	metrics.TopUsers = users
 	metrics.CPUPercent = cpu
 
 	// Parse Memory
@@ -256,25 +252,34 @@ type procStat struct {
 	jiffies int64 // utime + stime, in clock ticks
 }
 
-// parseProcUserCPU turns topUsersCmd's output (header + uid→name map + two
-// /proc/<pid>/stat snapshots, separated by procSnapMarker) into per-user CPU.
-// For each process present in both snapshots and not part of scout's own session
-// or serving sshd, it differences the (utime+stime) jiffies; the per-user totals
-// become a percentage where 100 == one fully-used core (delta / (clkTck * dt) *
-// 100), matching ps's %cpu unit. Users at or below userCPUThreshold are dropped,
-// and results are sorted by CPU descending.
-func parseProcUserCPU(section string) ([]UserCPU, error) {
+// parseProcSample turns procSampleCmd's output (header + uid→name map + two
+// snapshots of /proc/stat and every /proc/<pid>/stat, separated by procSnapMarker)
+// into per-user CPU and overall CPU, both measured over the single sample window.
+//
+// Per-user: for each process present in both snapshots and not part of scout's own
+// session or serving sshd, difference the (utime+stime) jiffies; the per-user
+// totals become a percentage where 100 == one fully-used core, matching ps's %cpu
+// unit. Users at or below userCPUThreshold are dropped, sorted by CPU descending.
+//
+// Overall: from /proc/stat's aggregate "cpu" line, busy% = (Δtotal − Δidle) /
+// Δtotal * 100, where idle includes iowait.
+func parseProcSample(section string) ([]UserCPU, float64, error) {
 	blocks := strings.Split(section, procSnapMarker)
 	if len(blocks) != 3 {
-		return nil, fmt.Errorf("expected 3 blocks separated by %q, got %d", procSnapMarker, len(blocks))
+		return nil, 0, fmt.Errorf("expected 3 blocks separated by %q, got %d", procSnapMarker, len(blocks))
 	}
 
 	clkTck, ownSession, sshdPID, pidUser, err := parseProcHeader(blocks[0])
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	before := parseProcSnapshot(blocks[1])
 	after := parseProcSnapshot(blocks[2])
+
+	cpuPercent, err := overallCPU(blocks[1], blocks[2])
+	if err != nil {
+		return nil, 0, err
+	}
 
 	jiffiesByUser := make(map[string]int64)
 	for pid, a := range after {
@@ -302,10 +307,61 @@ func parseProcUserCPU(section string) ([]UserCPU, error) {
 		}
 	}
 	sort.Slice(users, func(i, j int) bool { return users[i].CPUPercent > users[j].CPUPercent })
-	return users, nil
+	return users, cpuPercent, nil
 }
 
-// parseProcHeader parses the first block of topUsersCmd's output: a
+// overallCPU computes system-wide busy percent from the aggregate "cpu" line of
+// /proc/stat in the before and after snapshot blocks.
+func overallCPU(beforeBlock, afterBlock string) (float64, error) {
+	totalBefore, idleBefore, okBefore := parseCPUStat(beforeBlock)
+	totalAfter, idleAfter, okAfter := parseCPUStat(afterBlock)
+	if !okBefore || !okAfter {
+		return 0, fmt.Errorf("missing /proc/stat cpu line in snapshot")
+	}
+	deltaTotal := totalAfter - totalBefore
+	if deltaTotal <= 0 {
+		return 0, fmt.Errorf("non-positive /proc/stat total delta: %d", deltaTotal)
+	}
+	deltaIdle := idleAfter - idleBefore
+	return float64(deltaTotal-deltaIdle) * 100 / float64(deltaTotal), nil
+}
+
+// parseCPUStat reads the aggregate "cpu" line from a snapshot block (the rest of
+// /proc/stat and the per-pid lines are ignored) and returns total and idle jiffies.
+// Fields after "cpu": user nice system idle iowait irq softirq steal ...; idle
+// counts idle+iowait.
+func parseCPUStat(block string) (total, idle int64, ok bool) {
+	for _, line := range splitNonEmpty(block) {
+		f := strings.Fields(line)
+		if len(f) < 6 || f[0] != "cpu" {
+			continue
+		}
+		// Sum user..steal (fields 1–8). guest/guest_nice (9–10) are already
+		// included in user/nice, so adding them would double-count guest time.
+		end := len(f)
+		if end > 9 {
+			end = 9
+		}
+		for _, field := range f[1:end] {
+			v, err := strconv.ParseInt(field, 10, 64)
+			if err != nil {
+				return 0, 0, false
+			}
+			total += v
+		}
+		idle = mustInt(f[4]) + mustInt(f[5]) // idle + iowait
+		return total, idle, true
+	}
+	return 0, 0, false
+}
+
+// mustInt parses a base-10 int that parseCPUStat has already validated.
+func mustInt(s string) int64 {
+	v, _ := strconv.ParseInt(s, 10, 64)
+	return v
+}
+
+// parseProcHeader parses the first block of procSampleCmd's output: a
 // "CLK <n> SID <n> SSHD <n>" line followed by "<user> /proc/<pid>" mapping lines.
 func parseProcHeader(block string) (clkTck int64, ownSession, sshdPID string, pidUser map[string]string, err error) {
 	lines := splitNonEmpty(block)

--- a/internal/scout/metrics_test.go
+++ b/internal/scout/metrics_test.go
@@ -11,7 +11,7 @@ func TestBuildCommand_NoGPU(t *testing.T) {
 	if containsStr(cmd, "nvidia-smi") {
 		t.Error("command for non-GPU server should not contain nvidia-smi")
 	}
-	if !containsStr(cmd, "top -bn1") {
+	if !containsStr(cmd, "top -bn2") {
 		t.Error("command should contain top")
 	}
 	if !containsStr(cmd, "free -m") {

--- a/internal/scout/metrics_test.go
+++ b/internal/scout/metrics_test.go
@@ -20,8 +20,11 @@ func TestBuildCommand_NoGPU(t *testing.T) {
 	if !containsStr(cmd, "uptime") {
 		t.Error("command should contain uptime")
 	}
-	if !containsStr(cmd, "ps -eo") {
-		t.Error("command should contain ps")
+	if !containsStr(cmd, "/proc/self/stat") {
+		t.Error("command should contain the /proc per-user CPU sampler")
+	}
+	if !containsStr(cmd, "getent passwd") {
+		t.Error("per-user CPU sampler should resolve uids via getent (LDAP-aware)")
 	}
 }
 

--- a/internal/scout/metrics_test.go
+++ b/internal/scout/metrics_test.go
@@ -2,9 +2,26 @@ package scout
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 )
+
+// procStatLine builds a minimal /proc/<pid>/stat line: the given session and
+// utime jiffies (stime 0), with enough trailing fields for parseProcSnapshot.
+func procStatLine(pid int, comm, session string, jiffies int) string {
+	// After "(comm)": state ppid pgrp session tty tpgid flags minflt cminflt
+	// majflt cmajflt utime stime — session at index 3, utime at index 11.
+	return fmt.Sprintf("%d (%s) S 1 0 %s 0 -1 0 0 0 0 0 %d 0", pid, comm, session, jiffies)
+}
+
+// procSection assembles the output of topUsersCmd from its three blocks.
+func procSection(clk, sid, sshd string, nameLines, snap1, snap2 []string) string {
+	header := append([]string{"CLK " + clk + " SID " + sid + " SSHD " + sshd}, nameLines...)
+	return strings.Join(header, "\n") + "\n" + procSnapMarker + "\n" +
+		strings.Join(snap1, "\n") + "\n" + procSnapMarker + "\n" +
+		strings.Join(snap2, "\n")
+}
 
 func TestBuildCommand_NoGPU(t *testing.T) {
 	cmd := BuildCommand(Server{Name: "test", HasGPU: false})
@@ -20,11 +37,14 @@ func TestBuildCommand_NoGPU(t *testing.T) {
 	if !containsStr(cmd, "uptime") {
 		t.Error("command should contain uptime")
 	}
-	if !containsStr(cmd, "/proc/self/stat") {
+	if !containsStr(cmd, "cat /proc/[0-9]*/stat") {
 		t.Error("command should contain the /proc per-user CPU sampler")
 	}
-	if !containsStr(cmd, "getent passwd") {
-		t.Error("per-user CPU sampler should resolve uids via getent (LDAP-aware)")
+	if !containsStr(cmd, "stat -c") {
+		t.Error("per-user CPU sampler should resolve names via stat (full, LDAP-aware)")
+	}
+	if !containsStr(cmd, procSnapMarker) {
+		t.Error("per-user CPU sampler should delimit its snapshots with procSnapMarker")
 	}
 }
 
@@ -36,7 +56,13 @@ func TestBuildCommand_WithGPU(t *testing.T) {
 }
 
 func TestParseMetrics_NoGPU(t *testing.T) {
-	output := "alice 42.1\nbob 10.3" + delimiter +
+	// alice: delta 21 jiffies / (100*0.5) * 100 = 42.0%; bob: delta 5 = 10.0%.
+	users := procSection("100", "999", "0",
+		[]string{"alice /proc/10", "bob /proc/20"},
+		[]string{procStatLine(10, "bash", "10", 0), procStatLine(20, "python", "20", 0)},
+		[]string{procStatLine(10, "bash", "10", 21), procStatLine(20, "python", "20", 5)},
+	)
+	output := users + delimiter +
 		"12.5" + delimiter +
 		"45.3" + delimiter +
 		" 0.52, 0.48, 0.41"
@@ -67,13 +93,18 @@ func TestParseMetrics_NoGPU(t *testing.T) {
 	if len(metrics.TopUsers) != 2 {
 		t.Fatalf("expected 2 top users, got %d", len(metrics.TopUsers))
 	}
-	if metrics.TopUsers[0].User != "alice" || metrics.TopUsers[0].CPUPercent != 42.1 {
-		t.Errorf("expected alice 42.1, got %s %f", metrics.TopUsers[0].User, metrics.TopUsers[0].CPUPercent)
+	if metrics.TopUsers[0].User != "alice" || metrics.TopUsers[0].CPUPercent != 42.0 {
+		t.Errorf("expected alice 42.0, got %s %f", metrics.TopUsers[0].User, metrics.TopUsers[0].CPUPercent)
 	}
 }
 
 func TestParseMetrics_WithGPU(t *testing.T) {
-	output := "charlie 88.5" + delimiter +
+	charlie := procSection("100", "999", "0",
+		[]string{"charlie /proc/30"},
+		[]string{procStatLine(30, "matlab", "30", 0)},
+		[]string{procStatLine(30, "matlab", "30", 44)},
+	)
+	output := charlie + delimiter +
 		"9.8" + delimiter +
 		"26.1" + delimiter +
 		" 5.41, 5.43, 5.20" + delimiter +
@@ -194,65 +225,117 @@ func TestParseGPUMemory(t *testing.T) {
 	}
 }
 
-func TestParseTopUsers(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    string
-		expected []UserCPU
-		wantErr  bool
-	}{
-		{
-			name:     "empty input",
-			input:    "",
-			expected: nil,
-		},
-		{
-			name:  "single user",
-			input: "alice 42.1",
-			expected: []UserCPU{
-				{User: "alice", CPUPercent: 42.1},
-			},
-		},
-		{
-			name:  "multiple users",
-			input: "alice 42.1\nbob 10.3\ncharlie 5.0",
-			expected: []UserCPU{
-				{User: "alice", CPUPercent: 42.1},
-				{User: "bob", CPUPercent: 10.3},
-				{User: "charlie", CPUPercent: 5.0},
-			},
-		},
-		{
-			name:    "bad percent",
-			input:   "alice notanumber",
-			wantErr: true,
-		},
-		{
-			name:    "too few fields",
-			input:   "alice",
-			wantErr: true,
-		},
+func TestParseProcUserCPU_Deltas(t *testing.T) {
+	// denom = 100 * 0.5 = 50, so pct = delta_jiffies * 2.
+	// alice: 30 jiffies -> 60.0%; bob: 5 -> 10.0%. Sorted descending.
+	section := procSection("100", "999", "0",
+		[]string{"alice /proc/10", "bob /proc/20"},
+		[]string{procStatLine(10, "bash", "10", 100), procStatLine(20, "py", "20", 0)},
+		[]string{procStatLine(10, "bash", "10", 130), procStatLine(20, "py", "20", 5)},
+	)
+	got, err := parseProcUserCPU(section)
+	if err != nil {
+		t.Fatal(err)
 	}
+	want := []UserCPU{{User: "alice", CPUPercent: 60.0}, {User: "bob", CPUPercent: 10.0}}
+	if len(got) != len(want) {
+		t.Fatalf("expected %d users, got %d (%v)", len(want), len(got), got)
+	}
+	for i, u := range got {
+		if u != want[i] {
+			t.Errorf("user %d: expected %v, got %v", i, want[i], u)
+		}
+	}
+}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := parseTopUsers(tt.input)
-			if tt.wantErr {
-				if err == nil {
-					t.Fatal("expected error")
-				}
-				return
-			}
-			if err != nil {
-				t.Fatal(err)
-			}
-			if len(got) != len(tt.expected) {
-				t.Fatalf("expected %d users, got %d", len(tt.expected), len(got))
-			}
-			for i, u := range got {
-				if u.User != tt.expected[i].User || u.CPUPercent != tt.expected[i].CPUPercent {
-					t.Errorf("user %d: expected %v, got %v", i, tt.expected[i], u)
-				}
+func TestParseProcUserCPU_CommWithSpacesAndParens(t *testing.T) {
+	// utime is split from the text after the *last* ')', so a comm containing
+	// spaces and ')' must not corrupt the field offsets.
+	section := procSection("100", "999", "0",
+		[]string{"carol /proc/40"},
+		[]string{procStatLine(40, "weird ) name", "40", 0)},
+		[]string{procStatLine(40, "weird ) name", "40", 7)},
+	)
+	got, err := parseProcUserCPU(section)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].User != "carol" || got[0].CPUPercent != 14.0 {
+		t.Fatalf("expected carol 14.0, got %v", got)
+	}
+}
+
+func TestParseProcUserCPU_ExcludesOwnSession(t *testing.T) {
+	// pid 50 is in scout's own login session (SID 999) and must be dropped despite
+	// a large delta — that's the cat/stat pipeline doing the sampling.
+	section := procSection("100", "999", "0",
+		[]string{"alice /proc/10", "scout /proc/50"},
+		[]string{procStatLine(10, "bash", "10", 0), procStatLine(50, "cat", "999", 0)},
+		[]string{procStatLine(10, "bash", "10", 5), procStatLine(50, "cat", "999", 9999)},
+	)
+	got, err := parseProcUserCPU(section)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].User != "alice" {
+		t.Fatalf("expected only alice, got %v", got)
+	}
+}
+
+func TestParseProcUserCPU_ExcludesServingSshd(t *testing.T) {
+	// pid 50 is the sshd serving the connection (SSHD 50). It lives in a different
+	// session (777, not our SID 999), so only the explicit SSHD-pid exclusion
+	// drops it — otherwise the CPU it spends streaming output back is mis-charged.
+	section := procSection("100", "999", "50",
+		[]string{"alice /proc/10", "matsen /proc/50"},
+		[]string{procStatLine(10, "bash", "10", 0), procStatLine(50, "sshd", "777", 0)},
+		[]string{procStatLine(10, "bash", "10", 5), procStatLine(50, "sshd", "777", 9999)},
+	)
+	got, err := parseProcUserCPU(section)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].User != "alice" {
+		t.Fatalf("expected only alice (sshd excluded), got %v", got)
+	}
+}
+
+func TestParseProcUserCPU_ThresholdAndUnknownUser(t *testing.T) {
+	// With CLK 1000, denom = 500. dave: 3 jiffies -> 0.6% (dropped, <= 1.0).
+	// frank: 10 -> 2.0% (kept). pid 70 has no name entry -> labeled "?".
+	section := procSection("1000", "999", "0",
+		[]string{"dave /proc/60", "frank /proc/80"},
+		[]string{procStatLine(60, "a", "60", 0), procStatLine(80, "b", "80", 0), procStatLine(70, "c", "70", 0)},
+		[]string{procStatLine(60, "a", "60", 3), procStatLine(80, "b", "80", 10), procStatLine(70, "c", "70", 25)},
+	)
+	got, err := parseProcUserCPU(section)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// "?" (pid 70): 25 jiffies -> 5.0%; frank 2.0%; dave dropped.
+	want := []UserCPU{{User: "?", CPUPercent: 5.0}, {User: "frank", CPUPercent: 2.0}}
+	if len(got) != len(want) {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+	for i, u := range got {
+		if u != want[i] {
+			t.Errorf("user %d: expected %v, got %v", i, want[i], u)
+		}
+	}
+}
+
+func TestParseProcUserCPU_Malformed(t *testing.T) {
+	for _, tc := range []struct {
+		name, input string
+	}{
+		{"empty", ""},
+		{"wrong block count", "CLK 100 SID 1 SSHD 1\n" + procSnapMarker + "\nsnap1"},
+		{"bad header", "garbage\n" + procSnapMarker + "\n" + procSnapMarker},
+		{"bad clk", "CLK x SID 1 SSHD 1\n" + procSnapMarker + "\n" + procSnapMarker},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := parseProcUserCPU(tc.input); err == nil {
+				t.Errorf("expected error for %q", tc.input)
 			}
 		})
 	}

--- a/internal/scout/metrics_test.go
+++ b/internal/scout/metrics_test.go
@@ -15,12 +15,27 @@ func procStatLine(pid int, comm, session string, jiffies int) string {
 	return fmt.Sprintf("%d (%s) S 1 0 %s 0 -1 0 0 0 0 0 %d 0", pid, comm, session, jiffies)
 }
 
-// procSection assembles the output of topUsersCmd from its three blocks.
-func procSection(clk, sid, sshd string, nameLines, snap1, snap2 []string) string {
+// cpuStatLine builds a /proc/stat aggregate "cpu" line (user nice system idle
+// iowait, then zeros for irq/softirq/steal).
+func cpuStatLine(user, nice, system, idle, iowait int) string {
+	return fmt.Sprintf("cpu %d %d %d %d %d 0 0 0", user, nice, system, idle, iowait)
+}
+
+// procSectionCPU assembles procSampleCmd's output, prepending the given /proc/stat
+// "cpu" lines to each snapshot block.
+func procSectionCPU(clk, sid, sshd, cpuBefore, cpuAfter string, nameLines, snap1, snap2 []string) string {
 	header := append([]string{"CLK " + clk + " SID " + sid + " SSHD " + sshd}, nameLines...)
 	return strings.Join(header, "\n") + "\n" + procSnapMarker + "\n" +
-		strings.Join(snap1, "\n") + "\n" + procSnapMarker + "\n" +
-		strings.Join(snap2, "\n")
+		strings.Join(append([]string{cpuBefore}, snap1...), "\n") + "\n" + procSnapMarker + "\n" +
+		strings.Join(append([]string{cpuAfter}, snap2...), "\n")
+}
+
+// procSection assembles procSampleCmd's output with default /proc/stat lines that
+// yield 0% overall CPU (idle-only delta), for tests that only care about per-user.
+func procSection(clk, sid, sshd string, nameLines, snap1, snap2 []string) string {
+	return procSectionCPU(clk, sid, sshd,
+		cpuStatLine(0, 0, 0, 100, 0), cpuStatLine(0, 0, 0, 200, 0),
+		nameLines, snap1, snap2)
 }
 
 func TestBuildCommand_NoGPU(t *testing.T) {
@@ -28,8 +43,8 @@ func TestBuildCommand_NoGPU(t *testing.T) {
 	if containsStr(cmd, "nvidia-smi") {
 		t.Error("command for non-GPU server should not contain nvidia-smi")
 	}
-	if !containsStr(cmd, "top -bn2") {
-		t.Error("command should contain top")
+	if containsStr(cmd, "top ") {
+		t.Error("command should no longer shell out to top (overall CPU comes from /proc/stat)")
 	}
 	if !containsStr(cmd, "free -m") {
 		t.Error("command should contain free")
@@ -37,14 +52,14 @@ func TestBuildCommand_NoGPU(t *testing.T) {
 	if !containsStr(cmd, "uptime") {
 		t.Error("command should contain uptime")
 	}
-	if !containsStr(cmd, "cat /proc/[0-9]*/stat") {
-		t.Error("command should contain the /proc per-user CPU sampler")
+	if !containsStr(cmd, "cat /proc/stat /proc/[0-9]*/stat") {
+		t.Error("command should sample /proc/stat and every /proc/<pid>/stat")
 	}
 	if !containsStr(cmd, "stat -c") {
-		t.Error("per-user CPU sampler should resolve names via stat (full, LDAP-aware)")
+		t.Error("sampler should resolve names via stat (full, LDAP-aware)")
 	}
 	if !containsStr(cmd, procSnapMarker) {
-		t.Error("per-user CPU sampler should delimit its snapshots with procSnapMarker")
+		t.Error("sampler should delimit its snapshots with procSnapMarker")
 	}
 }
 
@@ -57,13 +72,14 @@ func TestBuildCommand_WithGPU(t *testing.T) {
 
 func TestParseMetrics_NoGPU(t *testing.T) {
 	// alice: delta 21 jiffies / (100*0.5) * 100 = 42.0%; bob: delta 5 = 10.0%.
-	users := procSection("100", "999", "0",
+	// Overall: Δtotal=100, Δidle=50 → 50% busy.
+	sample := procSectionCPU("100", "999", "0",
+		cpuStatLine(0, 0, 0, 100, 0), cpuStatLine(30, 0, 20, 150, 0),
 		[]string{"alice /proc/10", "bob /proc/20"},
 		[]string{procStatLine(10, "bash", "10", 0), procStatLine(20, "python", "20", 0)},
 		[]string{procStatLine(10, "bash", "10", 21), procStatLine(20, "python", "20", 5)},
 	)
-	output := users + delimiter +
-		"12.5" + delimiter +
+	output := sample + delimiter +
 		"45.3" + delimiter +
 		" 0.52, 0.48, 0.41"
 
@@ -72,8 +88,8 @@ func TestParseMetrics_NoGPU(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if metrics.CPUPercent != 12.5 {
-		t.Errorf("CPU: expected 12.5, got %f", metrics.CPUPercent)
+	if metrics.CPUPercent != 50.0 {
+		t.Errorf("CPU: expected 50.0, got %f", metrics.CPUPercent)
 	}
 	if metrics.MemoryPercent != 45.3 {
 		t.Errorf("Memory: expected 45.3, got %f", metrics.MemoryPercent)
@@ -99,13 +115,14 @@ func TestParseMetrics_NoGPU(t *testing.T) {
 }
 
 func TestParseMetrics_WithGPU(t *testing.T) {
-	charlie := procSection("100", "999", "0",
+	// Overall: Δtotal=100, Δidle=10 → 90% busy.
+	sample := procSectionCPU("100", "999", "0",
+		cpuStatLine(0, 0, 0, 100, 0), cpuStatLine(80, 0, 10, 110, 0),
 		[]string{"charlie /proc/30"},
 		[]string{procStatLine(30, "matlab", "30", 0)},
 		[]string{procStatLine(30, "matlab", "30", 44)},
 	)
-	output := charlie + delimiter +
-		"9.8" + delimiter +
+	output := sample + delimiter +
 		"26.1" + delimiter +
 		" 5.41, 5.43, 5.20" + delimiter +
 		"100\n100" + delimiter +
@@ -116,8 +133,8 @@ func TestParseMetrics_WithGPU(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if metrics.CPUPercent != 9.8 {
-		t.Errorf("CPU: expected 9.8, got %f", metrics.CPUPercent)
+	if metrics.CPUPercent != 90.0 {
+		t.Errorf("CPU: expected 90.0, got %f", metrics.CPUPercent)
 	}
 	if len(metrics.GPUs) != 2 {
 		t.Fatalf("expected 2 GPUs, got %d", len(metrics.GPUs))
@@ -147,8 +164,16 @@ func TestParseMetrics_InsufficientSections(t *testing.T) {
 	}
 }
 
+// validSample is a well-formed sample section yielding 0 users and 0% overall CPU.
+func validSample() string {
+	return procSection("100", "999", "0", nil, nil, nil)
+}
+
 func TestParseMetrics_BadCPU(t *testing.T) {
-	output := "" + delimiter + "not_a_number" + delimiter + "45.3" + delimiter + "0.52, 0.48, 0.41"
+	// /proc/stat cpu line has non-numeric fields.
+	sample := procSectionCPU("100", "999", "0",
+		"cpu x y z 100 0", "cpu x y z 200 0", nil, nil, nil)
+	output := sample + delimiter + "45.3" + delimiter + "0.52, 0.48, 0.41"
 	_, err := ParseMetrics(output, false)
 	if err == nil {
 		t.Fatal("expected error for bad CPU value")
@@ -156,7 +181,7 @@ func TestParseMetrics_BadCPU(t *testing.T) {
 }
 
 func TestParseMetrics_BadMemory(t *testing.T) {
-	output := "" + delimiter + "12.5" + delimiter + "bad" + delimiter + "0.52, 0.48, 0.41"
+	output := validSample() + delimiter + "bad" + delimiter + "0.52, 0.48, 0.41"
 	_, err := ParseMetrics(output, false)
 	if err == nil {
 		t.Fatal("expected error for bad memory value")
@@ -164,7 +189,7 @@ func TestParseMetrics_BadMemory(t *testing.T) {
 }
 
 func TestParseMetrics_BadLoadAvg(t *testing.T) {
-	output := "" + delimiter + "12.5" + delimiter + "45.3" + delimiter + "0.52, bad, 0.41"
+	output := validSample() + delimiter + "45.3" + delimiter + "0.52, bad, 0.41"
 	_, err := ParseMetrics(output, false)
 	if err == nil {
 		t.Fatal("expected error for bad load avg value")
@@ -173,8 +198,7 @@ func TestParseMetrics_BadLoadAvg(t *testing.T) {
 
 func TestParseMetrics_MissingGPUGraceful(t *testing.T) {
 	// GPU server where nvidia-smi output is empty/missing
-	output := "" + delimiter + // empty user section
-		"9.8" + delimiter +
+	output := validSample() + delimiter +
 		"26.1" + delimiter +
 		" 5.41, 5.43, 5.20" + delimiter +
 		"" + delimiter + // empty GPU util
@@ -185,8 +209,8 @@ func TestParseMetrics_MissingGPUGraceful(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Should still return metrics, just without GPU data
-	if metrics.CPUPercent != 9.8 {
-		t.Errorf("CPU: expected 9.8, got %f", metrics.CPUPercent)
+	if metrics.CPUPercent != 0.0 {
+		t.Errorf("CPU: expected 0.0, got %f", metrics.CPUPercent)
 	}
 	if metrics.GPUs != nil {
 		t.Error("expected nil GPUs when nvidia-smi output is empty")
@@ -233,7 +257,7 @@ func TestParseProcUserCPU_Deltas(t *testing.T) {
 		[]string{procStatLine(10, "bash", "10", 100), procStatLine(20, "py", "20", 0)},
 		[]string{procStatLine(10, "bash", "10", 130), procStatLine(20, "py", "20", 5)},
 	)
-	got, err := parseProcUserCPU(section)
+	got, _, err := parseProcSample(section)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -256,7 +280,7 @@ func TestParseProcUserCPU_CommWithSpacesAndParens(t *testing.T) {
 		[]string{procStatLine(40, "weird ) name", "40", 0)},
 		[]string{procStatLine(40, "weird ) name", "40", 7)},
 	)
-	got, err := parseProcUserCPU(section)
+	got, _, err := parseProcSample(section)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -273,7 +297,7 @@ func TestParseProcUserCPU_ExcludesOwnSession(t *testing.T) {
 		[]string{procStatLine(10, "bash", "10", 0), procStatLine(50, "cat", "999", 0)},
 		[]string{procStatLine(10, "bash", "10", 5), procStatLine(50, "cat", "999", 9999)},
 	)
-	got, err := parseProcUserCPU(section)
+	got, _, err := parseProcSample(section)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -291,7 +315,7 @@ func TestParseProcUserCPU_ExcludesServingSshd(t *testing.T) {
 		[]string{procStatLine(10, "bash", "10", 0), procStatLine(50, "sshd", "777", 0)},
 		[]string{procStatLine(10, "bash", "10", 5), procStatLine(50, "sshd", "777", 9999)},
 	)
-	got, err := parseProcUserCPU(section)
+	got, _, err := parseProcSample(section)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -308,7 +332,7 @@ func TestParseProcUserCPU_ThresholdAndUnknownUser(t *testing.T) {
 		[]string{procStatLine(60, "a", "60", 0), procStatLine(80, "b", "80", 0), procStatLine(70, "c", "70", 0)},
 		[]string{procStatLine(60, "a", "60", 3), procStatLine(80, "b", "80", 10), procStatLine(70, "c", "70", 25)},
 	)
-	got, err := parseProcUserCPU(section)
+	got, _, err := parseProcSample(section)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -334,7 +358,7 @@ func TestParseProcUserCPU_Malformed(t *testing.T) {
 		{"bad clk", "CLK x SID 1 SSHD 1\n" + procSnapMarker + "\n" + procSnapMarker},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			if _, err := parseProcUserCPU(tc.input); err == nil {
+			if _, _, err := parseProcSample(tc.input); err == nil {
 				t.Errorf("expected error for %q", tc.input)
 			}
 		})
@@ -371,7 +395,10 @@ func (m *mockSSHClient) Close() error { return nil }
 
 func TestCheckServer_Online(t *testing.T) {
 	client := newMockSSHClient()
-	client.outputs["test"] = "" + delimiter + "12.5" + delimiter + "45.3" + delimiter + "0.52, 0.48, 0.41"
+	// Δtotal=200, Δidle=175 → 12.5% busy.
+	sample := procSectionCPU("100", "999", "0",
+		"cpu 0 0 0 100 0", "cpu 25 0 0 275 0", nil, nil, nil)
+	client.outputs["test"] = sample + delimiter + "45.3" + delimiter + "0.52, 0.48, 0.41"
 
 	status := CheckServer(client, Server{Name: "test"})
 	if status.Status != "online" {
@@ -407,7 +434,7 @@ func TestCheckAllServers_Parallel(t *testing.T) {
 	for i := range servers {
 		name := fmt.Sprintf("server%02d", i)
 		servers[i] = Server{Name: name}
-		client.outputs[name] = "" + delimiter + "1.0" + delimiter + "2.0" + delimiter + "0.1, 0.2, 0.3"
+		client.outputs[name] = validSample() + delimiter + "2.0" + delimiter + "0.1, 0.2, 0.3"
 	}
 
 	result := CheckAllServers(client, servers)
@@ -440,7 +467,7 @@ func TestCheckAllServers_BoundedConcurrency(t *testing.T) {
 	for i := range servers {
 		name := fmt.Sprintf("server%02d", i)
 		servers[i] = Server{Name: name}
-		client.outputs[name] = "" + delimiter + "1.0" + delimiter + "2.0" + delimiter + "0.1, 0.2, 0.3"
+		client.outputs[name] = validSample() + delimiter + "2.0" + delimiter + "0.1, 0.2, 0.3"
 	}
 
 	result := CheckAllServers(client, servers)


### PR DESCRIPTION
🤖 Closes #154.

## Confirmed both bugs

1. **Per-user CPU** used `ps %cpu`, which is a lifetime average (cputime/realtime). The short-lived sshd serving scout's own session has a tiny denominator, so it reports a large %, producing the spurious "~220%" floor seen identically across nodes.
2. **Overall CPU** used `top -bn1`, whose first iteration has no prior sample and reports cumulative-since-boot stats — near 0% on long-uptime boxes regardless of recent load. (It also only parsed top's `us` field, so it ignored system/IO time entirely — see below.)

## Fix

Both numbers now come from **one `/proc` sample**: two snapshots of `/proc/stat` and every `/proc/<pid>/stat` taken 0.5s apart. The remote command only dumps raw data; Go (`parseProcSample`) does the math:

```
echo "CLK <clk_tck> SID <session> SSHD <ppid>"
stat -c '%U %n' /proc/[0-9]*                              # pid → full username
@@SCOUT_SNAP@@
cat /proc/stat /proc/[0-9]*/stat                          # snapshot 1
@@SCOUT_SNAP@@
sleep 0.5; cat /proc/stat /proc/[0-9]*/stat               # snapshot 2
```

**Per-user CPU:** difference each process's `(utime+stime)` jiffies and aggregate by user — `delta/(CLK·dt)·100`, so `100% == one core` (same unit as `ps %cpu`). Reflects current usage; not fooled by processes that ran hot earlier and are now idle.

**Overall CPU:** from `/proc/stat`'s aggregate `cpu` line, `busy% = (Δtotal − Δidle)/Δtotal·100` (idle includes iowait). This is **total busy**, which fixes a latent under-report: the old code parsed only top's `us` (user) field, so on a syscall/IO-heavy node it read ~23% when the machine was ~67% busy. (`guest`/`guest_nice` are excluded from the total since they're already counted in `user`/`nice`.)

Computing overall CPU from the same snapshots means a single 0.5s sample window for the whole check and **no `top` dependency** (which also removes top's `~/.toprc` column-order fragility).

Two details that matter:

- **Names come from `stat -c %U`**, which is untruncated and LDAP-aware. (top's `USER` column truncates to 8 chars + `+`, merging e.g. `systemd-resolve` and `systemd-timesync` into `systemd+`.)
- **Scout's own footprint is excluded.** The dump is ~300 KB, so the sshd streaming it back uses measurable CPU that would otherwise be charged to the ssh user. That sshd is the shell's parent (`$PPID`, in a different session), so it's excluded by pid; scout's session (`SID`) covers the `cat`/`stat` pipeline.

## Validation

Run end-to-end on a live node: per-user numbers track a `top` per-user reference and the ssh user no longer appears as phantom load; overall CPU tracks top's busy figure (and is ~3x the old `us`-only reading on a system-heavy box). `parseProcSample` has unit tests for the jiffy-delta math, the `/proc/stat` busy computation, comm-with-parens parsing, session/sshd exclusion, threshold, and unknown users.

## Cost

One 0.5s sample per host for both CPU numbers (down from two sequential samples in an earlier revision). Hosts are checked in parallel, so this adds ~0.5s only on the slowest host.

## Caveat

The serving-sshd exclusion assumes `$PPID` (the command shell's parent) is the sshd itself. On a host whose login shell spawns an intermediate process before running the command (a forced-command wrapper, or `tmux`/`screen`/etc. launched from `.profile`), `$PPID` would be that wrapper instead, so the sshd's output-streaming CPU could reappear as a small phantom attributed to the ssh user. This affects only scout's self-attribution, never other users' numbers, and was not observed on the test node.
