### PR TITLE
Honor env vars for ASTA API key; warn on anonymous access; fix docs nav (#153)

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,3 +2,4 @@
 
 - **Erick Matsen** — bip CLI, agents, skills
 - **Jared Galloway** (@jgalloway07) — snakemake-pipeline-expert agent
+- **Duncan Ralph** (@psathyrella) — ASTA API key resolution

--- a/cmd/bip/asta.go
+++ b/cmd/bip/asta.go
@@ -20,14 +20,17 @@ Use --human flag for human-readable output.
 
 Environment Variables (take precedence over asta_api_key in config.yml):
   BIP_ASTA_API_KEY  Your ASTA API key (recommended, bip-scoped)
-  ASTA_API_KEY      Your ASTA API key (fallback; also loaded from a .env file)
+  ASTA_API_KEY      Your ASTA API key (fallback)
+
+Either variable may also be set in a local .env file, which is loaded
+automatically.
 
 Without a key, requests are sent anonymously: the cheap endpoints work, but
 the search endpoint may time out. Register at https://allenai.org/asta/resources/mcp`,
 }
 
 func init() {
-	// Load .env file if present (for ASTA_API_KEY)
+	// Load .env file if present (for BIP_ASTA_API_KEY / ASTA_API_KEY)
 	_ = godotenv.Load()
 
 	astaCmd.PersistentFlags().BoolVar(&astaHuman, "human", false, "Output human-readable format instead of JSON")

--- a/cmd/bip/asta.go
+++ b/cmd/bip/asta.go
@@ -18,8 +18,12 @@ powerful text snippet search capabilities.
 All commands output JSON by default for agent consumption.
 Use --human flag for human-readable output.
 
-Environment Variables:
-  ASTA_API_KEY  Your ASTA API key (required)`,
+Environment Variables (take precedence over asta_api_key in config.yml):
+  BIP_ASTA_API_KEY  Your ASTA API key (recommended, bip-scoped)
+  ASTA_API_KEY      Your ASTA API key (fallback; also loaded from a .env file)
+
+Without a key, requests are sent anonymously: the cheap endpoints work, but
+the search endpoint may time out. Register at https://allenai.org/asta/resources/mcp`,
 }
 
 func init() {

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -38,7 +38,7 @@ EOF
 |-------|-------------|
 | `nexus_path` | Default bipartite repository path. Allows running bip commands from anywhere. |
 | `s2_api_key` | Semantic Scholar API key for higher rate limits |
-| `asta_api_key` | ASTA MCP API key |
+| `asta_api_key` | ASTA MCP API key ([register here](https://allenai.org/asta/resources/mcp)). Also accepts env vars: `BIP_ASTA_API_KEY`, `ASTA_API_KEY` (in that order). |
 | `github_token` | GitHub personal access token ([setup guide](#github-authentication)). Also accepts env vars: `BIP_GITHUB_TOKEN`, `GITHUB_TOKEN`, `GH_TOKEN` (in that order). |
 | `slack_bot_token` | Slack bot token for reading channel history. Also accepts env vars: `BIP_SLACK_TOKEN`, `SLACK_BOT_TOKEN` (in that order). |
 | `slack_webhooks` | Slack webhook URLs keyed by channel name |

--- a/internal/asta/client.go
+++ b/internal/asta/client.go
@@ -152,6 +152,23 @@ func parseSSEResponse(body io.Reader) ([]string, error) {
 			}
 
 			if mcpResp.Result != nil {
+				// A tool-level error: Content carries a plain-text message,
+				// not the tool's normal JSON output. Surface it as an error
+				// instead of passing the message downstream, where a typed
+				// JSON parse would fail with a cryptic "invalid character".
+				if mcpResp.Result.IsError {
+					var msg strings.Builder
+					for _, content := range mcpResp.Result.Content {
+						if content.Type == "text" {
+							msg.WriteString(content.Text)
+						}
+					}
+					return nil, &APIError{
+						Code:    "tool_error",
+						Message: msg.String(),
+					}
+				}
+
 				for _, content := range mcpResp.Result.Content {
 					if content.Type == "text" && content.Text != "" {
 						allTextContent = append(allTextContent, content.Text)

--- a/internal/asta/client.go
+++ b/internal/asta/client.go
@@ -163,9 +163,13 @@ func parseSSEResponse(body io.Reader) ([]string, error) {
 							msg.WriteString(content.Text)
 						}
 					}
+					message := msg.String()
+					if message == "" {
+						message = "tool reported an error with no message"
+					}
 					return nil, &APIError{
 						Code:    "tool_error",
-						Message: msg.String(),
+						Message: message,
 					}
 				}
 

--- a/internal/asta/client.go
+++ b/internal/asta/client.go
@@ -8,7 +8,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -94,7 +96,26 @@ func NewClient(opts ...ClientOption) *Client {
 		opt(c)
 	}
 
+	// Warn once per process if we are operating without an API key. The
+	// cheap endpoints (paper, citations, ...) accept anonymous calls, so a
+	// missing key stays invisible until `search` trips the SSE timeout.
+	if c.apiKey == "" {
+		warnNoAPIKey()
+	}
+
 	return c
+}
+
+// anonymousWarnOnce ensures the no-key warning is emitted at most once per
+// process, regardless of how many clients are constructed.
+var anonymousWarnOnce sync.Once
+
+func warnNoAPIKey() {
+	anonymousWarnOnce.Do(func() {
+		fmt.Fprintln(os.Stderr, "bip: ASTA API key not configured; falling back to anonymous access "+
+			"(the search endpoint may time out). Set BIP_ASTA_API_KEY or see "+
+			"https://allenai.org/asta/resources/mcp")
+	})
 }
 
 // parseSSEResponse extracts text content from an SSE/MCP response stream.

--- a/internal/asta/client_test.go
+++ b/internal/asta/client_test.go
@@ -72,6 +72,22 @@ func TestParseSSEResponse_ToolError(t *testing.T) {
 	}
 }
 
+func TestParseSSEResponse_ToolErrorNoMessage(t *testing.T) {
+	// isError:true with no text content must still yield a non-empty,
+	// readable APIError message rather than a dangling "code tool_error): ".
+	body := "event: message\n" +
+		`data: {"jsonrpc":"2.0","id":1,"result":{"content":[],"isError":true}}` + "\n"
+
+	_, err := parseSSEResponse(strings.NewReader(body))
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected *APIError, got %T: %v", err, err)
+	}
+	if apiErr.Message == "" {
+		t.Error("expected a non-empty fallback message for an empty tool error")
+	}
+}
+
 func TestParseSSEResponse_Success(t *testing.T) {
 	// isError:false (and absent) must still return the content text,
 	// skipping ping/comment lines.

--- a/internal/asta/client_test.go
+++ b/internal/asta/client_test.go
@@ -50,6 +50,45 @@ func TestCombineStreamingResults(t *testing.T) {
 	})
 }
 
+func TestParseSSEResponse_ToolError(t *testing.T) {
+	// A tool-level error: JSON-RPC succeeded but the tool reports isError
+	// with a plain-text message instead of JSON. Previously this message
+	// leaked downstream and surfaced as "invalid character 'E'" (#153).
+	body := "event: message\n" +
+		`data: {"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text",` +
+		`"text":"Error executing tool get_paper: Paper with id 10.1126/science.1058040 not found"}],` +
+		`"isError":true}}` + "\n"
+
+	_, err := parseSSEResponse(strings.NewReader(body))
+	if err == nil {
+		t.Fatal("expected an error for isError:true response, got nil")
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected *APIError, got %T: %v", err, err)
+	}
+	if !strings.Contains(apiErr.Message, "Paper with id 10.1126/science.1058040 not found") {
+		t.Errorf("server message not preserved, got: %q", apiErr.Message)
+	}
+}
+
+func TestParseSSEResponse_Success(t *testing.T) {
+	// isError:false (and absent) must still return the content text,
+	// skipping ping/comment lines.
+	body := ": ping - 2026-05-29\n" +
+		"event: message\n" +
+		`data: {"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text",` +
+		`"text":"{\"paperId\":\"abc123\"}"}],"isError":false}}` + "\n"
+
+	content, err := parseSSEResponse(strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(content) != 1 || content[0] != `{"paperId":"abc123"}` {
+		t.Errorf("unexpected content: %#v", content)
+	}
+}
+
 func TestParseSearchPapersResult(t *testing.T) {
 	paperChunk := loadFixture(t, "paper_single_chunk.json")
 

--- a/internal/asta/types.go
+++ b/internal/asta/types.go
@@ -25,9 +25,13 @@ type MCPResponse struct {
 	Error   *MCPError  `json:"error,omitempty"`  // Error result
 }
 
-// MCPResult contains successful tool results.
+// MCPResult contains tool results. IsError marks a tool-level failure: the
+// JSON-RPC call itself succeeded (no MCPError), but the tool reported an
+// error and Content holds a plain-text message rather than the tool's
+// normal JSON output.
 type MCPResult struct {
 	Content []MCPContent `json:"content"` // Array of content blocks
+	IsError bool         `json:"isError"` // Tool-level error flag
 }
 
 // MCPContent represents a content block in the result.

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -84,9 +84,23 @@ func ResetGlobalConfigCache() {
 	globalConfigCache = nil
 }
 
+// firstEnvOrConfig returns the first non-empty environment variable named in
+// names, falling back to configValue. Empty env vars are treated as unset.
+func firstEnvOrConfig(names []string, configValue string) string {
+	for _, name := range names {
+		if v := os.Getenv(name); v != "" {
+			return v
+		}
+	}
+	return configValue
+}
+
 // GetS2APIKey returns the Semantic Scholar API key from global config.
 func GetS2APIKey() string {
-	cfg, _ := LoadGlobalConfig()
+	cfg, err := LoadGlobalConfig()
+	if err != nil || cfg == nil {
+		return ""
+	}
 	return cfg.S2APIKey
 }
 
@@ -106,13 +120,12 @@ var ASTAAPIKeyEnvVars = []string{"BIP_ASTA_API_KEY", "ASTA_API_KEY"}
 //
 // Empty env vars are treated as unset.
 func GetASTAAPIKey() string {
-	for _, name := range ASTAAPIKeyEnvVars {
-		if v := os.Getenv(name); v != "" {
-			return v
-		}
-	}
 	cfg, _ := LoadGlobalConfig()
-	return cfg.ASTAAPIKey
+	configValue := ""
+	if cfg != nil {
+		configValue = cfg.ASTAAPIKey
+	}
+	return firstEnvOrConfig(ASTAAPIKeyEnvVars, configValue)
 }
 
 // GitHubTokenEnvVars lists the environment variables consulted by
@@ -136,13 +149,12 @@ var SlackBotTokenEnvVars = []string{"BIP_SLACK_TOKEN", "SLACK_BOT_TOKEN"}
 //
 // Empty env vars are treated as unset.
 func GetSlackBotToken() string {
-	for _, name := range SlackBotTokenEnvVars {
-		if v := os.Getenv(name); v != "" {
-			return v
-		}
-	}
 	cfg, _ := LoadGlobalConfig()
-	return cfg.SlackBotToken
+	configValue := ""
+	if cfg != nil {
+		configValue = cfg.SlackBotToken
+	}
+	return firstEnvOrConfig(SlackBotTokenEnvVars, configValue)
 }
 
 // GetGitHubToken returns the GitHub token.
@@ -155,13 +167,12 @@ func GetSlackBotToken() string {
 //
 // Empty env vars are treated as unset.
 func GetGitHubToken() string {
-	for _, name := range GitHubTokenEnvVars {
-		if v := os.Getenv(name); v != "" {
-			return v
-		}
-	}
 	cfg, _ := LoadGlobalConfig()
-	return cfg.GitHubToken
+	configValue := ""
+	if cfg != nil {
+		configValue = cfg.GitHubToken
+	}
+	return firstEnvOrConfig(GitHubTokenEnvVars, configValue)
 }
 
 // GetSlackWebhook returns the Slack webhook URL for a channel from global config.

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -90,8 +90,27 @@ func GetS2APIKey() string {
 	return cfg.S2APIKey
 }
 
-// GetASTAAPIKey returns the ASTA API key from global config.
+// ASTAAPIKeyEnvVars lists the environment variables consulted by
+// GetASTAAPIKey, in precedence order. BIP_ASTA_API_KEY is the
+// recommended bip-specific name; ASTA_API_KEY is the conventional
+// fallback advertised in `bip asta --help` and loaded from a local
+// .env file by cmd/bip/asta.go.
+var ASTAAPIKeyEnvVars = []string{"BIP_ASTA_API_KEY", "ASTA_API_KEY"}
+
+// GetASTAAPIKey returns the ASTA API key.
+//
+// Precedence:
+//  1. $BIP_ASTA_API_KEY
+//  2. $ASTA_API_KEY
+//  3. asta_api_key in ~/.config/bip/config.yml
+//
+// Empty env vars are treated as unset.
 func GetASTAAPIKey() string {
+	for _, name := range ASTAAPIKeyEnvVars {
+		if v := os.Getenv(name); v != "" {
+			return v
+		}
+	}
 	cfg, _ := LoadGlobalConfig()
 	return cfg.ASTAAPIKey
 }

--- a/internal/config/global_test.go
+++ b/internal/config/global_test.go
@@ -335,16 +335,55 @@ func clearTokenEnv(t *testing.T) {
 	}
 }
 
-// writeConfigWithASTAKey creates a config.yml under XDG_CONFIG_HOME with
-// the given asta_api_key and points XDG_CONFIG_HOME at it.
-func writeConfigWithASTAKey(t *testing.T, astaKey string) {
+// writeRawConfig writes raw bytes to config.yml under a fresh
+// XDG_CONFIG_HOME (bypassing yaml.Marshal so malformed content can be
+// tested), points XDG_CONFIG_HOME at it, and resets the config cache.
+func writeRawConfig(t *testing.T, content string) {
 	t.Helper()
 	tmpDir := t.TempDir()
 	configDir := filepath.Join(tmpDir, "bip")
 	if err := os.MkdirAll(configDir, 0755); err != nil {
 		t.Fatal(err)
 	}
-	data, _ := yaml.Marshal(GlobalConfig{ASTAAPIKey: astaKey})
+	if err := os.WriteFile(filepath.Join(configDir, "config.yml"), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	ResetGlobalConfigCache()
+}
+
+// TestGetters_MalformedConfig ensures a config.yml that fails to parse
+// makes the key/token getters return "" rather than panicking on a nil
+// config (LoadGlobalConfig returns (nil, err) on a parse failure).
+func TestGetters_MalformedConfig(t *testing.T) {
+	clearTokenEnv(t)
+	writeRawConfig(t, "asta_api_key: [unterminated\n")
+	getters := map[string]func() string{
+		"GetS2APIKey":      GetS2APIKey,
+		"GetASTAAPIKey":    GetASTAAPIKey,
+		"GetGitHubToken":   GetGitHubToken,
+		"GetSlackBotToken": GetSlackBotToken,
+	}
+	for name, get := range getters {
+		t.Run(name, func(t *testing.T) {
+			if got := get(); got != "" {
+				t.Errorf("%s() = %q, want \"\" on malformed config", name, got)
+			}
+		})
+	}
+}
+
+// writeGlobalConfig marshals cfg to config.yml under a fresh
+// XDG_CONFIG_HOME, points XDG_CONFIG_HOME at it, and resets the config
+// cache so the next load reads the file.
+func writeGlobalConfig(t *testing.T, cfg GlobalConfig) {
+	t.Helper()
+	tmpDir := t.TempDir()
+	configDir := filepath.Join(tmpDir, "bip")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	data, _ := yaml.Marshal(cfg)
 	if err := os.WriteFile(filepath.Join(configDir, "config.yml"), data, 0644); err != nil {
 		t.Fatal(err)
 	}
@@ -401,7 +440,7 @@ func TestGetASTAAPIKey_EnvPrecedence(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			clearTokenEnv(t)
-			writeConfigWithASTAKey(t, tc.configKey)
+			writeGlobalConfig(t, GlobalConfig{ASTAAPIKey: tc.configKey})
 			for k, v := range tc.envs {
 				t.Setenv(k, v)
 			}
@@ -410,28 +449,6 @@ func TestGetASTAAPIKey_EnvPrecedence(t *testing.T) {
 			}
 		})
 	}
-}
-
-// writeConfigWithTokens creates a config.yml under XDG_CONFIG_HOME with
-// the given token values and points XDG_CONFIG_HOME at it. Returns the
-// temp dir for cleanup-by-t.TempDir().
-func writeConfigWithTokens(t *testing.T, githubToken, slackToken string) {
-	t.Helper()
-	tmpDir := t.TempDir()
-	configDir := filepath.Join(tmpDir, "bip")
-	if err := os.MkdirAll(configDir, 0755); err != nil {
-		t.Fatal(err)
-	}
-	cfgData := GlobalConfig{
-		GitHubToken:   githubToken,
-		SlackBotToken: slackToken,
-	}
-	data, _ := yaml.Marshal(cfgData)
-	if err := os.WriteFile(filepath.Join(configDir, "config.yml"), data, 0644); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("XDG_CONFIG_HOME", tmpDir)
-	ResetGlobalConfigCache()
 }
 
 func TestGetGitHubToken_EnvPrecedence(t *testing.T) {
@@ -494,7 +511,7 @@ func TestGetGitHubToken_EnvPrecedence(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			clearTokenEnv(t)
-			writeConfigWithTokens(t, tc.configToken, "")
+			writeGlobalConfig(t, GlobalConfig{GitHubToken: tc.configToken})
 			for k, v := range tc.envs {
 				t.Setenv(k, v)
 			}
@@ -554,7 +571,7 @@ func TestGetSlackBotToken_EnvPrecedence(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			clearTokenEnv(t)
-			writeConfigWithTokens(t, "", tc.configToken)
+			writeGlobalConfig(t, GlobalConfig{SlackBotToken: tc.configToken})
 			for k, v := range tc.envs {
 				t.Setenv(k, v)
 			}

--- a/internal/config/global_test.go
+++ b/internal/config/global_test.go
@@ -327,8 +327,88 @@ func TestValidateNexusPath_PathNotExist(t *testing.T) {
 // the user's shell exports. t.Setenv restores values on cleanup.
 func clearTokenEnv(t *testing.T) {
 	t.Helper()
-	for _, name := range append(append([]string{}, GitHubTokenEnvVars...), SlackBotTokenEnvVars...) {
+	names := append([]string{}, GitHubTokenEnvVars...)
+	names = append(names, SlackBotTokenEnvVars...)
+	names = append(names, ASTAAPIKeyEnvVars...)
+	for _, name := range names {
 		t.Setenv(name, "")
+	}
+}
+
+// writeConfigWithASTAKey creates a config.yml under XDG_CONFIG_HOME with
+// the given asta_api_key and points XDG_CONFIG_HOME at it.
+func writeConfigWithASTAKey(t *testing.T, astaKey string) {
+	t.Helper()
+	tmpDir := t.TempDir()
+	configDir := filepath.Join(tmpDir, "bip")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	data, _ := yaml.Marshal(GlobalConfig{ASTAAPIKey: astaKey})
+	if err := os.WriteFile(filepath.Join(configDir, "config.yml"), data, 0644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	ResetGlobalConfigCache()
+}
+
+func TestGetASTAAPIKey_EnvPrecedence(t *testing.T) {
+	cases := []struct {
+		name      string
+		envs      map[string]string
+		configKey string
+		want      string
+	}{
+		{
+			name: "BIP_ASTA_API_KEY wins over ASTA_API_KEY",
+			envs: map[string]string{
+				"BIP_ASTA_API_KEY": "from-bip",
+				"ASTA_API_KEY":     "from-asta",
+			},
+			configKey: "from-config",
+			want:      "from-bip",
+		},
+		{
+			name: "ASTA_API_KEY wins when BIP_ASTA_API_KEY unset",
+			envs: map[string]string{
+				"ASTA_API_KEY": "from-asta",
+			},
+			configKey: "from-config",
+			want:      "from-asta",
+		},
+		{
+			name:      "config used when no env vars set",
+			envs:      nil,
+			configKey: "from-config",
+			want:      "from-config",
+		},
+		{
+			name: "empty env vars treated as unset",
+			envs: map[string]string{
+				"BIP_ASTA_API_KEY": "",
+				"ASTA_API_KEY":     "",
+			},
+			configKey: "from-config",
+			want:      "from-config",
+		},
+		{
+			name:      "empty config and no env returns empty",
+			envs:      nil,
+			configKey: "",
+			want:      "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			clearTokenEnv(t)
+			writeConfigWithASTAKey(t, tc.configKey)
+			for k, v := range tc.envs {
+				t.Setenv(k, v)
+			}
+			if got := GetASTAAPIKey(); got != tc.want {
+				t.Errorf("GetASTAAPIKey() = %q, want %q", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,6 +60,7 @@ nav:
   - Home: index.md
   - Guides:
     - Getting Started: guides/getting-started.md
+    - Configuration: guides/configuration.md
     - Reference Management: guides/reference-management.md
     - Knowledge Graph: guides/knowledge-graph.md
     - Workflow Coordination: guides/workflow-coordination.md


### PR DESCRIPTION
Fixes the three findings in #153, mirroring the GitHub/Slack token fix from #151 (which missed ASTA), plus a related diagnostics bug surfaced while verifying it.

## Changes

**Fix 1 — env-var precedence for ASTA** (`internal/config/global.go`)
- `GetASTAAPIKey()` now consults `BIP_ASTA_API_KEY` → `ASTA_API_KEY` → `asta_api_key` in `config.yml`, mirroring `GitHubTokenEnvVars`/`SlackBotTokenEnvVars`. The env var advertised in `bip asta --help` and the `.env` autoload in `cmd/bip/asta.go` were inert because nothing read `os.Getenv`. Empty env vars are treated as unset; no-env behavior is unchanged.
- Adds `TestGetASTAAPIKey_EnvPrecedence` (5 cases) reusing the existing table-test pattern.

**Fix 2 — warn on anonymous ASTA calls** (`internal/asta/client.go`)
- `NewClient` emits a one-time (`sync.Once`) stderr warning when no key is configured, checked *after* options apply so `WithAPIKey` isn't falsely flagged. Points at the registration URL. Previously anonymous requests went out silently; cheap endpoints work anonymously, so a missing key stayed invisible until `search` tripped the 3-minute SSE timeout.

**Fix 3 — docs** (`mkdocs.yml`, `docs/guides/configuration.md`, `cmd/bip/asta.go`)
- Wires the orphaned `configuration.md` into the nav sidebar.
- `asta_api_key` config row now documents the env vars and the [registration link](https://allenai.org/asta/resources/mcp).
- Updates `bip asta --help` to list `BIP_ASTA_API_KEY` (recommended) and `ASTA_API_KEY`, and to note the anonymous-search caveat.

**Fix 4 — surface tool-level errors** (`internal/asta/types.go`, `internal/asta/client.go`)
- A tool call can return JSON-RPC success with `result.isError=true`, where `Content` holds a plain-text message (e.g. "Paper with id X not found") rather than the tool's normal JSON. `MCPResult` didn't model `isError` and `parseSSEResponse` never checked it, so the message was passed through as content and the downstream typed parse failed with the cryptic `invalid response from ASTA: ... invalid character 'E'`. Now modeled and returned as an `*APIError` carrying the server's message.
- Adds `parseSSEResponse` tests for the tool-error and success paths.
- Surfaced while confirming anonymous ASTA access had **not** changed (see investigation note on #153).

## Acceptance criteria (all verified live)

- [x] `export BIP_ASTA_API_KEY=…` makes `bip asta search` work without editing YAML (verified with config unreachable).
- [x] Keyless `bip asta` emits a clear one-line stderr warning pointing at the registration URL.
- [x] The Configuration guide appears in the sidebar nav.
- [x] `bip asta search` with a valid key returns in seconds, not a 3-min SSE timeout.
- [x] `bip asta paper <unresolvable-id>` prints the server's message, not `invalid character 'E'`.

`go build`, `go vet`, `gofmt`, and the full `go test ./...` suite pass.

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)