### PR TITLE
Add bip-epic-prepare-reboot: park the tmux host before a planned reboot

### DIFF
--- a/skills/bip-epic-prepare-reboot/SKILL.md
+++ b/skills/bip-epic-prepare-reboot/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: bip-epic-prepare-reboot
+description: Quiesce the whole tmux host before a PLANNED reboot — walk every session, resolve each Claude window's exact session id, optionally checkpoint workers, and write a manifest so bip-epic-recover can rebuild the workspace deterministically. Use when you know a reboot is coming and want a clean, lossless restart.
+allowed-tools: Bash, Read
+---
+
+# /bip-epic-prepare-reboot
+
+`/bip-epic-recover` reconstructs a *killed* fleet after an unplanned reboot by scanning `~/.claude/projects/*/<id>.jsonl` and inferring which sessions were live from file mtimes. That inference is lossy: mtime is last *activity*, not "window was open", and it cannot tell which of several concurrent sessions in one cwd were on screen.
+
+When the reboot is **planned**, we can do better: capture ground truth *while tmux is still alive*. This skill walks every pane on the host in one run, resolves each Claude window's exact `session_id` from the live process (its `--resume` cmdline, or start-time correlation for fresh sessions), optionally checkpoints epic workers, and writes a host-wide manifest. `bip-epic-recover` then replays that manifest after the reboot — rebuilding every session by its real name, windows in order, each Claude window resumed to the right id — instead of guessing.
+
+The deterministic engine is the bundled `epic-prepare-reboot` shell helper; this skill is the brain that runs it, sanity-checks the resolved table with the user, and triggers the manifest write / shutdown. Run it **on the box about to reboot** — that is where tmux, the jsonl files, and the clones live.
+
+## Usage
+
+```
+/bip-epic-prepare-reboot [--no-checkpoint] [--shutdown]
+```
+
+Run it once, host-wide, *before* the reboot. There is no project argument — the manifest spans the entire tmux host, not one epic project.
+
+## The bundled helper
+
+This skill ships the `epic-prepare-reboot` helper next to `SKILL.md` — no separate install. At the start of the run, set `HELPER` to its absolute path (this skill's base directory, given at invocation, + `/epic-prepare-reboot`) and use `"$HELPER"` in every command below:
+
+```bash
+HELPER="<this-skill-dir>/epic-prepare-reboot"
+```
+
+It needs `tmux`, `jq`, bash ≥ 4, and a GNU `date` (or `gdate`): it runs on Linux out of the box, and on macOS with `brew install coreutils bash`. Session-id resolution reads Linux `/proc` first and falls back to `ps` (so it is fully functional on macOS too, just second-resolution start times). It exits 2 with guidance if a prerequisite is missing.
+
+## Workflow
+
+### Step 1: Dry-run and review the resolved table
+
+Always look before you write. `--dry-run` walks every pane, resolves each window, and prints the table **without** checkpointing, writing, or shutting anything down:
+
+```bash
+"$HELPER" --dry-run
+```
+
+Each row shows `SESSION  IDX  WINDOW  METHOD  CONF  SESSION_ID/CWD`. The resolution `method` per Claude window, in priority order:
+
+- **cmdline** (`high`) — `--resume <id>` was in the Claude process args. Exact; covers any resumed session in any cwd.
+- **starttime** (`medium`) — a *fresh* session (launched without `--resume`) carries no id in its cmdline, so the helper correlates the Claude process start time with the cwd's jsonl that *began* closest. Handles fresh windows, including two fresh windows in one cwd.
+- **newest** (`low`) — last resort: the newest jsonl for the cwd.
+- **shell** (`none`) — no Claude descendant; a bare shell or editor. Recorded with its cwd so the layout returns, recreated as a plain window.
+
+When start-time correlation finds two jsonls that fit a fresh process nearly equally (within a few seconds), the window is flagged **`ambiguous`** and both candidate ids are recorded — recover will ask rather than guess.
+
+Present a short summary to the user: how many sessions/windows, how many Claude windows resolved by each method, and call out any `ambiguous` rows by name. This is the moment to catch a misresolved window before it goes in the manifest.
+
+### Step 2: Decide on checkpointing
+
+By default the helper sends every epic **worker** (a Claude window whose cwd has `.epic-status.json`) a one-line checkpoint instruction — commit WIP, flush `.epic-status.json` + `.epic-worklog.md` — and waits briefly (`EPIC_PREPARE_CHECKPOINT_WAIT`, default 20s) for the flush. This **persists state; it does not wait for tasks to finish.**
+
+- Default (checkpoint): use when workers are mid-task and you want their latest state captured.
+- `--no-checkpoint`: skip it when the fleet is already quiet, or when interrupting in-flight tool calls would do more harm than good.
+
+Confirm the choice with the user before the real run.
+
+### Step 3: Write the manifest
+
+Run the helper for real. Without `--shutdown` it stops after writing the manifest, leaving tmux running so you can verify:
+
+```bash
+"$HELPER"                 # checkpoint workers, then write the manifest
+"$HELPER" --no-checkpoint # write the manifest without quiescing workers
+```
+
+The manifest lands at `~/.epic-recover/manifest.json` (override the dir with `EPIC_RECOVER_DIR`). It preserves your real session names, window names, order, and cwds, with a `session_id`, `method`, and `confidence` per Claude window — a **host-level** file so recover finds it without knowing the project list.
+
+### Step 4: Shut down (optional)
+
+When you are ready to reboot, either reboot the box yourself, or let the helper tear tmux down only **after** the manifest is on disk:
+
+```bash
+"$HELPER" --shutdown      # writes the manifest, then `tmux kill-server`
+```
+
+`--shutdown` never kills the server before the manifest write succeeds.
+
+### Step 5: After the reboot
+
+On the rebooted box, run `/bip-epic-recover`. It detects the manifest (parked before the current boot, not yet consumed), rebuilds **every** session by its real name with windows in order — Claude windows `--resume`'d to their exact ids, plain windows as bare shells — reports "(from manifest)", and asks about any `ambiguous` windows. After a successful replay it stamps the manifest consumed so a later *unplanned* reboot falls back to the jsonl scan instead of replaying a stale park.
+
+## The manifest (what recover consumes)
+
+```json
+{
+  "host": "pax",
+  "parked_at": "2026-05-29T06:00:00Z",
+  "sessions": [
+    {"name": "phyz", "windows": [
+      {"index": 0, "name": "claude",     "cwd": "/home/matsen/re/phyz",     "session_id": "30ebe63e-…", "method": "starttime", "confidence": "medium", "issue": null},
+      {"index": 1, "name": "1483-alder", "cwd": "/home/matsen/re/pz/alder", "session_id": "ee906cc5-…", "method": "cmdline",   "confidence": "high",   "issue": 1483}
+    ]}
+  ]
+}
+```
+
+`confidence` ∈ `high` (cmdline) · `medium` (starttime) · `low` (newest) · `ambiguous` · `none` (shell). An `ambiguous` window also carries a `candidates: [id, id]` array. `session_id` is `null` for shell windows.
+
+## Manual verification
+
+These helpers introspect live tmux and the process tree, so they are verified by exercising them, not by a unit-test suite (the same convention as `epic-recover`). To check a change, against any host with a few tmux windows open:
+
+1. **Fidelity** — `"$HELPER" --dry-run`; confirm the table's sessions/windows match `tmux list-panes -a` exactly (names, order, cwds), with a resolved `session_id` per Claude window.
+2. **Resolution** — a resumed window (started with `--resume`) shows `method=cmdline`; a fresh window shows `starttime`; two fresh windows in one cwd with near-identical start times show `ambiguous` (with two candidates in the manifest).
+3. **Roundtrip** — run for real, then on the same host `epic-recover --manifest-status` reports VALID and `--manifest-resume` rebuilds the sessions by real name with windows in order. (See `bip-epic-recover`'s own verification notes for staleness/consumed/fallback.)
+4. **Guards** — `--no-checkpoint` skips the worker nudges; `--shutdown` kills tmux only after the manifest exists.
+
+## Notes
+
+- `--dry-run` mutates nothing. Only a real run writes the manifest, sends checkpoints, or (with `--shutdown`) kills tmux.
+- The skill is **host-wide and project-agnostic** — it does *not* require `.epic-config.json` and records every session on the host, not just epic clones.
+- Naming pairs it with `bip-epic-recover`, though it operates beyond epic clones. Related: `bip-epic-tuckin` persists *orchestrator* state for a context reset — distinct from parking the *whole host* for a reboot.
+- Driving a remote box from elsewhere: prefix with `ssh <host> 'bash <skill-dir>/epic-prepare-reboot …'`, but it is cleanest run from a shell on the box itself.

--- a/skills/bip-epic-prepare-reboot/epic-prepare-reboot
+++ b/skills/bip-epic-prepare-reboot/epic-prepare-reboot
@@ -1,0 +1,265 @@
+#!/usr/bin/env bash
+# epic-prepare-reboot — quiesce the whole tmux host before a PLANNED reboot.
+#
+# Run ONCE, host-wide, while tmux is still alive. It walks every pane on the
+# host, resolves each claude window's exact session id from ground truth
+# (process cmdline / start-time correlation), optionally checkpoints epic
+# workers, and writes a manifest that bip-epic-recover replays after the reboot
+# to rebuild the workspace deterministically — preserving your real session
+# names, window names, order, and cwds.
+#
+#   epic-prepare-reboot                  checkpoint workers, write the manifest
+#   epic-prepare-reboot --dry-run        print the resolved table, write nothing
+#   epic-prepare-reboot --no-checkpoint  skip quiescing workers
+#   epic-prepare-reboot --shutdown       after the manifest is on disk, tmux kill-server
+#
+# Resolution priority per claude window:
+#   1. cmdline   — `--resume <id>` in the claude process args (exact; resumed sessions)
+#   2. starttime — claude process start time correlated to the cwd's jsonl that
+#                  *began* closest (fresh sessions, incl. two fresh in one cwd)
+#   3. newest    — newest jsonl for the cwd (last resort)
+# Windows that two jsonls fit nearly equally are flagged `ambiguous` so recover
+# asks rather than guessing. Non-claude windows are recorded as plain shells.
+#
+# Linux uses /proc first; macOS falls back to `ps`. Needs bash >= 4, jq, and a
+# GNU `date` (or `gdate` via `brew install coreutils`).
+set -euo pipefail
+
+RECOVER_DIR=${EPIC_RECOVER_DIR:-$HOME/.epic-recover}
+MANIFEST="$RECOVER_DIR/manifest.json"
+PROJ=$HOME/.claude/projects
+AMBIG_GAP=${EPIC_PREPARE_AMBIG_GAP:-5}          # 2nd-closest jsonl within Ns of closest -> ambiguous
+CHECKPOINT_WAIT=${EPIC_PREPARE_CHECKPOINT_WAIT:-20}
+
+UUID_RE='[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+
+command -v jq >/dev/null   || { echo "epic-prepare-reboot: jq is required." >&2; exit 1; }
+command -v tmux >/dev/null || { echo "epic-prepare-reboot: tmux is required." >&2; exit 1; }
+tmux list-panes -a >/dev/null 2>&1 || { echo "epic-prepare-reboot: no running tmux server — nothing to park." >&2; exit 1; }
+
+# GNU date (needs -d). macOS ships BSD date; Homebrew coreutils provides gdate.
+if date -d @0 +%s >/dev/null 2>&1; then DATE=date
+elif command -v gdate >/dev/null 2>&1 && gdate -d @0 +%s >/dev/null 2>&1; then DATE=gdate
+else
+  echo "epic-prepare-reboot: needs GNU date (for -d). Install it (brew install coreutils -> gdate)" >&2
+  echo "  or run on the Linux fleet host." >&2
+  exit 2
+fi
+command -v mapfile >/dev/null 2>&1 || {
+  echo "epic-prepare-reboot: needs bash >= 4 (mapfile); found bash ${BASH_VERSION:-unknown}." >&2
+  echo "  On macOS: brew install bash, or run on the Linux host." >&2
+  exit 2
+}
+
+DRY=0; CHECKPOINT=1; SHUTDOWN=0
+for a in "$@"; do
+  case "$a" in
+    --dry-run)       DRY=1 ;;
+    --no-checkpoint) CHECKPOINT=0 ;;
+    --shutdown)      SHUTDOWN=1 ;;
+    -h|--help) sed -n '2,30p' "$0"; exit 0 ;;
+    *) echo "epic-prepare-reboot: unknown arg '$a'" >&2; exit 1 ;;
+  esac
+done
+
+enc() { printf '%s' "$1" | sed 's#/#-#g'; }
+mtime() { stat -c %Y "$1" 2>/dev/null || stat -f %m "$1" 2>/dev/null; }
+
+# claude descendant pid of a pane's shell pid (BFS over the process tree).
+claude_pid_under() {
+  local root=$1 cur comm args
+  local queue=("$root")
+  while [ ${#queue[@]} -gt 0 ]; do
+    cur=${queue[0]}; queue=("${queue[@]:1}")
+    comm=$(ps -o comm= -p "$cur" 2>/dev/null || true)
+    args=$(ps -o args= -p "$cur" 2>/dev/null || true)
+    if [ "${comm##*/}" = claude ] || case "$args" in *claude\ --*|*/claude\ *) true ;; *) false ;; esac; then
+      echo "$cur"; return
+    fi
+    local kids; mapfile -t kids < <(pgrep -P "$cur" 2>/dev/null || true)
+    queue+=("${kids[@]}")
+  done
+}
+
+# Exact session id if `--resume <id>` is in the claude process args.
+resume_id_from() {
+  local pid=$1 cl=""
+  [ -r "/proc/$pid/cmdline" ] && cl=$(tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null || true)
+  [ -n "$cl" ] || cl=$(ps -o args= -p "$pid" 2>/dev/null || true)
+  case "$cl" in *--resume*) ;; *) return ;; esac
+  printf '%s\n' "$cl" | grep -oiE "$UUID_RE" | head -1
+}
+
+# Process start time in epoch seconds: Linux /proc first, ps lstart fallback.
+proc_start_epoch() {
+  local pid=$1 st btime hz ls
+  if [ -r "/proc/$pid/stat" ]; then
+    # strip "PID (comm) " (comm may contain spaces/parens), then field 20 is starttime ticks.
+    st=$(sed -E 's/^[0-9]+ \(.*\) //' "/proc/$pid/stat" 2>/dev/null | awk '{print $20}')
+    if [ -n "$st" ]; then
+      btime=$(awk '/^btime/{print $2}' /proc/stat 2>/dev/null)
+      hz=$(getconf CLK_TCK 2>/dev/null || echo 100)
+      [ -n "$btime" ] && { echo $(( btime + st / hz )); return; }
+    fi
+  fi
+  ls=$(ps -o lstart= -p "$pid" 2>/dev/null || true)
+  [ -n "$ls" ] && "$DATE" -d "$ls" +%s 2>/dev/null
+}
+
+# Epoch of a session's first record (when the session began); falls back to mtime.
+jsonl_begin_epoch() {
+  local f=$1 ts
+  ts=$(head -20 "$f" 2>/dev/null | jq -rs '[.[]|.timestamp // empty]|.[0] // empty' 2>/dev/null || true)
+  [ -n "$ts" ] && { "$DATE" -d "$ts" +%s 2>/dev/null && return; }
+  mtime "$f"
+}
+
+issue_for() {
+  local cwd=$1 st="$cwd/.epic-status.json" i
+  [ -f "$st" ] && i=$(jq -r '.issue // empty' "$st" 2>/dev/null) && [ -n "$i" ] && { echo "$i"; return; }
+  echo "-"
+}
+
+# ---- Pass 1: enumerate panes, resolve cmdline ids, note which jsonls are claimed ----
+# ROW fields (tab-separated): session index name cwd pane_pid claude_pid sid method conf issue candidates
+ROWS=()
+declare -A CLAIMED            # jsonl-id -> 1 once a cmdline resume locks it
+declare -A FRESH_IDX          # index into ROWS for windows needing start-time resolution
+
+readarray -t PANES < <(tmux list-panes -a -F '#{session_name}	#{window_index}	#{window_name}	#{pane_current_path}	#{pane_pid}')
+
+i=0
+for line in "${PANES[@]}"; do
+  IFS=$'\t' read -r sess widx wname cwd ppid <<<"$line"
+  cpid=$(claude_pid_under "$ppid" || true)
+  issue=$(issue_for "$cwd")
+  if [ -z "$cpid" ]; then
+    ROWS+=("$sess	$widx	$wname	$cwd	$ppid	-	-	shell	none	$issue	")
+    i=$((i+1)); continue
+  fi
+  rid=$(resume_id_from "$cpid" || true)
+  if [ -n "$rid" ]; then
+    CLAIMED["$rid"]=1
+    ROWS+=("$sess	$widx	$wname	$cwd	$ppid	$cpid	$rid	cmdline	high	$issue	")
+  else
+    ROWS+=("$sess	$widx	$wname	$cwd	$ppid	$cpid	-	pending	pending	$issue	")
+    FRESH_IDX["$i"]=1
+  fi
+  i=$((i+1))
+done
+
+# ---- Pass 2: start-time correlation for fresh windows (skipping cmdline-claimed jsonls) ----
+for idx in "${!FRESH_IDX[@]}"; do
+  IFS=$'\t' read -r sess widx wname cwd ppid cpid sid method conf issue cand <<<"${ROWS[$idx]}"
+  pstart=$(proc_start_epoch "$cpid" || true)
+  d=$PROJ/$(enc "$cwd")
+  best=""; bestdiff=""; second_diff=""; second_id=""; newest=""; newest_mt=""
+  if [ -n "$pstart" ] && [ -d "$d" ]; then
+    for f in "$d"/*.jsonl; do
+      [ -e "$f" ] || continue
+      fid=$(basename "$f" .jsonl)
+      [ -n "${CLAIMED[$fid]:-}" ] && continue          # already locked by a cmdline window
+      mt=$(mtime "$f"); [ -n "$mt" ] || continue
+      if [ -z "$newest_mt" ] || [ "$mt" -gt "$newest_mt" ]; then newest=$fid; newest_mt=$mt; fi
+      bid=$(jsonl_begin_epoch "$f"); [ -n "$bid" ] || continue
+      diff=$(( pstart>bid ? pstart-bid : bid-pstart ))
+      if [ -z "$bestdiff" ] || [ "$diff" -lt "$bestdiff" ]; then
+        second_diff=$bestdiff; second_id=$best; best=$fid; bestdiff=$diff
+      elif [ -z "$second_diff" ] || [ "$diff" -lt "$second_diff" ]; then
+        second_diff=$diff; second_id=$fid
+      fi
+    done
+  fi
+  if [ -n "$best" ]; then
+    if [ -n "$second_diff" ] && [ $(( second_diff - bestdiff )) -le "$AMBIG_GAP" ]; then
+      # two sessions fit this process nearly equally — let recover ask.
+      sid=$best; method=starttime; conf=ambiguous; cand="$best|$second_id"
+    else
+      sid=$best; method=starttime; conf=medium; cand=""
+    fi
+    CLAIMED["$sid"]=1
+  elif [ -n "$newest" ]; then
+    sid=$newest; method=newest; conf=low; cand=""
+    CLAIMED["$sid"]=1
+  else
+    sid="-"; method=none; conf=none; cand=""
+  fi
+  ROWS[$idx]="$sess	$widx	$wname	$cwd	$ppid	$cpid	$sid	$method	$conf	$issue	$cand"
+done
+
+# ---- Report ----
+nwin=${#ROWS[@]}; nclaude=0; namb=0
+print_table() {
+  printf '%-14s %-3s %-16s %-9s %-10s %s\n' SESSION IDX WINDOW METHOD CONF SESSION_ID/CWD
+  for r in "${ROWS[@]}"; do
+    IFS=$'\t' read -r sess widx wname cwd ppid cpid sid method conf issue cand <<<"$r"
+    local shown="$sid"; [ "$sid" = "-" ] && shown="(shell) $cwd"
+    printf '%-14s %-3s %-16s %-9s %-10s %s\n' "$sess" "$widx" "${wname:0:16}" "$method" "$conf" "$shown"
+  done
+}
+for r in "${ROWS[@]}"; do
+  IFS=$'\t' read -r _ _ _ _ _ cpid sid method conf _ _ <<<"$r"
+  [ "$method" = shell ] || nclaude=$((nclaude+1))
+  [ "$conf" = ambiguous ] && namb=$((namb+1))
+done
+
+print_table
+echo
+echo "Host: $(hostname)   windows: $nwin   claude: $nclaude   ambiguous: $namb"
+
+if [ "$DRY" = 1 ]; then
+  echo "(--dry-run: no checkpoint, no manifest, no shutdown.)"
+  exit 0
+fi
+
+# ---- Optionally checkpoint epic workers (claude windows whose cwd has .epic-status.json) ----
+if [ "$CHECKPOINT" = 1 ]; then
+  msg="Planned host reboot imminent. Checkpoint now: commit any WIP, then flush .epic-status.json and .epic-worklog.md. You do not need to finish the task — just persist state."
+  sent=0
+  for r in "${ROWS[@]}"; do
+    IFS=$'\t' read -r sess widx wname cwd ppid cpid sid method conf issue cand <<<"$r"
+    [ "$method" = shell ] && continue
+    [ -f "$cwd/.epic-status.json" ] || continue
+    tmux send-keys -t "$sess:$widx" "$msg" 2>/dev/null && tmux send-keys -t "$sess:$widx" Enter 2>/dev/null && sent=$((sent+1))
+  done
+  if [ "$sent" -gt 0 ]; then
+    echo "Checkpoint sent to $sent worker window(s); waiting ${CHECKPOINT_WAIT}s for flush..."
+    sleep "$CHECKPOINT_WAIT"
+  else
+    echo "No epic workers to checkpoint."
+  fi
+else
+  echo "(--no-checkpoint: workers not quiesced.)"
+fi
+
+# ---- Write the manifest ----
+mkdir -p "$RECOVER_DIR"
+parked_at=$("$DATE" -u +%Y-%m-%dT%H:%M:%SZ)
+host=$(hostname)
+
+printf '%s\n' "${ROWS[@]}" | jq -R -s --arg host "$host" --arg parked "$parked_at" '
+  split("\n") | map(select(length>0)) | map(split("\t")) |
+  map(. as $f | {
+    session: $f[0],
+    win: ({
+      index:      ($f[1]|tonumber),
+      name:       $f[2],
+      cwd:        $f[3],
+      session_id: (if $f[6]=="-" then null else $f[6] end),
+      method:     $f[7],
+      confidence: $f[8],
+      issue:      (if $f[9]=="-" then null else ($f[9]|tonumber) end)
+    } | if (($f[10]? // "")|length) > 0 then .candidates = ($f[10]|split("|")) else . end)
+  }) |
+  reduce .[] as $r ([];
+    if any(.[]; .name == $r.session)
+    then map(if .name == $r.session then .windows += [$r.win] else . end)
+    else . + [{name: $r.session, windows: [$r.win]}] end) |
+  {host: $host, parked_at: $parked, sessions: .}' > "$MANIFEST"
+
+echo "Wrote $MANIFEST ($(jq '.sessions|length' "$MANIFEST") sessions, $nwin windows)."
+
+if [ "$SHUTDOWN" = 1 ]; then
+  echo "Manifest on disk — killing the tmux server now."
+  tmux kill-server
+fi

--- a/skills/bip-epic-recover/SKILL.md
+++ b/skills/bip-epic-recover/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bip-epic-recover
-description: Recover bip-epic Claude sessions after a host reboot — find the killed sessions, label them, and resume each into a tmux window. Use when a box running a bip-epic fleet rebooted and the tmux sessions are gone.
+description: Recover bip-epic Claude sessions after a host reboot — replay a planned-reboot manifest if one exists, else find the killed sessions by scanning jsonl, label them, and resume each into a tmux window. Use when a box running a bip-epic fleet rebooted and the tmux sessions are gone.
 allowed-tools: Bash, Read
 ---
 
@@ -30,7 +30,36 @@ It needs GNU `date` (or `gdate`), `stat`, bash ≥ 4, and `jq`: it runs on Linux
 
 Start tmux the usual way first (e.g. `eval $(keychain --eval id_rsa) && tmux`) so the server holds your ssh-agent; windows the helper creates inherit that env.
 
-## Workflow
+## Two recovery paths
+
+If the reboot was **planned** and `/bip-epic-prepare-reboot` parked the host first, a host-wide manifest at `~/.epic-recover/manifest.json` records every session/window with its exact `session_id`. Replaying it is deterministic and lossless — prefer it. Otherwise fall back to the jsonl **scan** below, which infers the live-at-reboot set from file mtimes.
+
+### Step 0: Check for a planned-reboot manifest
+
+```bash
+"$HELPER" --manifest-status
+```
+
+- **Exit 0 (`VALID …`)** — a manifest exists, was parked *before* the current boot, and is not yet consumed. Use the **manifest path** (Step M) and skip the scan entirely.
+- **Exit 1 (`none` / `stale` / `invalid`)** — no usable manifest (none written, parked *after* this boot, already consumed, or unparseable). Fall through to the **scan path** (Step 1). This is project-specific, so `cd` to the project's main clone first.
+
+### Step M: Replay the manifest
+
+```bash
+"$HELPER" --manifest-list      # TSV: session, index, window, cwd, session_id, method, confidence, issue, candidates
+```
+
+Present the plan grouped by session (real names, windows in order). Most windows resume straight to their recorded id. For any window with `confidence=ambiguous`, show its `candidates` and **ask the user which id to resume** (or to leave it a plain shell) — do not guess. Then replay:
+
+```bash
+"$HELPER" --manifest-resume \
+  ["<session>:<index>=<chosen-id>" ...] \    # one per ambiguous window the user resolved
+  ["<session>:<index>=skip" ...]             # leave that window a plain shell
+```
+
+This rebuilds **every** session by its real name with windows in order — Claude windows `--resume`'d to their ids, shell windows as bare shells — and reports "(from manifest)". Ambiguous windows not given an explicit pick are left as plain shells. On success it stamps the manifest consumed (renames it `manifest.<boot>.done`) so a later *unplanned* reboot does not replay a stale park. Then nudge resumed workers per **Step 5**.
+
+## Scan path (no usable manifest)
 
 ### Step 1: Enumerate the killed sessions
 
@@ -81,6 +110,17 @@ Auto-`send-keys` timing against claude's resume-load is unreliable, so prompt th
 
 ## Notes
 
-- `--list` mutates nothing; only `--resume` (and the helper's bare interactive mode) create tmux windows. Re-running is safe.
+- `--list`, `--manifest-status`, and `--manifest-list` mutate nothing; only `--resume`, `--manifest-resume`, and the bare interactive mode create tmux windows. Re-running the read-only modes is safe.
+- The manifest modes are **host-wide and project-agnostic** — they do not need `.epic-config.json` and rebuild every session in the manifest, not just one project's clones. The scan modes (`--list`, `--resume`, interactive) still require `.epic-config.json` in the cwd.
+- For a planned reboot, write that manifest first with `/bip-epic-prepare-reboot` — it captures exact session ids from live processes, which is lossless where the mtime scan only infers.
 - Driving a remote rebooted box from elsewhere: prefix the helper calls with `ssh <host> 'cd <main-clone> && bash <skill-dir>/epic-recover …'`, but resuming into tmux is cleanest run from a shell already inside that host's tmux.
 - For a no-Claude recovery, run the helper directly with no args (`bash <skill-dir>/epic-recover`) for an interactive numbered picker over the same data — less smart labeling, same engine. Symlink it onto your `PATH` if you want it as a bare command.
+
+## Manual verification
+
+The manifest data paths are pure JSON logic and worth exercising after a change; the live-tmux/process parts of the partner skill are verified the same way (see `bip-epic-prepare-reboot`). Both helpers ship without a unit-test suite, matching this repo's shell-helper convention.
+
+1. **Staleness** — a manifest whose `parked_at` is *after* the current boot → `--manifest-status` reports `stale` and exits 1 (recover falls back to the scan).
+2. **Consumed** — after `--manifest-resume`, the manifest is renamed `manifest.<boot>.done`; a fresh `--manifest-status` reports `none`.
+3. **Fallback** — with no manifest, `--manifest-status` exits 1 and the scan path behaves exactly as before.
+4. **Ambiguity** — an `ambiguous` window is left a plain shell unless an explicit `<session>:<index>=<id>` pick resumes it.

--- a/skills/bip-epic-recover/epic-recover
+++ b/skills/bip-epic-recover/epic-recover
@@ -1,24 +1,36 @@
 #!/usr/bin/env bash
 # epic-recover — recover bip-epic Claude sessions after a reboot.
-# Run from a project's MAIN clone (the dir holding .epic-config.json).
 #
-#   epic-recover            interactive: list sessions, pick numbers, spawn windows
-#   epic-recover --list     emit TSV of candidate sessions (for the bip-epic-recover skill)
-#   epic-recover --resume <id> [<id>...]   spawn a window per session-id into current tmux
+# Two recovery sources:
 #
-# Enumerates ALL Claude sessions (cwd = main clone OR any worker clone) whose jsonl
-# was active within SINCE_HOURS before the last reboot — no git-branch filter, because
-# a clone often returns to main while its conversation continues. When run inside tmux
-# ($TMUX set) it ADDS windows to the current session, preserving the keychain/ssh-agent
-# env of the running tmux server; otherwise it builds a detached session named for the project.
+#   MANIFEST (planned reboot) — if bip-epic-prepare-reboot parked the host, a
+#   host-wide manifest records every session/window with its exact session id.
+#   Recover replays it deterministically by real name, in order. Project-agnostic.
+#     epic-recover --manifest-status                 is there a valid manifest to replay?
+#     epic-recover --manifest-list                   TSV of the manifest's windows
+#     epic-recover --manifest-resume [PICK ...]      rebuild every session from the manifest
+#       PICK = "<session>:<index>=<id>"   resume an ambiguous window with this id
+#            | "<session>:<index>=skip"   leave it a plain shell
+#
+#   SCAN (unplanned reboot) — no/stale manifest: enumerate Claude sessions whose
+#   cwd is a project clone and whose jsonl was active before boot. Run from the
+#   project's MAIN clone (the dir holding .epic-config.json).
+#     epic-recover            interactive: list sessions, pick numbers, spawn windows
+#     epic-recover --list     emit TSV of candidate sessions (for the skill)
+#     epic-recover --resume <id> [<id>...]   spawn a window per session-id into current tmux
+#
+# When run inside tmux ($TMUX set) the SCAN modes ADD windows to the current
+# session (preserving its keychain/ssh-agent env); otherwise they build a detached
+# session named for the project. MANIFEST mode always builds named sessions.
 set -euo pipefail
 
 SINCE_HOURS=${EPIC_RECOVER_SINCE_HOURS:-36}
 CLAUDE="claude --dangerously-skip-permissions"
 PROJ=$HOME/.claude/projects
 CFG=.epic-config.json
+RECOVER_DIR=${EPIC_RECOVER_DIR:-$HOME/.epic-recover}
+MANIFEST="$RECOVER_DIR/manifest.json"
 
-[ -f "$CFG" ] || { echo "No $CFG here — run from an EPIC project's main clone." >&2; exit 1; }
 command -v jq >/dev/null || { echo "epic-recover: jq is required." >&2; exit 1; }
 
 # Pick a GNU `date` (needs `-d @epoch`). macOS /bin/date is BSD; Homebrew coreutils ships `gdate`.
@@ -37,15 +49,7 @@ command -v mapfile >/dev/null 2>&1 || {
 
 # Portable file-mtime epoch: GNU stat, then BSD/macOS stat.
 mtime() { stat -c %Y "$1" 2>/dev/null || stat -f %m "$1" 2>/dev/null; }
-
-main_dir=$PWD
-proj=$(basename "$PWD")
-clone_root=$(jq -r '.clone_root' "$CFG"); clone_root=${clone_root/#\~/$HOME}
-mapfile -t clone_names < <(jq -r '.clone_names[]?' "$CFG")
-
-# directories to scan: main clone + each worker clone
-dirs=("$main_dir")
-for n in "${clone_names[@]}"; do [ -d "$clone_root/$n" ] && dirs+=("$clone_root/$n"); done
+enc() { printf '%s' "$1" | sed 's#/#-#g'; }
 
 # cutoff = boot - SINCE_HOURS. boot via `uptime -s` (Linux) or kern.boottime (macOS); else now.
 boot_epoch() {
@@ -56,10 +60,125 @@ boot_epoch() {
   fi
   date +%s
 }
-boot=$(boot_epoch); [ -n "$boot" ] || boot=$(date +%s)
-cutoff=$(( boot - SINCE_HOURS*3600 ))
 
-enc() { printf '%s' "$1" | sed 's#/#-#g'; }
+# ---------------------------------------------------------------------------
+# MANIFEST mode (planned-reboot replay) — project-agnostic, host-wide.
+# ---------------------------------------------------------------------------
+
+# Is there a manifest worth replaying? Echoes a verdict; exit 0 if VALID else 1.
+# Valid = parseable, parked_at strictly before the current boot, and not yet
+# consumed (a consumed manifest was renamed to manifest.<boot>.done).
+manifest_status() {
+  [ -f "$MANIFEST" ] || { echo "none: no manifest at $MANIFEST"; return 1; }
+  local parked boot parked_e
+  parked=$(jq -r '.parked_at // empty' "$MANIFEST" 2>/dev/null) || { echo "invalid: $MANIFEST is not valid JSON"; return 1; }
+  [ -n "$parked" ] || { echo "invalid: $MANIFEST has no parked_at"; return 1; }
+  parked_e=$("$DATE" -d "$parked" +%s 2>/dev/null) || { echo "invalid: unparseable parked_at '$parked'"; return 1; }
+  boot=$(boot_epoch)
+  if [ -n "$boot" ] && [ "$parked_e" -ge "$boot" ]; then
+    echo "stale: parked_at ($parked) is not before this boot ($("$DATE" -d @"$boot" '+%Y-%m-%dT%H:%M:%SZ')) — ignoring; use the scan instead"
+    return 1
+  fi
+  local ns nw na
+  ns=$(jq '.sessions|length' "$MANIFEST" 2>/dev/null)
+  nw=$(jq '[.sessions[].windows[]]|length' "$MANIFEST" 2>/dev/null)
+  na=$(jq '[.sessions[].windows[]|select(.confidence=="ambiguous")]|length' "$MANIFEST" 2>/dev/null)
+  printf 'VALID\t%s\t%s\t%s sessions\t%s windows\t%s ambiguous\n' "$MANIFEST" "$parked" "$ns" "$nw" "$na"
+  return 0
+}
+
+# TSV of every window in the manifest, for the skill to present.
+manifest_list() {
+  manifest_status >/dev/null || { manifest_status >&2; exit 1; }
+  printf 'session\tindex\twindow\tcwd\tsession_id\tmethod\tconfidence\tissue\tcandidates\n'
+  jq -r '.sessions[] as $s | $s.windows[] |
+    [$s.name, (.index|tostring), .name, .cwd, (.session_id // "-"),
+     .method, .confidence, (.issue|tostring),
+     ((.candidates // [])|join("|"))] | @tsv' "$MANIFEST"
+}
+
+# Rebuild every session from the manifest. PICK args override ambiguous windows.
+manifest_resume() {
+  manifest_status >/dev/null || { manifest_status >&2; exit 1; }
+
+  declare -A PICK   # "session:index" -> id | "skip"
+  shift  # drop --manifest-resume
+  for p in "$@"; do
+    case "$p" in *=*) PICK["${p%%=*}"]="${p#*=}" ;; *) echo "epic-recover: bad pick '$p' (want session:index=id|skip)" >&2; exit 1 ;; esac
+  done
+
+  local nsess; nsess=$(jq '.sessions|length' "$MANIFEST")
+  echo "Replaying $MANIFEST ($(jq -r .host "$MANIFEST"), parked $(jq -r .parked_at "$MANIFEST")):"
+
+  local s w
+  for s in $(seq 0 $((nsess-1))); do
+    local sname nwin
+    sname=$(jq -r ".sessions[$s].name" "$MANIFEST")
+    nwin=$(jq ".sessions[$s].windows|length" "$MANIFEST")
+    local fresh_session=0
+    tmux has-session -t "$sname" 2>/dev/null || fresh_session=1
+    echo "  session '$sname' ($nwin windows):"
+    for w in $(seq 0 $((nwin-1))); do
+      local wname cwd sid conf idx key eff cmd
+      wname=$(jq -r ".sessions[$s].windows[$w].name" "$MANIFEST")
+      cwd=$(jq -r ".sessions[$s].windows[$w].cwd" "$MANIFEST")
+      sid=$(jq -r ".sessions[$s].windows[$w].session_id // \"-\"" "$MANIFEST")
+      conf=$(jq -r ".sessions[$s].windows[$w].confidence" "$MANIFEST")
+      idx=$(jq -r ".sessions[$s].windows[$w].index" "$MANIFEST")
+      key="$sname:$idx"
+
+      # Resolve which id (if any) to resume this window with.
+      eff="$sid"
+      if [ -n "${PICK[$key]:-}" ]; then
+        eff="${PICK[$key]}"
+      elif [ "$conf" = ambiguous ]; then
+        eff="skip"   # ambiguous and not explicitly picked → leave a plain shell
+      fi
+
+      if [ "$eff" = "-" ] || [ "$eff" = skip ] || [ "$eff" = null ]; then
+        cmd=""   # plain shell window
+      else
+        cmd="$CLAUDE --resume $eff"
+      fi
+
+      if [ "$fresh_session" = 1 ] && [ "$w" = 0 ]; then
+        tmux new-session -d -s "$sname" -n "$wname" -c "$cwd"
+      else
+        tmux new-window -t "$sname" -n "$wname" -c "$cwd"
+      fi
+      if [ -n "$cmd" ]; then
+        tmux send-keys -t "$sname:$wname" "$cmd" Enter
+        echo "    + [$idx] $wname  →  resume ${eff:0:8}"
+      else
+        local note="shell"; [ "$conf" = ambiguous ] && note="shell (ambiguous — pick to resume)"
+        echo "    + [$idx] $wname  →  $note  $cwd"
+      fi
+    done
+  done
+
+  # Stamp consumed so a later unplanned reboot doesn't replay this stale park.
+  local boot; boot=$(boot_epoch)
+  mv "$MANIFEST" "$RECOVER_DIR/manifest.${boot}.done"
+  echo
+  echo "Rebuilt $nsess session(s) from manifest (from manifest). Marked consumed: manifest.${boot}.done"
+  echo "Attach: tmux attach -t $(jq -r '.sessions[0].name' "$RECOVER_DIR/manifest.${boot}.done")"
+}
+
+# ---------------------------------------------------------------------------
+# SCAN mode (unplanned reboot) — needs .epic-config.json in the cwd.
+# ---------------------------------------------------------------------------
+
+need_cfg_and_setup() {
+  [ -f "$CFG" ] || { echo "No $CFG here — run from an EPIC project's main clone (or use --manifest-* for a planned-reboot manifest)." >&2; exit 1; }
+  main_dir=$PWD
+  proj=$(basename "$PWD")
+  clone_root=$(jq -r '.clone_root' "$CFG"); clone_root=${clone_root/#\~/$HOME}
+  mapfile -t clone_names < <(jq -r '.clone_names[]?' "$CFG")
+  dirs=("$main_dir")
+  for n in "${clone_names[@]}"; do [ -d "$clone_root/$n" ] && dirs+=("$clone_root/$n"); done
+  boot=$(boot_epoch); [ -n "$boot" ] || boot=$(date +%s)
+  cutoff=$(( boot - SINCE_HOURS*3600 ))
+}
 
 first_prompt() { # $1=jsonl -> short human hint (tags stripped, command names kept)
   jq -rs '[.[]|select(.type=="user")| .message.content
@@ -113,18 +232,24 @@ spawn_one() { # $1=session-id  $2=optional window-name
 }
 
 case "${1:-}" in
+  --manifest-status) manifest_status ;;
+  --manifest-list)   manifest_list ;;
+  --manifest-resume) manifest_resume "$@" ;;
   --list)
+    need_cfg_and_setup
     collect
     printf 'last_active\tclone\tbranch\tissue\tphase\tsession\tfirst_prompt\n'
     printf '%s' "$rows" | sort -t$'\t' -k1,1nr | cut -f2-
     ;;
   --resume)
+    need_cfg_and_setup
     shift; [ $# -gt 0 ] || { echo "usage: epic-recover --resume <id>..." >&2; exit 1; }
     echo "Spawning ${#@} window(s) into ${TMUX:+current tmux}${TMUX:-session '$proj'}:"
     for id in "$@"; do spawn_one "$id"; done
     [ -z "${TMUX:-}" ] && echo "Attach: tmux attach -t $proj"
     ;;
   ""|--interactive)
+    need_cfg_and_setup
     collect
     [ ${#IDS[@]} -gt 0 ] || { echo "No sessions active in the ${SINCE_HOURS}h before boot ($("$DATE" -d @"$boot" '+%m-%d %H:%M'))."; exit 0; }
     # sorted display
@@ -146,5 +271,5 @@ case "${1:-}" in
     echo; for id in "${sel[@]}"; do spawn_one "$id"; done
     [ -z "${TMUX:-}" ] && echo "Attach: tmux attach -t $proj"
     ;;
-  *) echo "usage: epic-recover [--list | --resume <id>... | (no args = interactive)]" >&2; exit 1;;
+  *) echo "usage: epic-recover [--manifest-status|--manifest-list|--manifest-resume [PICK...] | --list | --resume <id>... | (no args = interactive)]" >&2; exit 1;;
 esac

--- a/skills/bip-epic/SKILL.md
+++ b/skills/bip-epic/SKILL.md
@@ -26,11 +26,16 @@ updates, use `/bip-epic-poll`. To spawn work, use `/bip-epic-spawn`.
 The conductor session stays on `main` and does NOT do feature work.
 It orchestrates: scans, updates EPICs, spawns clones.
 
-### Recovery after a reboot
-If the host reboots and the tmux fleet is lost, use `/bip-epic-recover` from a
-project's main clone to find the killed Claude sessions and resume each into a
-tmux window (`claude --resume`). It reads each session's own jsonl, so workers
-that returned to `main` and concurrent main-clone sessions are all recoverable.
+### Reboots: parking and recovery
+For a **planned** reboot, run `/bip-epic-prepare-reboot` first (host-wide, while
+tmux is alive): it resolves each Claude window's exact session id, optionally
+checkpoints workers, and writes a manifest so the workspace returns
+deterministically. For an **unplanned** reboot (or if no manifest was written),
+use `/bip-epic-recover` from a project's main clone to find the killed Claude
+sessions and resume each into a tmux window (`claude --resume`). Recover replays
+the manifest when one exists and otherwise reads each session's own jsonl, so
+workers that returned to `main` and concurrent main-clone sessions are all
+recoverable.
 
 **Numbered issues → spawn**: If work is tied to a GitHub issue (`iN`),
 always use `/bip-epic-spawn` to assign it to a clone — even if the fix


### PR DESCRIPTION
🤖 Closes #159.

## Summary

Adds `/bip-epic-prepare-reboot` and teaches `/bip-epic-recover` to replay its manifest, so a **planned** reboot restarts losslessly instead of relying on the mtime-scan inference recover uses after an *unplanned* one.

- **New skill `bip-epic-prepare-reboot`** (`SKILL.md` + bundled `epic-prepare-reboot` helper). Run once, host-wide, while tmux is alive. It walks every pane (`tmux list-panes -a`), finds each window's Claude descendant in the process tree, and resolves its `session_id` in priority order:
  1. `cmdline` (high) — `--resume <id>` in the Claude process args (exact; resumed sessions, any cwd).
  2. `starttime` (medium) — fresh sessions carry no id, so it correlates the Claude process start time with the cwd's jsonl that *began* closest.
  3. `newest` (low) — last resort.
  Two jsonls fitting a fresh process nearly equally → flagged `ambiguous` with both candidates recorded. Non-Claude windows are recorded as plain shells with their cwd.
- Optionally checkpoints epic **workers** (Claude windows whose cwd has `.epic-status.json`) — sends a flush instruction and waits briefly. `--no-checkpoint` skips; `--shutdown` runs `tmux kill-server` only after the manifest is on disk.
- Writes `~/.epic-recover/manifest.json` preserving real session names, window names, order, cwds, with `session_id`/`method`/`confidence` per Claude window. Project-agnostic — needs no `.epic-config.json`.
- **`bip-epic-recover` manifest mode**: new `--manifest-status` / `--manifest-list` / `--manifest-resume [<session>:<index>=<id>|skip ...]`. A manifest parked before the current boot and not yet consumed is replayed (rebuild every session by real name, windows in order, Claude windows resumed to their ids, "(from manifest)"); ambiguous windows are surfaced for the user to pick. On success the manifest is renamed `manifest.<boot>.done` so a later unplanned reboot doesn't replay a stale park. Stale/consumed/absent → falls back to the existing jsonl scan unchanged. The scan modes still require `.epic-config.json`; the `.epic-config.json` check was moved out of the global preamble into the scan-only paths.
- Cross-linked both from `bip-epic`. Not added to the automated-workflow diagram — recovery utilities (`recover`, `tuckin`, `check`) are intentionally absent from it.

## Verification

No automated suite — these helpers introspect live tmux and the process tree, so they are verified by exercising them (the repo's shell-helper convention; `epic-recover` ships testless too). Exercised on macOS against throwaway tmux servers with a fake `claude` process:

- **Resolution**: a window started with `--resume <uuid>` resolved via `cmdline` (high); a plain shell window classified as `shell`/`none`. Manifest matched the issue schema exactly.
- **Roundtrip**: park → `kill-server` → `--manifest-resume` rebuilt the session by real name, window 0 resumed to the exact id, window 1 as a plain shell, in order; consumed marker stamped; the `claude --resume <id>` command landed in the pane.
- **Staleness**: `parked_at` after boot → `--manifest-status` reports `stale`, exit 1.
- **Consumed/absent**: after resume the manifest is renamed `.done` and `--manifest-status` reports `none`; no manifest → exit 1, scan path unchanged.
- **Ambiguity + picks**: an `ambiguous` window is left a plain shell unless a `<session>:<index>=<id>` pick resumes it (verified both).
- `go build` / `go vet` / `gofmt -l` clean (shell + markdown only).

## DEFERRED

- In a *true* start-time tie (two fresh windows in one cwd whose Claude processes started within `EPIC_PREPARE_AMBIG_GAP` seconds), only the first-processed window is flagged `ambiguous`; the second resolves to the remaining jsonl as `medium` and could in principle be swapped. Harmless in practice (both are fresh sessions in the same cwd, both recoverable) and the dry-run table surfaces the ambiguous row for review, but flagging *both* sides of a tie would need cross-window coordination in pass 2. Rationale: the issue's ambiguity contract is "flag and ask"; this satisfies it for the common case without the extra complexity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)