### PR TITLE
Add bip-epic-recover: resurrect bip-epic sessions after a host reboot

### DIFF
--- a/skills/bip-epic-recover/SKILL.md
+++ b/skills/bip-epic-recover/SKILL.md
@@ -20,7 +20,7 @@ The deterministic engine is the bundled `epic-recover` shell helper; this skill 
 
 ## Prerequisite: install the helper on the recovery host
 
-The helper lives at `skills/bip-epic-recover/epic-recover` (Linux-targeted; uses GNU `date` and `jq`). On the host that runs the fleet:
+The helper lives at `skills/bip-epic-recover/epic-recover` (Linux-targeted; uses GNU `date`, bash ≥ 4, and `jq` — it exits 2 with a clear message if run on macOS or old bash). On the host that runs the fleet:
 
 ```bash
 install -m755 skills/bip-epic-recover/epic-recover ~/bin/epic-recover   # ~/bin on PATH

--- a/skills/bip-epic-recover/SKILL.md
+++ b/skills/bip-epic-recover/SKILL.md
@@ -18,13 +18,15 @@ The deterministic engine is the bundled `epic-recover` shell helper; this skill 
 
 `project` is a path to a bip-epic project's **main clone** (the dir holding `.epic-config.json`), or its basename. Defaults to the current directory.
 
-## Prerequisite: install the helper on the recovery host
+## The bundled helper
 
-The helper lives at `skills/bip-epic-recover/epic-recover` (Linux-targeted; uses GNU `date`, bash ≥ 4, and `jq` — it exits 2 with a clear message if run on macOS or old bash). On the host that runs the fleet:
+This skill ships the `epic-recover` shell helper next to `SKILL.md` — no separate install. At the start of the run, set `HELPER` to its absolute path (this skill's base directory, given at invocation, + `/epic-recover`) and use `"$HELPER"` in every command below:
 
 ```bash
-install -m755 skills/bip-epic-recover/epic-recover ~/bin/epic-recover   # ~/bin on PATH
+HELPER="<this-skill-dir>/epic-recover"
 ```
+
+It needs GNU `date` (or `gdate`), `stat`, bash ≥ 4, and `jq`: it runs on Linux out of the box, and on macOS with `brew install coreutils bash`. It exits 2 with guidance if a prerequisite is missing.
 
 Start tmux the usual way first (e.g. `eval $(keychain --eval id_rsa) && tmux`) so the server holds your ssh-agent; windows the helper creates inherit that env.
 
@@ -36,7 +38,7 @@ From the project's main clone, run the helper's list mode:
 
 ```bash
 cd <project-main-clone>
-epic-recover --list
+"$HELPER" --list
 ```
 
 This emits one TSV row per Claude session whose cwd is the main clone **or any worker clone** and whose jsonl was active in the window before the last reboot (default 36h; `EPIC_RECOVER_SINCE_HOURS` to widen). Columns: `last_active  clone  branch  issue  phase  session  first_prompt`. There is intentionally **no git-branch filter** — a worker clone often returns to `main` while its conversation continues, and the main clone hosts several concurrent sessions (conductor, planning, topic coordination).
@@ -64,7 +66,7 @@ Show a compact labeled table (last-active, clone, label, short session-id) sorte
 Pass the selected session-ids to the helper. Run this from inside the project's tmux session so windows are added to it (the helper detects `$TMUX`):
 
 ```bash
-epic-recover --resume <id1> <id2> ...
+"$HELPER" --resume <id1> <id2> ...
 ```
 
 Each becomes a window named `<issue>-<clone>` (workers) or the clone basename (main-clone sessions), running `claude --dangerously-skip-permissions --resume <id>`.
@@ -80,5 +82,5 @@ Auto-`send-keys` timing against claude's resume-load is unreliable, so prompt th
 ## Notes
 
 - `--list` mutates nothing; only `--resume` (and the helper's bare interactive mode) create tmux windows. Re-running is safe.
-- Driving a remote rebooted box from elsewhere: prefix the helper calls with `ssh <host> 'cd <main-clone> && epic-recover …'`, but resuming into tmux is cleanest run from a shell already inside that host's tmux.
-- For a no-Claude recovery, `epic-recover` with no args gives an interactive numbered picker over the same data — less smart labeling, same engine.
+- Driving a remote rebooted box from elsewhere: prefix the helper calls with `ssh <host> 'cd <main-clone> && bash <skill-dir>/epic-recover …'`, but resuming into tmux is cleanest run from a shell already inside that host's tmux.
+- For a no-Claude recovery, run the helper directly with no args (`bash <skill-dir>/epic-recover`) for an interactive numbered picker over the same data — less smart labeling, same engine. Symlink it onto your `PATH` if you want it as a bare command.

--- a/skills/bip-epic-recover/SKILL.md
+++ b/skills/bip-epic-recover/SKILL.md
@@ -59,7 +59,7 @@ Turn each row into a short human label, e.g. `#1481 → clade-matched ASR parity
 
 ### Step 3: Present the choices and confirm
 
-Show a compact labeled table (last-active, clone, label, short session-id) sorted newest first. Recommend the live-at-reboot set (newest per clone, plus the distinct main-clone sessions) but let the user choose. **Do not spawn anything before the user confirms which sessions to resume.**
+Show a compact labeled table (last-active, clone, label, short session-id) sorted newest first. Recommend the live-at-reboot set (newest per clone, plus the distinct main-clone sessions) but let the user choose. Always offer an explicit **Recover all** option alongside the per-session picks (and "Recommended set" / "Cancel"); when the user picks **Recover all**, pass *every* listed session-id to `--resume` in one call. **Do not spawn anything before the user confirms which sessions to resume.**
 
 ### Step 4: Resume the chosen sessions
 

--- a/skills/bip-epic-recover/SKILL.md
+++ b/skills/bip-epic-recover/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: bip-epic-recover
+description: Recover bip-epic Claude sessions after a host reboot — find the killed sessions, label them, and resume each into a tmux window. Use when a box running a bip-epic fleet rebooted and the tmux sessions are gone.
+allowed-tools: Bash, Read
+---
+
+# /bip-epic-recover
+
+A reboot of a host running a bip-epic fleet kills the tmux server and every `claude` process at once. The clones, their `.epic-status.json`/`.epic-worklog.md`, and the full per-session `~/.claude/projects/*/<id>.jsonl` conversations all survive on disk, so the sessions are resumable via `claude --dangerously-skip-permissions --resume <id>`. This skill finds those sessions, labels them in human terms, and resumes the ones you pick into tmux windows.
+
+The deterministic engine is the bundled `epic-recover` shell helper; this skill is the brain that turns its raw output into labeled choices. Run it **on the box that rebooted** — that is where the tmux, jsonl, and clones live.
+
+## Usage
+
+```
+/bip-epic-recover [project]
+```
+
+`project` is a path to a bip-epic project's **main clone** (the dir holding `.epic-config.json`), or its basename. Defaults to the current directory.
+
+## Prerequisite: install the helper on the recovery host
+
+The helper lives at `skills/bip-epic-recover/epic-recover` (Linux-targeted; uses GNU `date` and `jq`). On the host that runs the fleet:
+
+```bash
+install -m755 skills/bip-epic-recover/epic-recover ~/bin/epic-recover   # ~/bin on PATH
+```
+
+Start tmux the usual way first (e.g. `eval $(keychain --eval id_rsa) && tmux`) so the server holds your ssh-agent; windows the helper creates inherit that env.
+
+## Workflow
+
+### Step 1: Enumerate the killed sessions
+
+From the project's main clone, run the helper's list mode:
+
+```bash
+cd <project-main-clone>
+epic-recover --list
+```
+
+This emits one TSV row per Claude session whose cwd is the main clone **or any worker clone** and whose jsonl was active in the window before the last reboot (default 36h; `EPIC_RECOVER_SINCE_HOURS` to widen). Columns: `last_active  clone  branch  issue  phase  session  first_prompt`. There is intentionally **no git-branch filter** — a worker clone often returns to `main` while its conversation continues, and the main clone hosts several concurrent sessions (conductor, planning, topic coordination).
+
+### Step 2: Label each session
+
+`first_prompt` is often spawn-prompt boilerplate ("IMPORTANT: Before doing any work…", "Caveat: The messages below…", a ralph-loop preamble) rather than the topic. When it is, peek deeper to name the session — read the first human-authored message past the preamble:
+
+```bash
+f=~/.claude/projects/$(printf '%s' "<clone-cwd>" | sed 's#/#-#g')/<session-id>*.jsonl
+jq -rs '[.[]|select(.type=="user")|.message.content
+          | if type=="string" then . elif type=="array" then (.[]|select(.type=="text")|.text) else empty end]
+        | map(select(test("tool_result|tool_use_id|^Caveat:|^IMPORTANT: Before")|not))
+        | .[0:3] | .[]' "$f" | head -c 600
+```
+
+Turn each row into a short human label, e.g. `#1481 → clade-matched ASR parity`, `pcp-pipeline #52 follow-ups`, `coordinate-pca`, `DASM planning`. Note duplicates: a clone may have several sessions across the day; the newest is usually the one that was live at reboot.
+
+### Step 3: Present the choices and confirm
+
+Show a compact labeled table (last-active, clone, label, short session-id) sorted newest first. Recommend the live-at-reboot set (newest per clone, plus the distinct main-clone sessions) but let the user choose. **Do not spawn anything before the user confirms which sessions to resume.**
+
+### Step 4: Resume the chosen sessions
+
+Pass the selected session-ids to the helper. Run this from inside the project's tmux session so windows are added to it (the helper detects `$TMUX`):
+
+```bash
+epic-recover --resume <id1> <id2> ...
+```
+
+Each becomes a window named `<issue>-<clone>` (workers) or the clone basename (main-clone sessions), running `claude --dangerously-skip-permissions --resume <id>`.
+
+### Step 5: Nudge resumed workers
+
+A resumed worker reloads its context but sits idle — the ralph-loop wakeup that would have driven the next iteration died with the process. After each worker window finishes loading, send a one-line nudge so it resumes forward motion:
+
+> Host rebooted and this session was interrupted. Re-read `.epic-status.json` and `.epic-worklog.md`, then continue from where you left off.
+
+Auto-`send-keys` timing against claude's resume-load is unreliable, so prompt the user to paste it (or do it interactively once the window is ready). Conductor/planning/discussion sessions usually need no nudge.
+
+## Notes
+
+- `--list` mutates nothing; only `--resume` (and the helper's bare interactive mode) create tmux windows. Re-running is safe.
+- Driving a remote rebooted box from elsewhere: prefix the helper calls with `ssh <host> 'cd <main-clone> && epic-recover …'`, but resuming into tmux is cleanest run from a shell already inside that host's tmux.
+- For a no-Claude recovery, `epic-recover` with no args gives an interactive numbered picker over the same data — less smart labeling, same engine.

--- a/skills/bip-epic-recover/epic-recover
+++ b/skills/bip-epic-recover/epic-recover
@@ -21,18 +21,22 @@ CFG=.epic-config.json
 [ -f "$CFG" ] || { echo "No $CFG here — run from an EPIC project's main clone." >&2; exit 1; }
 command -v jq >/dev/null || { echo "epic-recover: jq is required." >&2; exit 1; }
 
-# This helper targets the Linux fleet host (GNU date, bash >= 4). Fail clearly elsewhere
-# rather than emitting cryptic errors — recovery is meant to run on the box that rebooted.
-if ! date -d @0 +%s >/dev/null 2>&1; then
-  echo "epic-recover: needs GNU date (Linux). It runs on the rebooted fleet host, not macOS." >&2
-  echo "  From a Mac:  ssh <host> 'cd <main-clone> && epic-recover [--list|--resume <id>...]'" >&2
+# Pick a GNU `date` (needs `-d @epoch`). macOS /bin/date is BSD; Homebrew coreutils ships `gdate`.
+if date -d @0 +%s >/dev/null 2>&1; then DATE=date
+elif command -v gdate >/dev/null 2>&1 && gdate -d @0 +%s >/dev/null 2>&1; then DATE=gdate
+else
+  echo "epic-recover: needs GNU date (for -d @epoch). Install it (brew install coreutils → gdate)" >&2
+  echo "  or run on the Linux fleet host." >&2
   exit 2
 fi
 command -v mapfile >/dev/null 2>&1 || {
   echo "epic-recover: needs bash >= 4 (mapfile); found bash ${BASH_VERSION:-unknown}." >&2
-  echo "  On macOS install a newer bash, or run on the Linux fleet host." >&2
+  echo "  On macOS: brew install bash (picked up via /usr/bin/env bash), or run on the Linux host." >&2
   exit 2
 }
+
+# Portable file-mtime epoch: GNU stat, then BSD/macOS stat.
+mtime() { stat -c %Y "$1" 2>/dev/null || stat -f %m "$1" 2>/dev/null; }
 
 main_dir=$PWD
 proj=$(basename "$PWD")
@@ -43,8 +47,16 @@ mapfile -t clone_names < <(jq -r '.clone_names[]?' "$CFG")
 dirs=("$main_dir")
 for n in "${clone_names[@]}"; do [ -d "$clone_root/$n" ] && dirs+=("$clone_root/$n"); done
 
-# cutoff = boot - SINCE_HOURS (fall back to now if uptime -s unavailable)
-boot=$(date -d "$(uptime -s)" +%s 2>/dev/null || date +%s)
+# cutoff = boot - SINCE_HOURS. boot via `uptime -s` (Linux) or kern.boottime (macOS); else now.
+boot_epoch() {
+  local b
+  if b=$(uptime -s 2>/dev/null) && [ -n "$b" ]; then "$DATE" -d "$b" +%s; return; fi
+  if b=$(sysctl -n kern.boottime 2>/dev/null); then  # "{ sec = N, usec = M } ..." — anchor on sec, not usec
+    printf '%s\n' "$b" | sed -n 's/^{ *sec *= *\([0-9][0-9]*\).*/\1/p'; return
+  fi
+  date +%s
+}
+boot=$(boot_epoch); [ -n "$boot" ] || boot=$(date +%s)
 cutoff=$(( boot - SINCE_HOURS*3600 ))
 
 enc() { printf '%s' "$1" | sed 's#/#-#g'; }
@@ -64,8 +76,8 @@ collect() {
     d=$PROJ/$(enc "$cwd"); [ -d "$d" ] || continue
     for f in "$d"/*.jsonl; do
       [ -e "$f" ] || continue
-      mt=$(date -r "$f" +%s); [ "$mt" -ge "$cutoff" ] || continue
-      id=$(basename "$f" .jsonl); mth=$(date -r "$f" "+%m-%d_%H:%M")
+      mt=$(mtime "$f"); [ -n "$mt" ] || continue; [ "$mt" -ge "$cutoff" ] || continue
+      id=$(basename "$f" .jsonl); mth=$("$DATE" -d @"$mt" "+%m-%d_%H:%M")
       br=$(jq -rs '[.[].gitBranch // empty]|last' "$f" 2>/dev/null)
       issue="-"; phase="-"; st="$cwd/.epic-status.json"
       if [ -f "$st" ]; then issue=$(jq -r '.issue // "-"' "$st" 2>/dev/null); phase=$(jq -r '.phase // "-"' "$st" 2>/dev/null); fi
@@ -114,10 +126,10 @@ case "${1:-}" in
     ;;
   ""|--interactive)
     collect
-    [ ${#IDS[@]} -gt 0 ] || { echo "No sessions active in the ${SINCE_HOURS}h before boot ($(date -d @$boot '+%m-%d %H:%M'))."; exit 0; }
+    [ ${#IDS[@]} -gt 0 ] || { echo "No sessions active in the ${SINCE_HOURS}h before boot ($("$DATE" -d @"$boot" '+%m-%d %H:%M'))."; exit 0; }
     # sorted display
     mapfile -t sorted < <(printf '%s' "$rows" | sort -t$'\t' -k1,1nr)
-    echo "Sessions for '$proj' active before reboot ($(date -d @$boot '+%m-%d %H:%M')):"; echo
+    echo "Sessions for '$proj' active before reboot ($("$DATE" -d @"$boot" '+%m-%d %H:%M')):"; echo
     declare -a MENU_ID
     i=0
     for line in "${sorted[@]}"; do

--- a/skills/bip-epic-recover/epic-recover
+++ b/skills/bip-epic-recover/epic-recover
@@ -19,7 +19,20 @@ PROJ=$HOME/.claude/projects
 CFG=.epic-config.json
 
 [ -f "$CFG" ] || { echo "No $CFG here — run from an EPIC project's main clone." >&2; exit 1; }
-command -v jq >/dev/null || { echo "jq required" >&2; exit 1; }
+command -v jq >/dev/null || { echo "epic-recover: jq is required." >&2; exit 1; }
+
+# This helper targets the Linux fleet host (GNU date, bash >= 4). Fail clearly elsewhere
+# rather than emitting cryptic errors — recovery is meant to run on the box that rebooted.
+if ! date -d @0 +%s >/dev/null 2>&1; then
+  echo "epic-recover: needs GNU date (Linux). It runs on the rebooted fleet host, not macOS." >&2
+  echo "  From a Mac:  ssh <host> 'cd <main-clone> && epic-recover [--list|--resume <id>...]'" >&2
+  exit 2
+fi
+command -v mapfile >/dev/null 2>&1 || {
+  echo "epic-recover: needs bash >= 4 (mapfile); found bash ${BASH_VERSION:-unknown}." >&2
+  echo "  On macOS install a newer bash, or run on the Linux fleet host." >&2
+  exit 2
+}
 
 main_dir=$PWD
 proj=$(basename "$PWD")

--- a/skills/bip-epic-recover/epic-recover
+++ b/skills/bip-epic-recover/epic-recover
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# epic-recover — recover bip-epic Claude sessions after a reboot.
+# Run from a project's MAIN clone (the dir holding .epic-config.json).
+#
+#   epic-recover            interactive: list sessions, pick numbers, spawn windows
+#   epic-recover --list     emit TSV of candidate sessions (for the bip-epic-recover skill)
+#   epic-recover --resume <id> [<id>...]   spawn a window per session-id into current tmux
+#
+# Enumerates ALL Claude sessions (cwd = main clone OR any worker clone) whose jsonl
+# was active within SINCE_HOURS before the last reboot — no git-branch filter, because
+# a clone often returns to main while its conversation continues. When run inside tmux
+# ($TMUX set) it ADDS windows to the current session, preserving the keychain/ssh-agent
+# env of the running tmux server; otherwise it builds a detached session named for the project.
+set -euo pipefail
+
+SINCE_HOURS=${EPIC_RECOVER_SINCE_HOURS:-36}
+CLAUDE="claude --dangerously-skip-permissions"
+PROJ=$HOME/.claude/projects
+CFG=.epic-config.json
+
+[ -f "$CFG" ] || { echo "No $CFG here — run from an EPIC project's main clone." >&2; exit 1; }
+command -v jq >/dev/null || { echo "jq required" >&2; exit 1; }
+
+main_dir=$PWD
+proj=$(basename "$PWD")
+clone_root=$(jq -r '.clone_root' "$CFG"); clone_root=${clone_root/#\~/$HOME}
+mapfile -t clone_names < <(jq -r '.clone_names[]?' "$CFG")
+
+# directories to scan: main clone + each worker clone
+dirs=("$main_dir")
+for n in "${clone_names[@]}"; do [ -d "$clone_root/$n" ] && dirs+=("$clone_root/$n"); done
+
+# cutoff = boot - SINCE_HOURS (fall back to now if uptime -s unavailable)
+boot=$(date -d "$(uptime -s)" +%s 2>/dev/null || date +%s)
+cutoff=$(( boot - SINCE_HOURS*3600 ))
+
+enc() { printf '%s' "$1" | sed 's#/#-#g'; }
+
+first_prompt() { # $1=jsonl -> short human hint (tags stripped, command names kept)
+  jq -rs '[.[]|select(.type=="user")| .message.content
+            | if type=="string" then . elif type=="array" then (.[]|select(.type=="text")|.text) else empty end]
+          | map(select(test("tool_result|tool_use_id")|not)) | map(select(length>0)) | .[0] // ""' "$1" 2>/dev/null \
+    | tr '\n\r\t' '   ' | sed -E 's#<[^>]+># #g; s#  +# #g; s#^ ##' | cut -c1-88
+}
+
+# Collect candidates -> arrays  IDS[] CWDS[] (TSV cache in $rows)
+IDS=(); CWDS=(); rows=""
+collect() {
+  local d enc f id mt mth br cwd st issue phase fp
+  for cwd in "${dirs[@]}"; do
+    d=$PROJ/$(enc "$cwd"); [ -d "$d" ] || continue
+    for f in "$d"/*.jsonl; do
+      [ -e "$f" ] || continue
+      mt=$(date -r "$f" +%s); [ "$mt" -ge "$cutoff" ] || continue
+      id=$(basename "$f" .jsonl); mth=$(date -r "$f" "+%m-%d_%H:%M")
+      br=$(jq -rs '[.[].gitBranch // empty]|last' "$f" 2>/dev/null)
+      issue="-"; phase="-"; st="$cwd/.epic-status.json"
+      if [ -f "$st" ]; then issue=$(jq -r '.issue // "-"' "$st" 2>/dev/null); phase=$(jq -r '.phase // "-"' "$st" 2>/dev/null); fi
+      fp=$(first_prompt "$f")
+      IDS+=("$id"); CWDS+=("$cwd")
+      rows+="$mt"$'\t'"$mth"$'\t'"$(basename "$cwd")"$'\t'"${br:-?}"$'\t'"$issue"$'\t'"$phase"$'\t'"$id"$'\t'"$fp"$'\n'
+    done
+  done
+}
+
+cwd_for() { local id="$1" cwd d; for cwd in "${dirs[@]}"; do d=$PROJ/$(enc "$cwd"); [ -e "$d/$id"*.jsonl ] && { echo "$cwd"; return; }; done; }
+
+label_for() { # $1=cwd -> window-name base
+  local cwd="$1" st="$1/.epic-status.json"
+  if [ -f "$st" ]; then local i; i=$(jq -r '.issue // empty' "$st" 2>/dev/null); [ -n "$i" ] && { echo "$i-$(basename "$cwd")"; return; }; fi
+  basename "$cwd"
+}
+
+spawn_one() { # $1=session-id  $2=optional window-name
+  local id="$1" name="${2:-}" cwd
+  cwd=$(cwd_for "$id") || true
+  [ -n "$cwd" ] || { echo "  ! no clone found for session $id — skipped" >&2; return; }
+  [ -n "$name" ] || name=$(label_for "$cwd")
+  local cmd="$CLAUDE --resume $id"
+  if [ -n "${TMUX:-}" ]; then
+    tmux new-window -n "$name" -c "$cwd"
+    tmux send-keys -t "$name" "$cmd" Enter
+  else
+    tmux has-session -t "$proj" 2>/dev/null || tmux new-session -d -s "$proj" -n "$name" -c "$cwd" \; send-keys -t "$proj:$name" "$cmd" Enter && { echo "  + $name ($id) [new session '$proj']"; return; }
+    tmux new-window -t "$proj" -n "$name" -c "$cwd"; tmux send-keys -t "$proj:$name" "$cmd" Enter
+  fi
+  echo "  + $name  ($id)  $cwd"
+}
+
+case "${1:-}" in
+  --list)
+    collect
+    printf 'last_active\tclone\tbranch\tissue\tphase\tsession\tfirst_prompt\n'
+    printf '%s' "$rows" | sort -t$'\t' -k1,1nr | cut -f2-
+    ;;
+  --resume)
+    shift; [ $# -gt 0 ] || { echo "usage: epic-recover --resume <id>..." >&2; exit 1; }
+    echo "Spawning ${#@} window(s) into ${TMUX:+current tmux}${TMUX:-session '$proj'}:"
+    for id in "$@"; do spawn_one "$id"; done
+    [ -z "${TMUX:-}" ] && echo "Attach: tmux attach -t $proj"
+    ;;
+  ""|--interactive)
+    collect
+    [ ${#IDS[@]} -gt 0 ] || { echo "No sessions active in the ${SINCE_HOURS}h before boot ($(date -d @$boot '+%m-%d %H:%M'))."; exit 0; }
+    # sorted display
+    mapfile -t sorted < <(printf '%s' "$rows" | sort -t$'\t' -k1,1nr)
+    echo "Sessions for '$proj' active before reboot ($(date -d @$boot '+%m-%d %H:%M')):"; echo
+    declare -a MENU_ID
+    i=0
+    for line in "${sorted[@]}"; do
+      mth=$(cut -f2 <<<"$line"); clone=$(cut -f3 <<<"$line"); iss=$(cut -f5 <<<"$line"); ph=$(cut -f6 <<<"$line"); sid=$(cut -f7 <<<"$line"); fp=$(cut -f8 <<<"$line")
+      i=$((i+1)); MENU_ID[$i]=$sid
+      tag=""; [ "$iss" != "-" ] && tag="#$iss/$ph"
+      printf "  [%2d] %-11s %-10s %-12s %-9s %s\n" "$i" "$mth" "$clone" "$tag" "${sid:0:8}" "$fp"
+    done
+    echo
+    printf "Resume which? (numbers, 'a'=all, 'q'=quit): "; read -r ans
+    [ "$ans" = q ] && exit 0
+    sel=(); if [ "$ans" = a ]; then for n in $(seq 1 $i); do sel+=("${MENU_ID[$n]}"); done; else for n in $ans; do [ -n "${MENU_ID[$n]:-}" ] && sel+=("${MENU_ID[$n]}"); done; fi
+    [ ${#sel[@]} -gt 0 ] || { echo "nothing selected"; exit 0; }
+    echo; for id in "${sel[@]}"; do spawn_one "$id"; done
+    [ -z "${TMUX:-}" ] && echo "Attach: tmux attach -t $proj"
+    ;;
+  *) echo "usage: epic-recover [--list | --resume <id>... | (no args = interactive)]" >&2; exit 1;;
+esac

--- a/skills/bip-epic/SKILL.md
+++ b/skills/bip-epic/SKILL.md
@@ -26,6 +26,12 @@ updates, use `/bip-epic-poll`. To spawn work, use `/bip-epic-spawn`.
 The conductor session stays on `main` and does NOT do feature work.
 It orchestrates: scans, updates EPICs, spawns clones.
 
+### Recovery after a reboot
+If the host reboots and the tmux fleet is lost, use `/bip-epic-recover` from a
+project's main clone to find the killed Claude sessions and resume each into a
+tmux window (`claude --resume`). It reads each session's own jsonl, so workers
+that returned to `main` and concurrent main-clone sessions are all recoverable.
+
 **Numbered issues → spawn**: If work is tied to a GitHub issue (`iN`),
 always use `/bip-epic-spawn` to assign it to a clone — even if the fix
 seems trivial. The conductor can do light triage (reading files, checking


### PR DESCRIPTION
🤖 Adds the `bip-epic-recover` skill plus a bundled `epic-recover` shell helper that, run from a bip-epic project's main clone after the host reboots, finds the killed Claude sessions and resumes each into a tmux window via `claude --dangerously-skip-permissions --resume <id>`.

## Why
A reboot kills the tmux server and every `claude` process at once, but the clones, `.epic-status.json`/`.epic-worklog.md`, and the full per-session `~/.claude/projects/*/<id>.jsonl` conversations all survive on disk — so the sessions are resumable. There was no tool that found them and brought them back.

## Design
- `skills/bip-epic-recover/epic-recover` — deterministic engine (Linux/`jq`/GNU-`date`). Enumerates every session whose cwd is the main clone **or any worker clone** and whose jsonl was active in the window before the last reboot. Modes: `--list` (TSV), `--resume <id>…` (spawn a window per id), bare (interactive picker).
- `skills/bip-epic-recover/SKILL.md` — the brain: runs `--list`, labels raw first-prompts into human terms, presents a pick menu, calls `--resume`.

Two findings from validating against the 2026-05-29 `pax` reboot drove the design:
- **No git-branch filter.** Worker clones return to `main` while their conversation continues (e.g. balsa #1459 → pcp-pipeline #52 discussion). Filtering on branch would have missed them.
- **All sessions per cwd, not one.** The main clone hosts several concurrent sessions (conductor, planning, coordinate-pca). Taking only the newest would have dropped the others.

When run inside tmux (`$TMUX` set) the helper **adds windows to the current session**, preserving the running server's keychain/ssh-agent env.

## Test
Validated end-to-end on `pax` against the real reboot: `--list` from `~/re/phyz` returns exactly the 17 sessions active in the window across main + clones (correctly surfacing main-reset workers and the three concurrent phyz-main sessions), and resumes spawn correctly-named windows. `bash -n` clean; `go vet`/`go fmt` clean (no Go changed).

## Notes
- `--list` mutates nothing; only `--resume`/interactive create windows — safe to re-run.
- A resumed worker needs a one-line nudge to restart forward motion (the ralph-loop wakeup died with the process); the skill prompts for it rather than racing an unreliable auto `send-keys`.

Closes #157