### PR TITLE
bip-ms: issue creation is in-scope when the user asks

### DIFF
--- a/skills/bip-ms/SKILL.md
+++ b/skills/bip-ms/SKILL.md
@@ -22,17 +22,19 @@ updates, use `/bip-ms-poll`.
 
 ### Manuscript role
 This session **writes the paper**. It does not do feature work, run
-experiments, or create/manage issues on tracked repos — that's what
-the EPIC workers and conductor do (running on a remote). This session:
+experiments, or kick off computational work on tracked repos — that's
+what the EPIC workers and conductor do (running on a remote). This session:
 - Monitors tracked EPICs for new results
 - Pulls local clones, then runs their Makefile fetch targets to bring results from remote
 - Imports SVGs into `prep-figures/`, opens HTML notebooks in Chrome
 - Drafts results and methods text based on new findings
 - Maintains the manuscript TeX files
 
-**Out of scope:** Running experiments, creating issues on tracked repos,
-or kicking off computational work. If manuscript work reveals a gap,
-note it for the user — they will handle issue creation separately.
+**Out of scope:** Running experiments yourself, kicking off
+computational work, or modifying remote server state. Do **not** create
+issues on your own initiative — if manuscript work reveals a gap,
+surface it to the user. When the user explicitly asks to file an issue,
+that is in scope: follow the Issue quality gate below.
 
 **Never modify remote server state.** Do not run `snakemake` (even
 dry-run), `zig build`, `git pull`, `snakemake --unlock`, or any
@@ -218,7 +220,9 @@ Based on what's new, propose concrete next steps:
 2. **Open notebooks**: Open HTML notebooks in Chrome for review
 3. **Draft text**: Summarize findings in bullets, then draft results/methods
 4. **Note gaps**: If manuscript work reveals missing experiments or analyses,
-   note them for the user (do not create issues — that's out of scope)
+   note them for the user; do not file issues on your own initiative. If the
+   user asks you to file one, follow the Issue quality gate
+   (`/bip-issue-check` → `/bip-issue-file`).
 
 Wait for user confirmation before taking action.
 


### PR DESCRIPTION
🤖

## Summary
- Reword three conflicting passages in `skills/bip-ms/SKILL.md` so they describe *autonomous* issue creation and *computational* work, not issue authoring in general. The skill previously contradicted itself — three places said creating issues was "out of scope" while the Issue quality gate (lines 46–49) already contemplates the user asking for one.
- **Manuscript role**: list now names "kick off computational work" instead of "create/manage issues".
- **Out of scope**: now names experiments, computational work, and remote-state modification — not issue authoring — and cross-links the Issue quality gate. The accurate posture: the agent does not create issues on its own initiative and never shortcuts to `gh issue create`, but filing an issue when the user explicitly asks is in scope.
- **Step 4 / Note gaps**: points at the quality gate (`/bip-issue-check` → `/bip-issue-file`) for the user-asks path.

## Why
The blanket "out of scope" wording caused a manuscript session to refuse to file an issue the user explicitly requested. It also contradicts global `CLAUDE.md` ("Only run \`gh issue create\` if explicitly asked") and Constitution Principle IV (adjacent discoveries become follow-up issues). This change brings the skill into line.

## Notes
- Checked the sibling skills named in the issue (`bip-ms-poll`, `bip-ms-tuckin`, `bip-ms-audit`, `bip-ms-sweep`): none carry the blanket "creating issues is out of scope" phrasing. `bip-ms-poll` and `bip-ms-audit` already use the correct posture (propose → quality gate). No changes needed there.
- No behavioral change to the "Never modify remote server state" rules.

## Test plan
- Documentation-only change to one skill markdown file; no code touched. Verified the three target passages no longer state issue creation is out of scope and that the user-asks path references the quality gate.

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)