### PR TITLE
Map conference venue from Paperpile booktitle on import

### DIFF
--- a/internal/importer/paperpile.go
+++ b/internal/importer/paperpile.go
@@ -55,6 +55,7 @@ type PaperpileEntry struct {
 	Title     string `json:"title"`
 	Abstract  string `json:"abstract"`
 	Journal   string `json:"journal"`
+	Booktitle string `json:"booktitle"`
 	Published struct {
 		Year  FlexibleString `json:"year"`
 		Month FlexibleString `json:"month"`
@@ -260,13 +261,19 @@ func paperpileEntryToReference(entry PaperpileEntry, strict bool) (reference.Ref
 		id = entry.ID
 	}
 
+	// Conference papers carry the venue in booktitle, not journal.
+	venue := entry.Journal
+	if venue == "" {
+		venue = entry.Booktitle
+	}
+
 	ref := reference.Reference{
 		ID:              id,
 		DOI:             entry.DOI,
 		Title:           title,
 		Authors:         authors,
 		Abstract:        entry.Abstract,
-		Venue:           entry.Journal,
+		Venue:           venue,
 		Note:            entry.Note,
 		Tags:            tags,
 		Published:       pubDate,

--- a/internal/importer/paperpile_test.go
+++ b/internal/importer/paperpile_test.go
@@ -146,6 +146,58 @@ func TestParsePaperpile_ValidEntry(t *testing.T) {
 	}
 }
 
+func TestParsePaperpile_Venue(t *testing.T) {
+	// Conference papers carry the venue in booktitle (empty journal); articles
+	// carry it in journal. Journal wins when both are present.
+	tests := []struct {
+		name      string
+		data      string
+		wantVenue string
+	}{
+		{
+			name: "conference paper uses booktitle",
+			data: `[{
+				"_id": "abc", "citekey": "Prillo2024-bn", "title": "Conf paper",
+				"published": {"year": "2024"}, "author": [{"last": "Prillo"}],
+				"booktitle": "The Thirty-eighth Annual Conference on Neural Information Processing Systems"
+			}]`,
+			wantVenue: "The Thirty-eighth Annual Conference on Neural Information Processing Systems",
+		},
+		{
+			name: "journal wins when both present",
+			data: `[{
+				"_id": "abc", "citekey": "Both2024", "title": "Paper",
+				"published": {"year": "2024"}, "author": [{"last": "Smith"}],
+				"journal": "Real Journal", "booktitle": "Some Proceedings"
+			}]`,
+			wantVenue: "Real Journal",
+		},
+		{
+			name: "neither present yields empty venue",
+			data: `[{
+				"_id": "abc", "citekey": "None2024", "title": "Paper",
+				"published": {"year": "2024"}, "author": [{"last": "Smith"}]
+			}]`,
+			wantVenue: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			refs, _, errs := ParsePaperpile([]byte(tt.data), true)
+			if len(errs) > 0 {
+				t.Fatalf("ParsePaperpile() returned errors: %v", errs)
+			}
+			if len(refs) != 1 {
+				t.Fatalf("got %d refs, want 1", len(refs))
+			}
+			if refs[0].Venue != tt.wantVenue {
+				t.Errorf("Venue = %q, want %q", refs[0].Venue, tt.wantVenue)
+			}
+		})
+	}
+}
+
 func TestParsePaperpile_WithoutNotes(t *testing.T) {
 	data := []byte(`[{
 		"_id": "abc123",

--- a/testdata/paperpile_sample.json
+++ b/testdata/paperpile_sample.json
@@ -547,5 +547,31 @@
       "http://dx.doi.org/10.1016/s0195-6698(89)80009-5"
     ],
     "volume": "10"
+  },
+  {
+    "_id": "f1d2c3b4-a5e6-0789-abcd-ef0123456789",
+    "abstract": "We present a method for ancestral sequence reconstruction that scales to large protein families.",
+    "author": [
+      {
+        "first": "Sebastian",
+        "last": "Prillo",
+        "initials": "S",
+        "formatted": "Prillo S"
+      }
+    ],
+    "booktitle": "The Thirty-eighth Annual Conference on Neural Information Processing Systems",
+    "citekey": "Prillo2024-bn",
+    "doi": "10.5555/prillo2024",
+    "incomplete": 0,
+    "labels": [],
+    "owner": "4C91C6462CF411E3AEA40CBD9AB9BFFD",
+    "published": {
+      "year": "2024"
+    },
+    "pubtype": "PP_CONFERENCE_PAPER",
+    "title": "Scalable ancestral sequence reconstruction",
+    "url": [
+      "https://example.org/prillo2024"
+    ]
   }
 ]


### PR DESCRIPTION
🤖 ## Summary

- The Paperpile importer read the venue only from the `journal` key, so conference papers (`pubtype: "PP_CONFERENCE_PAPER"`) — which carry an empty `journal` and the venue in a separate `booktitle` key — imported with `venue: ""`.
- Added `Booktitle string \`json:"booktitle"\`` to `PaperpileEntry` and set the venue to `journal`, falling back to `booktitle` when `journal` is empty (inline, single call site). Journal still wins when both are present, so existing journal-based entries are unchanged.
- No BibTeX-export change needed: `determineEntryType` already emits `@inproceedings`/`booktitle` when the venue contains "conference"/"proceedings"/"workshop"/"symposium", and the NeurIPS venue string contains "Conference".

## Test plan

- New `TestParsePaperpile_Venue` covers the three cases: conference (empty journal, populated booktitle) → `Venue == booktitle`; both present → `Venue == journal`; neither → `Venue == ""`.
- Added a `PP_CONFERENCE_PAPER` fixture (`Prillo2024-bn`) to `testdata/paperpile_sample.json`, exercised by the existing `TestParsePaperpile_RealTestData`.
- `go test ./internal/importer/...` passes; `go fmt`, `go vet`, and `go build` clean.

Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)