### PR TITLE
Add `bip slack resolve` filter for channel-mention markup

### DIFF
--- a/cmd/bip/slack.go
+++ b/cmd/bip/slack.go
@@ -22,6 +22,10 @@ Requires a Slack bot token with channels:history, channels:read, and
 users:read scopes. Sourced from BIP_SLACK_TOKEN (recommended) or
 SLACK_BOT_TOKEN, falling back to slack_bot_token in ~/.config/bip/config.yml.
 
+The 'resolve' subcommand is a token-free stdin/stdout filter that rewrites
+channel-mention markup (<#CXXXX>) to #channel-name using sources.yml; pipe
+any Slack-derived text through it for human-readable channel references.
+
 All commands output JSON by default for agent consumption.
 Use --human flag for human-readable output.`,
 }

--- a/cmd/bip/slack_resolve.go
+++ b/cmd/bip/slack_resolve.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/matsen/bipartite/internal/config"
+	"github.com/matsen/bipartite/internal/flow"
+	"github.com/spf13/cobra"
+)
+
+var slackResolveCmd = &cobra.Command{
+	Use:   "resolve",
+	Short: "Substitute Slack channel-mention markup with channel names",
+	Long: `Read text on stdin, write text on stdout, replacing Slack channel-mention
+markup (<#CXXXXXXXX> and <#CXXXXXXXX|alias>) with #channel-name.
+
+Names come from sources.yml: the slack.channels block (reversed id->name) and
+the slack.project_channels block (id->name). When an ID appears in both,
+project_channels wins. Unknown IDs with no usable alias pass through unchanged.
+
+This is a dumb text filter that never touches the Slack API. It makes no
+assumptions about Markdown structure, so mentions inside code fences are
+resolved too.
+
+Examples:
+  echo '• <#C03T8U5RATY>: notes' | bip slack resolve
+  bip slack history fortnight-feats --since 2026-05-13 | bip slack resolve`,
+	Args: cobra.NoArgs,
+	RunE: runSlackResolve,
+}
+
+func init() {
+	slackCmd.AddCommand(slackResolveCmd)
+}
+
+func runSlackResolve(cmd *cobra.Command, args []string) error {
+	nexusPath := config.MustGetNexusPath()
+	idToName, err := flow.LoadChannelIDMap(nexusPath)
+	if err != nil {
+		return outputSlackError(1, "config_error", err.Error())
+	}
+
+	// Read all of stdin. Mention markup never spans lines and fortnight-scale
+	// input is well under a MB, so io.ReadAll is correct here; bufio.Scanner's
+	// default 64 KB token limit would silently truncate larger input.
+	input, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		return outputSlackError(1, "io_error", err.Error())
+	}
+
+	resolved := flow.ResolveChannelMentions(string(input), idToName)
+	if _, err := fmt.Fprint(os.Stdout, resolved); err != nil {
+		return outputSlackError(1, "io_error", err.Error())
+	}
+	return nil
+}

--- a/internal/flow/slack.go
+++ b/internal/flow/slack.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -504,4 +505,66 @@ func (c *SlackClient) ResolveUserName(userID string) string {
 		return name
 	}
 	return userID
+}
+
+// channelMentionRe matches Slack channel-mention markup. Slack channel IDs are
+// uppercase (`C` followed by uppercase letters and digits), so the pattern is
+// anchored to uppercase to leave malformed lowercase markup untouched. The
+// optional `|alias` group captures the human-readable alias Slack sometimes
+// embeds (it may be the empty string, e.g. `<#C…|>`).
+var channelMentionRe = regexp.MustCompile(`<#(C[A-Z0-9]+)(?:\|([^>]*))?>`)
+
+// LoadChannelIDMap loads a merged channel ID -> name map from sources.yml in the
+// given nexus directory. It reads two maps:
+//
+//   - slack.channels (name -> {id, purpose}), reversed to id -> name.
+//   - slack.project_channels (id -> name), used directly.
+//
+// When an ID appears in both, the project_channels value wins. Unlike
+// LoadSlackChannels, this does not require a slack.channels block: a sources.yml
+// with only project_channels still resolves. It returns an error only when both
+// maps are empty.
+func LoadChannelIDMap(nexusPath string) (map[string]string, error) {
+	sources, err := LoadSources(nexusPath)
+	if err != nil {
+		return nil, err
+	}
+
+	idToName := make(map[string]string)
+	for name, ch := range sources.Slack.Channels {
+		if ch.ID != "" {
+			idToName[ch.ID] = name
+		}
+	}
+	// project_channels takes precedence over reversed channels.
+	for id, name := range sources.Slack.ProjectChannels {
+		idToName[id] = name
+	}
+
+	if len(idToName) == 0 {
+		return nil, fmt.Errorf("no 'slack.channels' or 'slack.project_channels' entries in sources.yml")
+	}
+
+	return idToName, nil
+}
+
+// ResolveChannelMentions substitutes Slack channel-mention markup in text with
+// `#channel-name`, using idToName as the only data source. Resolution priority
+// for each mention is: mapped name, then a non-empty alias from the markup, then
+// the original markup left unchanged (so an unknown ID with no usable alias
+// passes through rather than emitting a bare `#`). The function is pure and
+// makes no assumptions about Markdown structure: markup inside code fences is
+// resolved like any other.
+func ResolveChannelMentions(text string, idToName map[string]string) string {
+	return channelMentionRe.ReplaceAllStringFunc(text, func(match string) string {
+		m := channelMentionRe.FindStringSubmatch(match)
+		id, alias := m[1], m[2]
+		if name, ok := idToName[id]; ok {
+			return "#" + name
+		}
+		if alias != "" {
+			return "#" + alias
+		}
+		return match
+	})
 }

--- a/internal/flow/slack_test.go
+++ b/internal/flow/slack_test.go
@@ -299,6 +299,136 @@ func TestGetSlackChannel_NotFound(t *testing.T) {
 	}
 }
 
+func TestResolveChannelMentions(t *testing.T) {
+	idToName := map[string]string{
+		"C08JB3LRDU2": "flu-mut-rates",
+		"C03T8U5RATY": "multidms",
+		"C044B4JUE5U": "antigen",
+	}
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"known ID", "<#C08JB3LRDU2>", "#flu-mut-rates"},
+		{"alias form prefers map", "<#C08JB3LRDU2|whatever>", "#flu-mut-rates"},
+		{"alias-only fallback", "<#CZZZZ99|fallback-name>", "#fallback-name"},
+		{"empty alias on known ID", "<#C044B4JUE5U|>", "#antigen"},
+		{"empty alias on unknown ID passes through", "<#CZZZZ99|>", "<#CZZZZ99|>"},
+		{"adjacent markup", "<#C08JB3LRDU2><#C03T8U5RATY>", "#flu-mut-rates#multidms"},
+		{"end of input no newline", "prefix <#C03T8U5RATY>", "prefix #multidms"},
+		{"inside backticks", "`<#C03T8U5RATY>`", "`#multidms`"},
+		{"lowercase ID passes through", "<#c03t8u5raty>", "<#c03t8u5raty>"},
+		{"trailing punctuation", "see <#C03T8U5RATY>.", "see #multidms."},
+		{"multiple IDs one line", "<#C08JB3LRDU2> and <#C03T8U5RATY>", "#flu-mut-rates and #multidms"},
+		{"empty input", "", ""},
+		{"no mentions", "plain text with #hashtag", "plain text with #hashtag"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ResolveChannelMentions(tc.in, idToName); got != tc.want {
+				t.Errorf("ResolveChannelMentions(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLoadChannelIDMap_Merged(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	sourcesContent := `slack:
+  channels:
+    fortnight-goals:
+      id: C123
+      purpose: goals
+  project_channels:
+    C08JB3LRDU2: flu-mut-rates
+    C03T8U5RATY: multidms
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, "sources.yml"), []byte(sourcesContent), 0644); err != nil {
+		t.Fatalf("failed to write sources.yml: %v", err)
+	}
+
+	idToName, err := LoadChannelIDMap(tmpDir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := map[string]string{
+		"C123":        "fortnight-goals", // reversed from channels
+		"C08JB3LRDU2": "flu-mut-rates",
+		"C03T8U5RATY": "multidms",
+	}
+	for id, name := range want {
+		if idToName[id] != name {
+			t.Errorf("id %s: got %q, want %q", id, idToName[id], name)
+		}
+	}
+	if len(idToName) != len(want) {
+		t.Errorf("expected %d entries, got %d: %v", len(want), len(idToName), idToName)
+	}
+}
+
+func TestLoadChannelIDMap_ProjectChannelsOverride(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Same ID in both maps: project_channels must win.
+	sourcesContent := `slack:
+  channels:
+    old-name:
+      id: C03T8U5RATY
+      purpose: goals
+  project_channels:
+    C03T8U5RATY: multidms
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, "sources.yml"), []byte(sourcesContent), 0644); err != nil {
+		t.Fatalf("failed to write sources.yml: %v", err)
+	}
+
+	idToName, err := LoadChannelIDMap(tmpDir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if idToName["C03T8U5RATY"] != "multidms" {
+		t.Errorf("expected project_channels to win (multidms), got %q", idToName["C03T8U5RATY"])
+	}
+}
+
+func TestLoadChannelIDMap_ProjectChannelsOnly(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// No slack.channels block at all — project_channels alone must resolve.
+	sourcesContent := `slack:
+  project_channels:
+    C03T8U5RATY: multidms
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, "sources.yml"), []byte(sourcesContent), 0644); err != nil {
+		t.Fatalf("failed to write sources.yml: %v", err)
+	}
+
+	idToName, err := LoadChannelIDMap(tmpDir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if idToName["C03T8U5RATY"] != "multidms" {
+		t.Errorf("expected multidms, got %q", idToName["C03T8U5RATY"])
+	}
+}
+
+func TestLoadChannelIDMap_Empty(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(tmpDir, "sources.yml"), []byte(`boards: {}`), 0644); err != nil {
+		t.Fatalf("failed to write sources.yml: %v", err)
+	}
+
+	if _, err := LoadChannelIDMap(tmpDir); err == nil {
+		t.Error("expected error when both channel maps are empty")
+	}
+}
+
 func TestMessage_JSONFields(t *testing.T) {
 	msg := Message{
 		Timestamp: "1737990123.000100",

--- a/internal/flow/types.go
+++ b/internal/flow/types.go
@@ -17,6 +17,9 @@ type Sources struct {
 // SlackConfig represents the slack section of sources.yml.
 type SlackConfig struct {
 	Channels map[string]SlackChannelConfig `yaml:"channels"`
+	// ProjectChannels maps channel ID -> name directly, for channels that are
+	// referenced by mention markup but not configured for history fetching.
+	ProjectChannels map[string]string `yaml:"project_channels"`
 }
 
 // SlackChannelConfig is a configured Slack channel from sources.yml.

--- a/tests/integration/slack_test.go
+++ b/tests/integration/slack_test.go
@@ -456,3 +456,118 @@ func setupTempDirWithSlackConfig(t *testing.T) *testEnvSetup {
 		TmpConfigDir: tmpConfigDir,
 	}
 }
+
+// setupResolveEnv creates a hermetic XDG_CONFIG_HOME + nexus with a controlled
+// sources.yml for testing `bip slack resolve`. Unlike setupTempDirWithSlackConfig,
+// it does not read the real nexus or require a Slack token, so these tests always
+// run. It returns the XDG config dir to pass via XDG_CONFIG_HOME.
+func setupResolveEnv(t *testing.T) string {
+	t.Helper()
+
+	nexusDir := t.TempDir()
+	// .bipartite marks the directory as a bipartite nexus.
+	if err := os.MkdirAll(filepath.Join(nexusDir, ".bipartite"), 0755); err != nil {
+		t.Fatalf("failed to create .bipartite dir: %v", err)
+	}
+
+	// Both maps present, with C03T8U5RATY appearing only in project_channels and
+	// C044B4JUE5U reachable via the reversed channels map. C123 is shared between
+	// the two maps to exercise the override rule.
+	sourcesContent := `slack:
+  channels:
+    antigen:
+      id: C044B4JUE5U
+      purpose: collab
+    old-name:
+      id: C123
+      purpose: legacy
+  project_channels:
+    C08JB3LRDU2: flu-mut-rates
+    C03T8U5RATY: multidms
+    C123: new-name
+`
+	if err := os.WriteFile(filepath.Join(nexusDir, "sources.yml"), []byte(sourcesContent), 0644); err != nil {
+		t.Fatalf("failed to write sources.yml: %v", err)
+	}
+
+	configHome := t.TempDir()
+	configDir := filepath.Join(configHome, "bip")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatalf("failed to create bip config dir: %v", err)
+	}
+	cfgYAML := fmt.Sprintf("nexus_path: %s\n", nexusDir)
+	if err := os.WriteFile(filepath.Join(configDir, "config.yml"), []byte(cfgYAML), 0644); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	return configHome
+}
+
+// runResolve runs `bip slack resolve` with the given stdin and hermetic config,
+// returning stdout. It fails the test if the command errors.
+func runResolve(t *testing.T, bp, configHome, stdin string) string {
+	t.Helper()
+	cmd := exec.Command(bp, "slack", "resolve")
+	cmd.Env = append(filterEnv(os.Environ(), "XDG_CONFIG_HOME"), "XDG_CONFIG_HOME="+configHome)
+	cmd.Stdin = strings.NewReader(stdin)
+	out, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			t.Fatalf("resolve failed (exit %d): %s", exitErr.ExitCode(), string(exitErr.Stderr))
+		}
+		t.Fatalf("resolve failed: %v", err)
+	}
+	return string(out)
+}
+
+// TestSlackResolve_EndToEnd drives the full stdin/stdout filter, no token required.
+func TestSlackResolve_EndToEnd(t *testing.T) {
+	bp := getBPBinary(t)
+	configHome := setupResolveEnv(t)
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"known project ID", "• <#C03T8U5RATY>: iterate on spike data", "• #multidms: iterate on spike data"},
+		{"reversed channels ID", "<#C044B4JUE5U>", "#antigen"},
+		{"empty alias on reversed ID", "<#C044B4JUE5U|>", "#antigen"},
+		{"override prefers project_channels", "<#C123>", "#new-name"},
+		{"unknown ID passes through", "<#CZZZZ99>", "<#CZZZZ99>"},
+		{"alias fallback for unknown", "<#CZZZZ99|fallback>", "#fallback"},
+		{"adjacent markup", "<#C08JB3LRDU2><#C03T8U5RATY>", "#flu-mut-rates#multidms"},
+		{"no trailing newline preserved", "prefix <#C03T8U5RATY>", "prefix #multidms"},
+		{"trailing punctuation", "see <#C03T8U5RATY>.", "see #multidms."},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := runResolve(t, bp, configHome, tc.in); got != tc.want {
+				t.Errorf("resolve(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSlackResolve_EmptyStdin verifies empty input yields empty output, exit 0.
+func TestSlackResolve_EmptyStdin(t *testing.T) {
+	bp := getBPBinary(t)
+	configHome := setupResolveEnv(t)
+
+	if got := runResolve(t, bp, configHome, ""); got != "" {
+		t.Errorf("expected empty output, got %q", got)
+	}
+}
+
+// TestSlackResolve_PreservesNonMentionText verifies the filter only touches mentions.
+func TestSlackResolve_PreservesNonMentionText(t *testing.T) {
+	bp := getBPBinary(t)
+	configHome := setupResolveEnv(t)
+
+	in := "line one\nline two with #literal-hashtag and a <#C03T8U5RATY> mention\nline three\n"
+	want := "line one\nline two with #literal-hashtag and a #multidms mention\nline three\n"
+	if got := runResolve(t, bp, configHome, in); got != want {
+		t.Errorf("resolve multi-line = %q, want %q", got, want)
+	}
+}

--- a/tests/integration/slack_test.go
+++ b/tests/integration/slack_test.go
@@ -274,8 +274,6 @@ func TestSlackIngestJSONFormat(t *testing.T) {
 
 	bp := getBPBinary(t)
 	setup := setupTempDirWithSlackConfig(t)
-	defer os.RemoveAll(setup.TmpDir)
-	defer os.RemoveAll(setup.TmpConfigDir)
 
 	// Run ingest with --create-store to create a new store
 	cmd := exec.Command(bp, "slack", "ingest", "fortnight-goals", "--store", "test_slack_msgs", "--create-store", "--limit", "5", "--days", "7")
@@ -333,8 +331,6 @@ func TestSlackIngestIdempotency(t *testing.T) {
 
 	bp := getBPBinary(t)
 	setup := setupTempDirWithSlackConfig(t)
-	defer os.RemoveAll(setup.TmpDir)
-	defer os.RemoveAll(setup.TmpConfigDir)
 
 	// First ingest - creates store and ingests messages
 	cmd := exec.Command(bp, "slack", "ingest", "fortnight-goals", "--store", "idem_test_store", "--create-store", "--limit", "3", "--days", "7")
@@ -394,86 +390,61 @@ type testEnvSetup struct {
 	TmpConfigDir string // Temp XDG_CONFIG_HOME directory
 }
 
-// setupTempDirWithSlackConfig creates a temp directory with sources.yml and a temp global config.
-// Returns paths for cleanup. The caller is responsible for cleanup with os.RemoveAll.
-func setupTempDirWithSlackConfig(t *testing.T) *testEnvSetup {
-	t.Helper()
-
-	// Create temp nexus directory
-	tmpDir, err := os.MkdirTemp("", "slack-test-nexus-*")
-	if err != nil {
-		t.Fatalf("failed to create temp dir: %v", err)
-	}
-
-	nexusDir := getNexusDir(t)
-	if !hasSlackConfig(nexusDir) {
-		os.RemoveAll(tmpDir)
-		t.Skip("No slack.channels configured in nexus sources.yml, skipping test")
-	}
-
-	// Create .bipartite directory structure (required for FindRepository)
-	bipartiteDir := filepath.Join(tmpDir, ".bipartite")
-	if err := os.MkdirAll(bipartiteDir, 0755); err != nil {
-		os.RemoveAll(tmpDir)
-		t.Fatalf("failed to create .bipartite dir: %v", err)
-	}
-
-	// Copy sources.yml
-	sourcesData, err := os.ReadFile(filepath.Join(nexusDir, "sources.yml"))
-	if err != nil {
-		os.RemoveAll(tmpDir)
-		t.Fatalf("failed to read sources.yml: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(tmpDir, "sources.yml"), sourcesData, 0644); err != nil {
-		os.RemoveAll(tmpDir)
-		t.Fatalf("failed to write sources.yml: %v", err)
-	}
-
-	// Create temp config directory with nexus_path and slack_bot_token
-	tmpConfigDir, err := os.MkdirTemp("", "slack-test-config-*")
-	if err != nil {
-		os.RemoveAll(tmpDir)
-		t.Fatalf("failed to create temp config dir: %v", err)
-	}
-	configDir := filepath.Join(tmpConfigDir, "bip")
-	if err := os.MkdirAll(configDir, 0755); err != nil {
-		os.RemoveAll(tmpDir)
-		os.RemoveAll(tmpConfigDir)
-		t.Fatalf("failed to create bip config dir: %v", err)
-	}
-
-	// Get slack_bot_token from current config
-	slackToken := config.GetSlackBotToken()
-	cfgYAML := fmt.Sprintf("nexus_path: %s\nslack_bot_token: %s\n", tmpDir, slackToken)
-	if err := os.WriteFile(filepath.Join(configDir, "config.yml"), []byte(cfgYAML), 0644); err != nil {
-		os.RemoveAll(tmpDir)
-		os.RemoveAll(tmpConfigDir)
-		t.Fatalf("failed to write config: %v", err)
-	}
-
-	return &testEnvSetup{
-		TmpDir:       tmpDir,
-		TmpConfigDir: tmpConfigDir,
-	}
-}
-
-// setupResolveEnv creates a hermetic XDG_CONFIG_HOME + nexus with a controlled
-// sources.yml for testing `bip slack resolve`. Unlike setupTempDirWithSlackConfig,
-// it does not read the real nexus or require a Slack token, so these tests always
-// run. It returns the XDG config dir to pass via XDG_CONFIG_HOME.
-func setupResolveEnv(t *testing.T) string {
+// writeTestNexus builds a hermetic test environment: a temp nexus directory
+// (marked with .bipartite) holding the given sources.yml content, plus a temp
+// XDG_CONFIG_HOME whose bip/config.yml points nexus_path at it. A non-empty
+// token is written as slack_bot_token. Both directories are registered for
+// automatic cleanup via t.TempDir, so callers need no manual os.RemoveAll.
+func writeTestNexus(t *testing.T, sourcesContent, token string) *testEnvSetup {
 	t.Helper()
 
 	nexusDir := t.TempDir()
-	// .bipartite marks the directory as a bipartite nexus.
+	// .bipartite marks the directory as a bipartite nexus (required for FindRepository).
 	if err := os.MkdirAll(filepath.Join(nexusDir, ".bipartite"), 0755); err != nil {
 		t.Fatalf("failed to create .bipartite dir: %v", err)
 	}
+	if err := os.WriteFile(filepath.Join(nexusDir, "sources.yml"), []byte(sourcesContent), 0644); err != nil {
+		t.Fatalf("failed to write sources.yml: %v", err)
+	}
 
-	// Both maps present, with C03T8U5RATY appearing only in project_channels and
-	// C044B4JUE5U reachable via the reversed channels map. C123 is shared between
-	// the two maps to exercise the override rule.
-	sourcesContent := `slack:
+	configHome := t.TempDir()
+	configDir := filepath.Join(configHome, "bip")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatalf("failed to create bip config dir: %v", err)
+	}
+	cfgYAML := fmt.Sprintf("nexus_path: %s\n", nexusDir)
+	if token != "" {
+		cfgYAML += fmt.Sprintf("slack_bot_token: %s\n", token)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "config.yml"), []byte(cfgYAML), 0644); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	return &testEnvSetup{TmpDir: nexusDir, TmpConfigDir: configHome}
+}
+
+// setupTempDirWithSlackConfig builds a test nexus from a copy of the real
+// sources.yml and the configured Slack token, for tests that exercise the live
+// Slack API. It skips when no Slack config is present.
+func setupTempDirWithSlackConfig(t *testing.T) *testEnvSetup {
+	t.Helper()
+
+	nexusDir := getNexusDir(t)
+	if !hasSlackConfig(nexusDir) {
+		t.Skip("No slack.channels configured in nexus sources.yml, skipping test")
+	}
+	sourcesData, err := os.ReadFile(filepath.Join(nexusDir, "sources.yml"))
+	if err != nil {
+		t.Fatalf("failed to read sources.yml: %v", err)
+	}
+	return writeTestNexus(t, string(sourcesData), config.GetSlackBotToken())
+}
+
+// hermeticSourcesYML is a controlled sources.yml for API-free tests. C03T8U5RATY
+// appears only in project_channels, C044B4JUE5U is reachable via the reversed
+// channels map, and C123 is shared between the two maps to exercise the override
+// rule (project_channels wins).
+const hermeticSourcesYML = `slack:
   channels:
     antigen:
       id: C044B4JUE5U
@@ -486,21 +457,13 @@ func setupResolveEnv(t *testing.T) string {
     C03T8U5RATY: multidms
     C123: new-name
 `
-	if err := os.WriteFile(filepath.Join(nexusDir, "sources.yml"), []byte(sourcesContent), 0644); err != nil {
-		t.Fatalf("failed to write sources.yml: %v", err)
-	}
 
-	configHome := t.TempDir()
-	configDir := filepath.Join(configHome, "bip")
-	if err := os.MkdirAll(configDir, 0755); err != nil {
-		t.Fatalf("failed to create bip config dir: %v", err)
-	}
-	cfgYAML := fmt.Sprintf("nexus_path: %s\n", nexusDir)
-	if err := os.WriteFile(filepath.Join(configDir, "config.yml"), []byte(cfgYAML), 0644); err != nil {
-		t.Fatalf("failed to write config: %v", err)
-	}
-
-	return configHome
+// setupResolveEnv creates a hermetic environment for `bip slack resolve` tests.
+// It needs no real nexus and no Slack token, so these tests always run. Returns
+// the XDG config dir to pass via XDG_CONFIG_HOME.
+func setupResolveEnv(t *testing.T) string {
+	t.Helper()
+	return writeTestNexus(t, hermeticSourcesYML, "").TmpConfigDir
 }
 
 // runResolve runs `bip slack resolve` with the given stdin and hermetic config,


### PR DESCRIPTION
🤖

## Summary

- New `bip slack resolve` subcommand: a token-free stdin/stdout filter that rewrites Slack channel-mention markup (`<#CXXXX>` and `<#CXXXX|alias>`) to `#channel-name`, using `sources.yml` as the only data source. Unknown IDs with no usable alias pass through unchanged.
- `internal/flow/types.go`: added `ProjectChannels map[string]string` (`project_channels`) to `SlackConfig`.
- `internal/flow/slack.go`: added `LoadChannelIDMap` (merges reversed `slack.channels` with `slack.project_channels`; the latter wins on ID collision; resolves even when only `project_channels` is present) and the pure helper `ResolveChannelMentions`. Resolution priority per mention: mapped name → non-empty alias from markup → original markup unchanged.
- `cmd/bip/slack_resolve.go`: new ~60-LOC Cobra command. Reads all of stdin with `io.ReadAll` (not `bufio.Scanner`, whose 64 KB token limit would truncate). `cmd/bip/slack.go`: registered the subcommand and extended the parent `--help` long description.

The regex `<#(C[A-Z0-9]+)(?:\|([^>]*))?>` anchors to uppercase IDs, so malformed lowercase markup passes through.

## Test plan

- `internal/flow/slack_test.go`: `TestResolveChannelMentions` (13 cases: known ID, alias-prefers-map, alias-only fallback, empty-alias on known/unknown ID, adjacent markup, backticks, lowercase passthrough, trailing punctuation, …) and `TestLoadChannelIDMap_*` (merge, override, project-channels-only, empty-error).
- `tests/integration/slack_test.go`: `TestSlackResolve_*` drive the real binary end-to-end through a hermetic temp nexus — no Slack token required, so these always run (no skip).
- `go fmt`, `go vet`, and the full `go test ./...` all pass.

Smoke check against the production nexus:

```
$ echo '• <#C03T8U5RATY>: iterate on spike data' | bip slack resolve
• #multidms: iterate on spike data
```

## Out of scope (per issue)

No skill catalog currently lists `bip slack` subcommands, so no skill-doc update is needed here. Teaching `/manager.fortnight`, `/bip.digest`, and `/bip.narrative` to pipe through `resolve` is tracked separately.

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)