### PR TITLE
Add unit tests for internal/s2, internal/git, internal/pdf

### DIFF
--- a/cmd/bip/s2_helpers.go
+++ b/cmd/bip/s2_helpers.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -132,9 +133,9 @@ func outputGenericNotFound(paperID, message string) error {
 
 // outputGenericRateLimited outputs a rate limit error in both human and JSON format and exits.
 func outputGenericRateLimited(err error) error {
-	apiErr, _ := err.(*s2.APIError)
+	var apiErr *s2.APIError
 	retryAfter := 300
-	if apiErr != nil && apiErr.RetryAfter > 0 {
+	if errors.As(err, &apiErr) && apiErr.RetryAfter > 0 {
 		retryAfter = apiErr.RetryAfter
 	}
 

--- a/internal/git/diff_test.go
+++ b/internal/git/diff_test.go
@@ -1,0 +1,88 @@
+package git
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/matsen/bipartite/internal/reference"
+)
+
+func ids(refs []reference.Reference) []string {
+	out := make([]string, len(refs))
+	for i, r := range refs {
+		out[i] = r.ID
+	}
+	sort.Strings(out)
+	return out
+}
+
+func equalIDs(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestDiffRefs(t *testing.T) {
+	ref := func(id string) reference.Reference { return reference.Reference{ID: id} }
+
+	tests := []struct {
+		name        string
+		old         []reference.Reference
+		current     []reference.Reference
+		wantAdded   []string
+		wantRemoved []string
+	}{
+		{
+			name:        "added only",
+			old:         []reference.Reference{ref("a")},
+			current:     []reference.Reference{ref("a"), ref("b"), ref("c")},
+			wantAdded:   []string{"b", "c"},
+			wantRemoved: nil,
+		},
+		{
+			name:        "removed only",
+			old:         []reference.Reference{ref("a"), ref("b"), ref("c")},
+			current:     []reference.Reference{ref("a")},
+			wantAdded:   nil,
+			wantRemoved: []string{"b", "c"},
+		},
+		{
+			name:        "unchanged",
+			old:         []reference.Reference{ref("a"), ref("b")},
+			current:     []reference.Reference{ref("a"), ref("b")},
+			wantAdded:   nil,
+			wantRemoved: nil,
+		},
+		{
+			name:        "added and removed",
+			old:         []reference.Reference{ref("a"), ref("b")},
+			current:     []reference.Reference{ref("b"), ref("c")},
+			wantAdded:   []string{"c"},
+			wantRemoved: []string{"a"},
+		},
+		{
+			name:        "both empty",
+			old:         nil,
+			current:     nil,
+			wantAdded:   nil,
+			wantRemoved: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			diff := diffRefs(tt.old, tt.current)
+			if gotAdded := ids(diff.Added); !equalIDs(gotAdded, tt.wantAdded) {
+				t.Errorf("Added = %v, want %v", gotAdded, tt.wantAdded)
+			}
+			if gotRemoved := ids(diff.Removed); !equalIDs(gotRemoved, tt.wantRemoved) {
+				t.Errorf("Removed = %v, want %v", gotRemoved, tt.wantRemoved)
+			}
+		})
+	}
+}

--- a/internal/git/diff_test.go
+++ b/internal/git/diff_test.go
@@ -1,7 +1,7 @@
 package git
 
 import (
-	"sort"
+	"slices"
 	"testing"
 
 	"github.com/matsen/bipartite/internal/reference"
@@ -12,20 +12,8 @@ func ids(refs []reference.Reference) []string {
 	for i, r := range refs {
 		out[i] = r.ID
 	}
-	sort.Strings(out)
+	slices.Sort(out)
 	return out
-}
-
-func equalIDs(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
 }
 
 func TestDiffRefs(t *testing.T) {
@@ -77,10 +65,10 @@ func TestDiffRefs(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			diff := diffRefs(tt.old, tt.current)
-			if gotAdded := ids(diff.Added); !equalIDs(gotAdded, tt.wantAdded) {
+			if gotAdded := ids(diff.Added); !slices.Equal(gotAdded, tt.wantAdded) {
 				t.Errorf("Added = %v, want %v", gotAdded, tt.wantAdded)
 			}
-			if gotRemoved := ids(diff.Removed); !equalIDs(gotRemoved, tt.wantRemoved) {
+			if gotRemoved := ids(diff.Removed); !slices.Equal(gotRemoved, tt.wantRemoved) {
 				t.Errorf("Removed = %v, want %v", gotRemoved, tt.wantRemoved)
 			}
 		})

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1,0 +1,196 @@
+package git
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseRefsJSONL(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		data := `{"id":"Zhang2018-vi","title":"Variational Inference"}
+{"id":"Doe2020-nn","title":"Neural Networks"}
+`
+		refs, err := parseRefsJSONL([]byte(data))
+		if err != nil {
+			t.Fatalf("parseRefsJSONL: %v", err)
+		}
+		if len(refs) != 2 {
+			t.Fatalf("len = %d, want 2", len(refs))
+		}
+		if refs[0].ID != "Zhang2018-vi" || refs[1].ID != "Doe2020-nn" {
+			t.Errorf("ids = %q, %q", refs[0].ID, refs[1].ID)
+		}
+	})
+
+	t.Run("blank lines tolerated", func(t *testing.T) {
+		data := "\n{\"id\":\"a\"}\n\n   \n{\"id\":\"b\"}\n\n"
+		refs, err := parseRefsJSONL([]byte(data))
+		if err != nil {
+			t.Fatalf("parseRefsJSONL: %v", err)
+		}
+		if len(refs) != 2 {
+			t.Fatalf("len = %d, want 2", len(refs))
+		}
+	})
+
+	t.Run("malformed line errors", func(t *testing.T) {
+		data := "{\"id\":\"a\"}\nnot json\n"
+		_, err := parseRefsJSONL([]byte(data))
+		if err == nil {
+			t.Fatal("expected error for malformed line, got nil")
+		}
+	})
+
+	t.Run("empty input", func(t *testing.T) {
+		refs, err := parseRefsJSONL([]byte(""))
+		if err != nil {
+			t.Fatalf("parseRefsJSONL: %v", err)
+		}
+		if len(refs) != 0 {
+			t.Errorf("len = %d, want 0", len(refs))
+		}
+	})
+}
+
+// newTestRepo creates a throwaway git repo with one commit that adds
+// .bipartite/refs.jsonl. It skips the test if git is not available.
+// Returns the repo root and the full SHA of the commit.
+func newTestRepo(t *testing.T) (root, sha string) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not in PATH")
+	}
+
+	root = t.TempDir()
+	run := func(args ...string) string {
+		t.Helper()
+		cmd := exec.Command("git", append([]string{"-C", root}, args...)...)
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=Test", "GIT_AUTHOR_EMAIL=test@example.com",
+			"GIT_COMMITTER_NAME=Test", "GIT_COMMITTER_EMAIL=test@example.com",
+		)
+		out, err := cmd.Output()
+		if err != nil {
+			t.Fatalf("git %v: %v", args, err)
+		}
+		return string(out)
+	}
+
+	run("init", "-q")
+	refsPath := filepath.Join(root, GetRefsJSONLPath())
+	if err := os.MkdirAll(filepath.Dir(refsPath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(refsPath, []byte(`{"id":"Zhang2018-vi","title":"Variational Inference"}`+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", GetRefsJSONLPath())
+	run("commit", "-q", "-m", "Add first paper")
+
+	cmd := exec.Command("git", "-C", root, "rev-parse", "HEAD")
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("rev-parse HEAD: %v", err)
+	}
+	sha = trimNL(string(out))
+	return root, sha
+}
+
+func trimNL(s string) string {
+	for len(s) > 0 && (s[len(s)-1] == '\n' || s[len(s)-1] == '\r') {
+		s = s[:len(s)-1]
+	}
+	return s
+}
+
+func TestFindRepoRootAndIsGitRepo(t *testing.T) {
+	root, _ := newTestRepo(t)
+
+	got, err := FindRepoRoot(root)
+	if err != nil {
+		t.Fatalf("FindRepoRoot: %v", err)
+	}
+	// Resolve symlinks since macOS TempDir lives under /var -> /private/var.
+	wantResolved, _ := filepath.EvalSymlinks(root)
+	gotResolved, _ := filepath.EvalSymlinks(got)
+	if gotResolved != wantResolved {
+		t.Errorf("FindRepoRoot = %q, want %q", gotResolved, wantResolved)
+	}
+
+	if !IsGitRepo(root) {
+		t.Error("IsGitRepo = false, want true")
+	}
+
+	// A bare temp dir (no git) should not be a repo.
+	notRepo := t.TempDir()
+	if IsGitRepo(notRepo) {
+		t.Error("IsGitRepo on non-repo = true, want false")
+	}
+	if _, err := FindRepoRoot(notRepo); err != ErrNotGitRepo {
+		t.Errorf("FindRepoRoot on non-repo err = %v, want ErrNotGitRepo", err)
+	}
+}
+
+func TestIsFileTracked(t *testing.T) {
+	root, _ := newTestRepo(t)
+	if !IsFileTracked(root) {
+		t.Error("IsFileTracked = false, want true (refs.jsonl committed)")
+	}
+
+	// Fresh repo with no commits: file not tracked.
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not in PATH")
+	}
+	empty := t.TempDir()
+	if err := exec.Command("git", "-C", empty, "init", "-q").Run(); err != nil {
+		t.Fatalf("git init: %v", err)
+	}
+	if IsFileTracked(empty) {
+		t.Error("IsFileTracked on empty repo = true, want false")
+	}
+}
+
+func TestValidateCommit(t *testing.T) {
+	root, sha := newTestRepo(t)
+
+	resolved, err := ValidateCommit(root, "HEAD")
+	if err != nil {
+		t.Fatalf("ValidateCommit(HEAD): %v", err)
+	}
+	if resolved != sha {
+		t.Errorf("ValidateCommit(HEAD) = %q, want %q", resolved, sha)
+	}
+
+	if _, err := ValidateCommit(root, "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"); err != ErrCommitNotFound {
+		t.Errorf("ValidateCommit(bogus) err = %v, want ErrCommitNotFound", err)
+	}
+}
+
+func TestGetRefsJSONLAtCommit(t *testing.T) {
+	root, sha := newTestRepo(t)
+	refs, err := GetRefsJSONLAtCommit(root, sha)
+	if err != nil {
+		t.Fatalf("GetRefsJSONLAtCommit: %v", err)
+	}
+	if len(refs) != 1 || refs[0].ID != "Zhang2018-vi" {
+		t.Errorf("refs = %+v, want one Zhang2018-vi", refs)
+	}
+}
+
+func TestFindCommitThatAdded(t *testing.T) {
+	root, sha := newTestRepo(t)
+	commits := []CommitInfo{{SHA: sha}}
+
+	// Paper present at the only commit -> returns shortSHA of earliest commit.
+	got := findCommitThatAdded(root, "Zhang2018-vi", commits)
+	if got != shortSHA(sha) {
+		t.Errorf("findCommitThatAdded(present) = %q, want %q", got, shortSHA(sha))
+	}
+
+	// Unknown paper never present -> empty (no commit lacked it before its add).
+	if got := findCommitThatAdded(root, "Nobody1999-xx", commits); got != "" {
+		t.Errorf("findCommitThatAdded(absent) = %q, want empty", got)
+	}
+}

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1,9 +1,11 @@
 package git
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -87,22 +89,16 @@ func newTestRepo(t *testing.T) (root, sha string) {
 		t.Fatal(err)
 	}
 	run("add", GetRefsJSONLPath())
-	run("commit", "-q", "-m", "Add first paper")
+	// Disable signing so a global commit.gpgsign=true (with no key) can't fail the commit.
+	run("-c", "commit.gpgsign=false", "commit", "-q", "-m", "Add first paper")
 
 	cmd := exec.Command("git", "-C", root, "rev-parse", "HEAD")
 	out, err := cmd.Output()
 	if err != nil {
 		t.Fatalf("rev-parse HEAD: %v", err)
 	}
-	sha = trimNL(string(out))
+	sha = strings.TrimSpace(string(out))
 	return root, sha
-}
-
-func trimNL(s string) string {
-	for len(s) > 0 && (s[len(s)-1] == '\n' || s[len(s)-1] == '\r') {
-		s = s[:len(s)-1]
-	}
-	return s
 }
 
 func TestFindRepoRootAndIsGitRepo(t *testing.T) {
@@ -128,7 +124,7 @@ func TestFindRepoRootAndIsGitRepo(t *testing.T) {
 	if IsGitRepo(notRepo) {
 		t.Error("IsGitRepo on non-repo = true, want false")
 	}
-	if _, err := FindRepoRoot(notRepo); err != ErrNotGitRepo {
+	if _, err := FindRepoRoot(notRepo); !errors.Is(err, ErrNotGitRepo) {
 		t.Errorf("FindRepoRoot on non-repo err = %v, want ErrNotGitRepo", err)
 	}
 }
@@ -139,10 +135,8 @@ func TestIsFileTracked(t *testing.T) {
 		t.Error("IsFileTracked = false, want true (refs.jsonl committed)")
 	}
 
-	// Fresh repo with no commits: file not tracked.
-	if _, err := exec.LookPath("git"); err != nil {
-		t.Skip("git not in PATH")
-	}
+	// Fresh repo with no commits: file not tracked. git is present here
+	// (newTestRepo above would have skipped otherwise).
 	empty := t.TempDir()
 	if err := exec.Command("git", "-C", empty, "init", "-q").Run(); err != nil {
 		t.Fatalf("git init: %v", err)
@@ -163,7 +157,7 @@ func TestValidateCommit(t *testing.T) {
 		t.Errorf("ValidateCommit(HEAD) = %q, want %q", resolved, sha)
 	}
 
-	if _, err := ValidateCommit(root, "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"); err != ErrCommitNotFound {
+	if _, err := ValidateCommit(root, "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"); !errors.Is(err, ErrCommitNotFound) {
 		t.Errorf("ValidateCommit(bogus) err = %v, want ErrCommitNotFound", err)
 	}
 }
@@ -183,7 +177,7 @@ func TestFindCommitThatAdded(t *testing.T) {
 	root, sha := newTestRepo(t)
 	commits := []CommitInfo{{SHA: sha}}
 
-	// Paper present at the only commit -> returns shortSHA of earliest commit.
+	// Paper present at the only commit in range -> returns that commit's short SHA.
 	got := findCommitThatAdded(root, "Zhang2018-vi", commits)
 	if got != shortSHA(sha) {
 		t.Errorf("findCommitThatAdded(present) = %q, want %q", got, shortSHA(sha))

--- a/internal/git/log_test.go
+++ b/internal/git/log_test.go
@@ -1,0 +1,94 @@
+package git
+
+import (
+	"testing"
+
+	"github.com/matsen/bipartite/internal/reference"
+)
+
+func TestParseGitLogOneline(t *testing.T) {
+	tests := []struct {
+		name string
+		data string
+		want []CommitInfo
+	}{
+		{
+			name: "two commits",
+			data: "abc123 Add paper X\ndef456 Remove paper Y\n",
+			want: []CommitInfo{
+				{SHA: "abc123", Message: "Add paper X"},
+				{SHA: "def456", Message: "Remove paper Y"},
+			},
+		},
+		{
+			name: "blank lines skipped",
+			data: "abc123 first\n\n\ndef456 second\n",
+			want: []CommitInfo{
+				{SHA: "abc123", Message: "first"},
+				{SHA: "def456", Message: "second"},
+			},
+		},
+		{
+			name: "sha only, no message",
+			data: "abc123\n",
+			want: []CommitInfo{{SHA: "abc123", Message: ""}},
+		},
+		{
+			name: "message with spaces preserved",
+			data: "abc123 fix: handle multi word subject lines\n",
+			want: []CommitInfo{{SHA: "abc123", Message: "fix: handle multi word subject lines"}},
+		},
+		{
+			name: "empty input",
+			data: "",
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseGitLogOneline([]byte(tt.data))
+			if len(got) != len(tt.want) {
+				t.Fatalf("len = %d, want %d (%+v)", len(got), len(tt.want), got)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("[%d] = %+v, want %+v", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestShortSHA(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"abcdef0123456789", "abcdef01"},
+		{"abcdef01", "abcdef01"},
+		{"abc", "abc"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			if got := shortSHA(tt.in); got != tt.want {
+				t.Errorf("shortSHA(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSortRefsAlphabetically(t *testing.T) {
+	refs := []reference.Reference{
+		{ID: "Zhang2018-vi"},
+		{ID: "Adams2001-os"},
+		{ID: "Madison1999-nn"},
+	}
+	SortRefsAlphabetically(refs)
+	want := []string{"Adams2001-os", "Madison1999-nn", "Zhang2018-vi"}
+	for i, w := range want {
+		if refs[i].ID != w {
+			t.Errorf("[%d] = %q, want %q", i, refs[i].ID, w)
+		}
+	}
+}

--- a/internal/pdf/doi_test.go
+++ b/internal/pdf/doi_test.go
@@ -1,0 +1,87 @@
+package pdf
+
+import "testing"
+
+func TestFindDOI(t *testing.T) {
+	tests := []struct {
+		name string
+		text string
+		want string
+	}{
+		{
+			name: "single doi",
+			text: "Published online. doi:10.1038/nature12373 in Nature.",
+			want: "10.1038/nature12373",
+		},
+		{
+			name: "trailing period stripped",
+			text: "See 10.1234/foo.",
+			want: "10.1234/foo",
+		},
+		{
+			name: "trailing punctuation stripped",
+			text: "(10.1234/foo);",
+			want: "10.1234/foo",
+		},
+		{
+			name: "no doi",
+			text: "This text has no identifier at all.",
+			want: "",
+		},
+		{
+			name: "multiple returns first",
+			text: "10.1111/aaa and later 10.2222/bbb",
+			want: "10.1111/aaa",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := findDOI(tt.text); got != tt.want {
+				t.Errorf("findDOI(%q) = %q, want %q", tt.text, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsValidDOI(t *testing.T) {
+	tests := []struct {
+		name string
+		doi  string
+		want bool
+	}{
+		{"valid", "10.1038/nature12373", true},
+		{"too short", "10.1/x", false},
+		{"missing 10. prefix", "11.1234/foobar", false},
+		{"missing slash", "10.1234foobar", false},
+		{"trailing slash only", "10.1234567/", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isValidDOI(tt.doi); got != tt.want {
+				t.Errorf("isValidDOI(%q) = %v, want %v", tt.doi, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsHeaderLine(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		want bool
+	}{
+		{"journal", "Journal of Molecular Biology", true},
+		{"volume and issue", "Volume 42, Issue 3", true},
+		{"copyright", "Copyright 2024 The Authors", true},
+		{"article published", "Article published online 2024", true},
+		{"ordinary title", "A Bayesian Approach to Phylogenetic Inference", false},
+		{"volume without issue", "Volume 42 of the proceedings", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isHeaderLine(tt.line); got != tt.want {
+				t.Errorf("isHeaderLine(%q) = %v, want %v", tt.line, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/s2/client.go
+++ b/internal/s2/client.go
@@ -285,7 +285,7 @@ func checkResponse(resp *http.Response) error {
 				apiErr.RetryAfter = secs
 			}
 		}
-		return fmt.Errorf("%w: %v", ErrRateLimited, apiErr)
+		return fmt.Errorf("%w: %w", ErrRateLimited, apiErr)
 	}
 
 	return apiErr

--- a/internal/s2/client_test.go
+++ b/internal/s2/client_test.go
@@ -1,0 +1,129 @@
+package s2
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// makeResponse builds a minimal *http.Response for checkResponse tests.
+func makeResponse(status int, body string, header http.Header) *http.Response {
+	if header == nil {
+		header = http.Header{}
+	}
+	return &http.Response{
+		StatusCode: status,
+		Status:     http.StatusText(status),
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     header,
+	}
+}
+
+func TestCheckResponse(t *testing.T) {
+	t.Run("2xx is nil", func(t *testing.T) {
+		if err := checkResponse(makeResponse(200, "ok", nil)); err != nil {
+			t.Errorf("checkResponse(200) = %v, want nil", err)
+		}
+		if err := checkResponse(makeResponse(204, "", nil)); err != nil {
+			t.Errorf("checkResponse(204) = %v, want nil", err)
+		}
+	})
+
+	t.Run("404 is APIError", func(t *testing.T) {
+		err := checkResponse(makeResponse(404, "missing", nil))
+		var apiErr *APIError
+		if !errors.As(err, &apiErr) {
+			t.Fatalf("checkResponse(404) = %v, want *APIError", err)
+		}
+		if apiErr.StatusCode != 404 {
+			t.Errorf("StatusCode = %d, want 404", apiErr.StatusCode)
+		}
+		if apiErr.Message != "missing" {
+			t.Errorf("Message = %q, want %q", apiErr.Message, "missing")
+		}
+	})
+
+	t.Run("429 wraps ErrRateLimited with Retry-After", func(t *testing.T) {
+		h := http.Header{}
+		h.Set("Retry-After", "42")
+		err := checkResponse(makeResponse(429, "slow down", h))
+		if !IsRateLimited(err) {
+			t.Fatalf("checkResponse(429): IsRateLimited = false, want true (err=%v)", err)
+		}
+		// The 429 path wraps ErrRateLimited (with %w) and embeds the
+		// formatted *APIError (with %v), so the parsed Retry-After surfaces
+		// in the message rather than as a retrievable *APIError.
+		if !strings.Contains(err.Error(), "retry after 42s") {
+			t.Errorf("error message = %q, want it to mention retry after 42s", err.Error())
+		}
+	})
+
+	t.Run("empty body falls back to status", func(t *testing.T) {
+		err := checkResponse(makeResponse(500, "", nil))
+		var apiErr *APIError
+		if !errors.As(err, &apiErr) {
+			t.Fatalf("checkResponse(500) = %v, want *APIError", err)
+		}
+		if apiErr.Message == "" {
+			t.Error("Message should fall back to status text, got empty")
+		}
+	})
+}
+
+func TestGetPaperHappyPath(t *testing.T) {
+	const body = `{
+		"paperId": "abc123",
+		"title": "A Great Paper",
+		"year": 2018,
+		"venue": "Nature",
+		"externalIds": {"DOI": "10.1038/nature12373"},
+		"authors": [{"name": "Cheng Zhang"}]
+	}`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.Path, "/paper/") {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		if r.URL.Query().Get("fields") == "" {
+			t.Error("fields query param missing")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, body)
+	}))
+	defer srv.Close()
+
+	c := NewClient(WithBaseURL(srv.URL))
+	paper, err := c.GetPaper(context.Background(), "DOI:10.1038/nature12373")
+	if err != nil {
+		t.Fatalf("GetPaper: %v", err)
+	}
+	if paper.PaperID != "abc123" {
+		t.Errorf("PaperID = %q, want abc123", paper.PaperID)
+	}
+	if paper.Title != "A Great Paper" {
+		t.Errorf("Title = %q", paper.Title)
+	}
+	if paper.ExternalIDs.DOI != "10.1038/nature12373" {
+		t.Errorf("DOI = %q", paper.ExternalIDs.DOI)
+	}
+	if len(paper.Authors) != 1 || paper.Authors[0].Name != "Cheng Zhang" {
+		t.Errorf("Authors = %+v", paper.Authors)
+	}
+}
+
+func TestGetPaperNotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := NewClient(WithBaseURL(srv.URL))
+	_, err := c.GetPaper(context.Background(), "DOI:10.0/missing")
+	if !IsNotFound(err) {
+		t.Errorf("GetPaper: IsNotFound = false, want true (err=%v)", err)
+	}
+}

--- a/internal/s2/client_test.go
+++ b/internal/s2/client_test.go
@@ -110,6 +110,12 @@ func TestGetPaperHappyPath(t *testing.T) {
 	if paper.Title != "A Great Paper" {
 		t.Errorf("Title = %q", paper.Title)
 	}
+	if paper.Year != 2018 {
+		t.Errorf("Year = %d, want 2018", paper.Year)
+	}
+	if paper.Venue != "Nature" {
+		t.Errorf("Venue = %q, want Nature", paper.Venue)
+	}
 	if paper.ExternalIDs.DOI != "10.1038/nature12373" {
 		t.Errorf("DOI = %q", paper.ExternalIDs.DOI)
 	}

--- a/internal/s2/client_test.go
+++ b/internal/s2/client_test.go
@@ -54,11 +54,14 @@ func TestCheckResponse(t *testing.T) {
 		if !IsRateLimited(err) {
 			t.Fatalf("checkResponse(429): IsRateLimited = false, want true (err=%v)", err)
 		}
-		// The 429 path wraps ErrRateLimited (with %w) and embeds the
-		// formatted *APIError (with %v), so the parsed Retry-After surfaces
-		// in the message rather than as a retrievable *APIError.
-		if !strings.Contains(err.Error(), "retry after 42s") {
-			t.Errorf("error message = %q, want it to mention retry after 42s", err.Error())
+		// The 429 path multi-wraps both ErrRateLimited and the *APIError,
+		// so the structured error and its parsed Retry-After are recoverable.
+		var apiErr *APIError
+		if !errors.As(err, &apiErr) {
+			t.Fatalf("checkResponse(429) does not unwrap to *APIError: %v", err)
+		}
+		if apiErr.RetryAfter != 42 {
+			t.Errorf("RetryAfter = %d, want 42", apiErr.RetryAfter)
 		}
 	})
 

--- a/internal/s2/errors_test.go
+++ b/internal/s2/errors_test.go
@@ -1,0 +1,79 @@
+package s2
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestIsNotFound(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"sentinel", ErrNotFound, true},
+		{"wrapped sentinel", fmt.Errorf("lookup: %w", ErrNotFound), true},
+		{"APIError 404", &APIError{StatusCode: 404}, true},
+		{"APIError 500", &APIError{StatusCode: 500}, false},
+		{"rate limited", ErrRateLimited, false},
+		{"unrelated", errors.New("boom"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsNotFound(tt.err); got != tt.want {
+				t.Errorf("IsNotFound(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsRateLimited(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"sentinel", ErrRateLimited, true},
+		{"wrapped sentinel", fmt.Errorf("call: %w", ErrRateLimited), true},
+		{"APIError 429", &APIError{StatusCode: 429}, true},
+		{"APIError 404", &APIError{StatusCode: 404}, false},
+		{"not found", ErrNotFound, false},
+		{"unrelated", errors.New("boom"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsRateLimited(tt.err); got != tt.want {
+				t.Errorf("IsRateLimited(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAPIErrorError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  *APIError
+		want string
+	}{
+		{
+			name: "without retry-after",
+			err:  &APIError{StatusCode: 404, Message: "not found"},
+			want: "S2 API error (status 404): not found",
+		},
+		{
+			name: "with retry-after",
+			err:  &APIError{StatusCode: 429, Message: "slow down", RetryAfter: 30},
+			want: "S2 API error (status 429): slow down (retry after 30s)",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.err.Error(); got != tt.want {
+				t.Errorf("Error() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/s2/local_test.go
+++ b/internal/s2/local_test.go
@@ -1,0 +1,143 @@
+package s2
+
+import (
+	"testing"
+
+	"github.com/matsen/bipartite/internal/reference"
+)
+
+func sampleRefs() []reference.Reference {
+	return []reference.Reference{
+		{
+			ID:     "Zhang2018-vi",
+			DOI:    "10.1038/Nature12373",
+			Title:  "Variational Inference",
+			Source: reference.ImportSource{Type: "s2", ID: "s2paper1"},
+		},
+		{
+			ID:     "Doe2020-nn",
+			DOI:    "",
+			Title:  "Neural Networks",
+			Source: reference.ImportSource{Type: "paperpile", ID: "pp123"},
+		},
+		{
+			ID:     "Smith2019-os",
+			DOI:    "10.1234/foo",
+			Title:  "Origin of Species",
+			Source: reference.ImportSource{Type: "s2", ID: "s2paper2"},
+		},
+	}
+}
+
+func TestLocalResolverFindByDOI(t *testing.T) {
+	r := NewLocalResolverFromRefs(sampleRefs())
+
+	// DOI lookup is normalized (case + prefix).
+	ref, ok := r.FindByDOI("https://doi.org/10.1038/nature12373")
+	if !ok {
+		t.Fatal("FindByDOI: expected to find normalized DOI")
+	}
+	if ref.ID != "Zhang2018-vi" {
+		t.Errorf("FindByDOI: got %q, want Zhang2018-vi", ref.ID)
+	}
+
+	if _, ok := r.FindByDOI("10.9999/missing"); ok {
+		t.Error("FindByDOI: expected miss for unknown DOI")
+	}
+}
+
+func TestLocalResolverFindByID(t *testing.T) {
+	r := NewLocalResolverFromRefs(sampleRefs())
+
+	ref, ok := r.FindByID("Doe2020-nn")
+	if !ok {
+		t.Fatal("FindByID: expected to find Doe2020-nn")
+	}
+	if ref.Title != "Neural Networks" {
+		t.Errorf("FindByID: got title %q", ref.Title)
+	}
+
+	if _, ok := r.FindByID("Nobody1999-xx"); ok {
+		t.Error("FindByID: expected miss for unknown ID")
+	}
+}
+
+func TestLocalResolverFindByS2ID(t *testing.T) {
+	r := NewLocalResolverFromRefs(sampleRefs())
+
+	ref, ok := r.FindByS2ID("s2paper2")
+	if !ok {
+		t.Fatal("FindByS2ID: expected to find s2paper2")
+	}
+	if ref.ID != "Smith2019-os" {
+		t.Errorf("FindByS2ID: got %q, want Smith2019-os", ref.ID)
+	}
+
+	// Non-s2 sources are not indexed by S2 ID.
+	if _, ok := r.FindByS2ID("pp123"); ok {
+		t.Error("FindByS2ID: paperpile source should not be indexed by S2 ID")
+	}
+}
+
+func TestLocalResolverExistsLocally(t *testing.T) {
+	r := NewLocalResolverFromRefs(sampleRefs())
+
+	tests := []struct {
+		name   string
+		paper  S2Paper
+		wantOK bool
+		wantID string
+	}{
+		{
+			name:   "match by DOI",
+			paper:  S2Paper{ExternalIDs: ExternalIDs{DOI: "10.1038/nature12373"}},
+			wantOK: true,
+			wantID: "Zhang2018-vi",
+		},
+		{
+			name:   "match by S2 ID",
+			paper:  S2Paper{PaperID: "s2paper2"},
+			wantOK: true,
+			wantID: "Smith2019-os",
+		},
+		{
+			name:   "no match",
+			paper:  S2Paper{PaperID: "unknown", ExternalIDs: ExternalIDs{DOI: "10.0/none"}},
+			wantOK: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ref, ok := r.ExistsLocally(tt.paper)
+			if ok != tt.wantOK {
+				t.Fatalf("ExistsLocally ok = %v, want %v", ok, tt.wantOK)
+			}
+			if ok && ref.ID != tt.wantID {
+				t.Errorf("ExistsLocally ID = %q, want %q", ref.ID, tt.wantID)
+			}
+		})
+	}
+}
+
+func TestLocalResolverCount(t *testing.T) {
+	r := NewLocalResolverFromRefs(sampleRefs())
+	if got := r.Count(); got != 3 {
+		t.Errorf("Count() = %d, want 3", got)
+	}
+	if got := NewLocalResolverFromRefs(nil).Count(); got != 0 {
+		t.Errorf("Count() on empty = %d, want 0", got)
+	}
+}
+
+func TestLocalResolverRefsWithDOI(t *testing.T) {
+	r := NewLocalResolverFromRefs(sampleRefs())
+	withDOI := r.RefsWithDOI()
+	if len(withDOI) != 2 {
+		t.Fatalf("RefsWithDOI len = %d, want 2", len(withDOI))
+	}
+	for _, ref := range withDOI {
+		if ref.DOI == "" {
+			t.Errorf("RefsWithDOI returned ref with empty DOI: %q", ref.ID)
+		}
+	}
+}

--- a/internal/s2/mapper_test.go
+++ b/internal/s2/mapper_test.go
@@ -1,0 +1,210 @@
+package s2
+
+import "testing"
+
+func TestSplitAuthorName(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantFirst string
+		wantLast  string
+	}{
+		{"empty", "", "", ""},
+		{"whitespace only", "   ", "", ""},
+		{"single name", "Madonna", "", "Madonna"},
+		{"first last", "John Smith", "John", "Smith"},
+		{"first middle last", "John Quincy Adams", "John Quincy", "Adams"},
+		{"suffix Jr", "John Smith Jr", "John", "Smith Jr"},
+		{"suffix III", "John Smith III", "John", "Smith III"},
+		{"suffix with middle", "John Quincy Smith Jr", "John Quincy", "Smith Jr"},
+		{"two-part suffix-like is just last", "Smith Jr", "Smith", "Jr"},
+		{"surrounding whitespace", "  John Smith  ", "John", "Smith"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			first, last := splitAuthorName(tt.input)
+			if first != tt.wantFirst {
+				t.Errorf("first = %q, want %q", first, tt.wantFirst)
+			}
+			if last != tt.wantLast {
+				t.Errorf("last = %q, want %q", last, tt.wantLast)
+			}
+		})
+	}
+}
+
+func TestParsePublicationDate(t *testing.T) {
+	tests := []struct {
+		name             string
+		year             int
+		dateStr          string
+		wantY, wantM, wD int
+	}{
+		{"year only, no date string", 2018, "", 2018, 0, 0},
+		{"full date overrides year", 2018, "2019-03-15", 2019, 3, 15},
+		{"year-only date string", 0, "2020", 2020, 0, 0},
+		{"year-month", 0, "2020-07", 2020, 7, 0},
+		{"invalid month ignored", 2021, "2021-13-01", 2021, 0, 1},
+		{"invalid day ignored", 2021, "2021-06-40", 2021, 6, 0},
+		{"non-numeric year keeps fallback", 2022, "abc-01-01", 2022, 1, 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pub := parsePublicationDate(tt.year, tt.dateStr)
+			if pub.Year != tt.wantY {
+				t.Errorf("Year = %d, want %d", pub.Year, tt.wantY)
+			}
+			if pub.Month != tt.wantM {
+				t.Errorf("Month = %d, want %d", pub.Month, tt.wantM)
+			}
+			if pub.Day != tt.wD {
+				t.Errorf("Day = %d, want %d", pub.Day, tt.wD)
+			}
+		})
+	}
+}
+
+func TestSanitizeForCiteKey(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"Smith", "Smith"},
+		{"O'Brien", "OBrien"},
+		{"van der Waals", "vanderWaals"},
+		{"Smith-Jones", "SmithJones"},
+		{"José", "José"},
+		{"Author 3rd", "Author3rd"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := sanitizeForCiteKey(tt.input); got != tt.want {
+				t.Errorf("sanitizeForCiteKey(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGenerateTitleSuffix(t *testing.T) {
+	tests := []struct {
+		name  string
+		title string
+		want  string
+	}{
+		{"two significant words", "Variational Inference", "vi"},
+		{"stop words skipped", "The Origin of Species", "os"},
+		{"single significant word padded", "Phylogenetics", "px"},
+		{"empty padded", "", "xx"},
+		{"all stop words padded", "the of and", "xx"},
+		{"leading stop word", "A Neural Network", "nn"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := generateTitleSuffix(tt.title); got != tt.want {
+				t.Errorf("generateTitleSuffix(%q) = %q, want %q", tt.title, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGenerateCiteKey(t *testing.T) {
+	tests := []struct {
+		name  string
+		paper S2Paper
+		want  string
+	}{
+		{
+			name: "standard",
+			paper: S2Paper{
+				Authors: []S2Author{{Name: "Cheng Zhang"}},
+				Year:    2018,
+				Title:   "Variational Inference",
+			},
+			want: "Zhang2018-vi",
+		},
+		{
+			name: "no authors -> Unknown",
+			paper: S2Paper{
+				Year:  2020,
+				Title: "Mystery Paper",
+			},
+			want: "Unknown2020-mp",
+		},
+		{
+			name: "no year -> 9999",
+			paper: S2Paper{
+				Authors: []S2Author{{Name: "Jane Doe"}},
+				Title:   "Neural Networks",
+			},
+			want: "Doe9999-nn",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := generateCiteKey(tt.paper); got != tt.want {
+				t.Errorf("generateCiteKey() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMapS2ToReference(t *testing.T) {
+	paper := S2Paper{
+		PaperID: "abc123",
+		ExternalIDs: ExternalIDs{
+			DOI:           "10.1038/nature12373",
+			ArXiv:         "2106.15928",
+			PubMed:        "19872477",
+			PubMedCentral: "PMC2323736",
+		},
+		Title:    "A Great Paper",
+		Abstract: "An abstract.",
+		Venue:    "Nature",
+		Authors:  []S2Author{{Name: "Cheng Zhang"}, {Name: "Jane Doe"}},
+		Year:     2018,
+		PubDate:  "2018-05-10",
+	}
+
+	ref := MapS2ToReference(paper)
+
+	if ref.ID != "Zhang2018-gp" {
+		t.Errorf("ID = %q, want %q", ref.ID, "Zhang2018-gp")
+	}
+	if ref.DOI != "10.1038/nature12373" {
+		t.Errorf("DOI = %q, want %q", ref.DOI, "10.1038/nature12373")
+	}
+	if ref.Title != "A Great Paper" {
+		t.Errorf("Title = %q", ref.Title)
+	}
+	if ref.Abstract != "An abstract." {
+		t.Errorf("Abstract = %q", ref.Abstract)
+	}
+	if ref.Venue != "Nature" {
+		t.Errorf("Venue = %q", ref.Venue)
+	}
+	if ref.PMID != "19872477" {
+		t.Errorf("PMID = %q", ref.PMID)
+	}
+	if ref.PMCID != "PMC2323736" {
+		t.Errorf("PMCID = %q", ref.PMCID)
+	}
+	if ref.ArXivID != "2106.15928" {
+		t.Errorf("ArXivID = %q", ref.ArXivID)
+	}
+	if ref.S2ID != "abc123" {
+		t.Errorf("S2ID = %q", ref.S2ID)
+	}
+	if ref.Source.Type != "s2" || ref.Source.ID != "abc123" {
+		t.Errorf("Source = %+v, want {s2 abc123}", ref.Source)
+	}
+	if ref.Published.Year != 2018 || ref.Published.Month != 5 || ref.Published.Day != 10 {
+		t.Errorf("Published = %+v, want 2018-05-10", ref.Published)
+	}
+	if len(ref.Authors) != 2 {
+		t.Fatalf("len(Authors) = %d, want 2", len(ref.Authors))
+	}
+	if ref.Authors[0].First != "Cheng" || ref.Authors[0].Last != "Zhang" {
+		t.Errorf("Authors[0] = %+v, want {Cheng Zhang}", ref.Authors[0])
+	}
+}

--- a/internal/s2/mapper_test.go
+++ b/internal/s2/mapper_test.go
@@ -35,10 +35,10 @@ func TestSplitAuthorName(t *testing.T) {
 
 func TestParsePublicationDate(t *testing.T) {
 	tests := []struct {
-		name             string
-		year             int
-		dateStr          string
-		wantY, wantM, wD int
+		name                string
+		year                int
+		dateStr             string
+		wantY, wantM, wantD int
 	}{
 		{"year only, no date string", 2018, "", 2018, 0, 0},
 		{"full date overrides year", 2018, "2019-03-15", 2019, 3, 15},
@@ -57,8 +57,8 @@ func TestParsePublicationDate(t *testing.T) {
 			if pub.Month != tt.wantM {
 				t.Errorf("Month = %d, want %d", pub.Month, tt.wantM)
 			}
-			if pub.Day != tt.wD {
-				t.Errorf("Day = %d, want %d", pub.Day, tt.wD)
+			if pub.Day != tt.wantD {
+				t.Errorf("Day = %d, want %d", pub.Day, tt.wantD)
 			}
 		})
 	}

--- a/internal/s2/parser_test.go
+++ b/internal/s2/parser_test.go
@@ -43,6 +43,9 @@ func TestPaperIdentifierIsExternalID(t *testing.T) {
 		{"ARXIV", true},
 		{"S2", true},
 		{"PMID", true},
+		{"CorpusId", true},
+		{"MAG", true},
+		{"ACL", true},
 		{"LOCAL", false},
 	}
 	for _, tt := range tests {

--- a/internal/s2/parser_test.go
+++ b/internal/s2/parser_test.go
@@ -1,0 +1,79 @@
+package s2
+
+import "testing"
+
+func TestParsePaperID(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantType string
+		wantVal  string
+	}{
+		{"doi", "DOI:10.1038/nature12373", "DOI", "10.1038/nature12373"},
+		{"arxiv", "ARXIV:2106.15928", "ARXIV", "2106.15928"},
+		{"pmid", "PMID:19872477", "PMID", "19872477"},
+		{"pmcid", "PMCID:2323736", "PMCID", "2323736"},
+		{"corpusid", "CorpusId:215416146", "CorpusId", "215416146"},
+		{"url", "URL:https://arxiv.org/abs/2106.15928", "URL", "https://arxiv.org/abs/2106.15928"},
+		{"lowercase prefix", "doi:10.1038/nature12373", "DOI", "10.1038/nature12373"},
+		{"raw s2 id", "649def34f8be52c8b66281af98ae884c09aef38b", "S2", "649def34f8be52c8b66281af98ae884c09aef38b"},
+		{"leading whitespace", "  DOI:10.1/x  ", "DOI", "10.1/x"},
+		{"bare local id", "Zhang2018-vi", "LOCAL", "Zhang2018-vi"},
+		{"short hex not s2", "abc123", "LOCAL", "abc123"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParsePaperID(tt.input)
+			if got.Type != tt.wantType {
+				t.Errorf("Type = %q, want %q", got.Type, tt.wantType)
+			}
+			if got.Value != tt.wantVal {
+				t.Errorf("Value = %q, want %q", got.Value, tt.wantVal)
+			}
+		})
+	}
+}
+
+func TestPaperIdentifierIsExternalID(t *testing.T) {
+	tests := []struct {
+		typ  string
+		want bool
+	}{
+		{"DOI", true},
+		{"ARXIV", true},
+		{"S2", true},
+		{"PMID", true},
+		{"LOCAL", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.typ, func(t *testing.T) {
+			p := PaperIdentifier{Type: tt.typ, Value: "x"}
+			if got := p.IsExternalID(); got != tt.want {
+				t.Errorf("IsExternalID() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeDOI(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"plain", "10.1038/Nature12373", "10.1038/nature12373"},
+		{"https doi.org", "https://doi.org/10.1038/Nature12373", "10.1038/nature12373"},
+		{"http doi.org", "http://doi.org/10.1038/NATURE12373", "10.1038/nature12373"},
+		{"bare doi.org", "doi.org/10.1038/nature12373", "10.1038/nature12373"},
+		{"DOI prefix", "DOI:10.1038/Nature12373", "10.1038/nature12373"},
+		{"surrounding whitespace", "  10.1038/Nature12373  ", "10.1038/nature12373"},
+		{"already normalized", "10.1234/foo", "10.1234/foo"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NormalizeDOI(tt.input); got != tt.want {
+				t.Errorf("NormalizeDOI(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
🤖 ## Summary

Closes #168. Adds `_test.go` coverage for the three packages the 2026-06-22 `/bip-decay-audit` flagged as the repo's only test asymmetry (source but zero tests). House style followed: table-driven, one `_test.go` per source file, in-package for unexported helpers. While writing the tests, a real rate-limit bug surfaced and is fixed here too.

Pure logic (no fakes):
- **s2/parser** — `ParsePaperID` (DOI/arXiv/PMID/CorpusId/URL/bare-hash/local), `IsExternalID`, `NormalizeDOI`.
- **s2/mapper** — `splitAuthorName` (single/first-last/middle/suffix), `parsePublicationDate`, `sanitizeForCiteKey`, `generateTitleSuffix`, `generateCiteKey`, `MapS2ToReference`.
- **s2/errors** — `IsNotFound`/`IsRateLimited` over sentinels, `*APIError{404|429}`, unrelated errors; `APIError.Error()` with/without `RetryAfter`.
- **git/log** — `parseGitLogOneline`, `shortSHA`, `SortRefsAlphabetically`.
- **git/diff** — `diffRefs` for added/removed/unchanged.
- **pdf/doi** — `findDOI`, `isValidDOI`, `isHeaderLine`.

Light stdlib seams:
- **s2/local** — `NewLocalResolverFromRefs` + `FindByDOI`/`FindByID`/`FindByS2ID`/`ExistsLocally`/`Count`/`RefsWithDOI`, no file I/O.
- **s2/client** — `checkResponse` status→error mapping; `GetPaper` happy-path and 404 against an `httptest.Server` wired via `WithBaseURL`.
- **git/git** — `parseRefsJSONL` (valid/blank-tolerant/malformed), and `FindRepoRoot`/`IsGitRepo`/`IsFileTracked`/`ValidateCommit`/`GetRefsJSONLAtCommit`/`findCommitThatAdded` against a throwaway `t.TempDir()` repo, guarded by a `git not in PATH` skip.

## Bug fixed (found while testing)

The server's rate-limit `Retry-After` was being silently discarded — the CLI always reported the 300s default. Two compounding causes:

1. `s2/client.go` `checkResponse` wrapped the `*APIError` into the 429 error with `%v`, so it was unrecoverable via `errors.As`.
2. `cmd/bip/s2_helpers.go` `outputGenericRateLimited` used a direct type assertion `err.(*s2.APIError)` against that already-wrapped error, which always failed → `apiErr` nil → 300s default.

Fix: multi-wrap the `*APIError` with `%w`, and recover it with `errors.As` at the CLI layer. The `checkResponse` test now asserts the structured error and its parsed `RetryAfter` are recoverable.

## Results

| package | coverage |
|---|---|
| internal/s2 | 63.0% |
| internal/git | 38.6% |
| internal/pdf | 19.2% |

Coverage is bounded by the large out-of-scope I/O surface in each package (live HTTP fetchers, `git` subprocess walkers, `ledongthuc/pdf` byte parsing). Per-function coverage confirms **every function listed in the issue is hit** (no 0.0% among targets). The suite runs in **~1.25s** with no network access and no skips on a machine with `git`.

## Test plan

- `go test ./...` — passes
- `go vet ./...` — clean
- `go build ./cmd/bip` — builds

## Out of scope

Live S2 HTTP calls, real git-history fixtures beyond one throwaway repo, real PDF byte parsing, and `cmd/` wiring — all per the issue. (The `cmd/` change here is the targeted rate-limit fix, not test coverage.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)