### PR TITLE
Add --model flag to bip spawn

### DIFF
--- a/cmd/bip/spawn.go
+++ b/cmd/bip/spawn.go
@@ -42,6 +42,7 @@ var spawnPrompt string
 var spawnPromptFile string
 var spawnDir string
 var spawnName string
+var spawnModel string
 
 func init() {
 	rootCmd.AddCommand(spawnCmd)
@@ -49,6 +50,7 @@ func init() {
 	spawnCmd.Flags().StringVar(&spawnPromptFile, "prompt-file", "", "Read prompt from file (avoids shell expansion issues)")
 	spawnCmd.Flags().StringVar(&spawnDir, "dir", "", "Working directory override (default: from sources.yml)")
 	spawnCmd.Flags().StringVar(&spawnName, "name", "", "Tmux window name override (default: repo#N)")
+	spawnCmd.Flags().StringVar(&spawnModel, "model", "", "Model to pass to the claude launcher (default: unspecified)")
 }
 
 func resolvePrompt() string {
@@ -219,7 +221,7 @@ func runSpawn(cmd *cobra.Command, args []string) {
 
 	// Create tmux window
 	url := flow.GitHubURL(ref.Repo, ref.Number, itemType)
-	spawnWindow(windowName, repoPath, prompt, url)
+	spawnWindow(windowName, repoPath, prompt, url, spawnModel)
 
 	// Print URL as last line for easy clicking
 	fmt.Println(url)
@@ -242,7 +244,7 @@ func runAdhocSpawn() {
 		}
 	}
 	fmt.Printf("Spawning tmux window %s...\n", windowName)
-	spawnWindow(windowName, workDir, spawnPrompt, "")
+	spawnWindow(windowName, workDir, spawnPrompt, "", spawnModel)
 }
 
 func mustValidateDir(dir string) string {
@@ -264,7 +266,7 @@ func mustValidateDir(dir string) string {
 }
 
 // spawnWindow validates tmux, checks for duplicates, and creates the window.
-func spawnWindow(windowName, workDir, prompt, url string) {
+func spawnWindow(windowName, workDir, prompt, url, model string) {
 	if !spawn.IsInTmux() {
 		fmt.Fprintf(os.Stderr, "Error: Must be running inside tmux\n")
 		os.Exit(1)
@@ -275,7 +277,7 @@ func spawnWindow(windowName, workDir, prompt, url string) {
 		return
 	}
 
-	if err := spawn.CreateWindow(windowName, workDir, prompt, url); err != nil {
+	if err := spawn.CreateWindow(windowName, workDir, prompt, url, model); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}

--- a/internal/flow/spawn/tmux.go
+++ b/internal/flow/spawn/tmux.go
@@ -32,7 +32,8 @@ func WindowExists(windowName string) bool {
 }
 
 // CreateWindow creates a tmux window and runs Claude Code with the given prompt.
-func CreateWindow(windowName, repoPath, prompt, url string) error {
+// model, if non-empty, is passed through as claude's --model flag.
+func CreateWindow(windowName, repoPath, prompt, url, model string) error {
 	// Write prompt to temp file
 	promptFile, err := os.CreateTemp("", fmt.Sprintf("review-%s-*.txt", windowName))
 	if err != nil {
@@ -60,13 +61,14 @@ func CreateWindow(windowName, repoPath, prompt, url string) error {
 	if url != "" {
 		urlLine = fmt.Sprintf("echo '%s'\necho ''\n", url)
 	}
+	claudeInvocation := buildClaudeInvocation(model)
 	launcherContent := fmt.Sprintf(`#!/bin/bash
 %scat '%s'
 echo '---'
 prompt=$(<'%s')
 rm -f '%s' '%s'
-claude --dangerously-skip-permissions "$prompt"
-`, urlLine, promptPath, promptPath, promptPath, launcherPath)
+%s
+`, urlLine, promptPath, promptPath, promptPath, launcherPath, claudeInvocation)
 
 	if _, err := launcherFile.WriteString(launcherContent); err != nil {
 		os.Remove(promptPath)
@@ -104,6 +106,16 @@ claude --dangerously-skip-permissions "$prompt"
 	}
 
 	return nil
+}
+
+// buildClaudeInvocation returns the shell command that launches claude, with
+// --model injected only when model is non-empty. Empty model must produce a
+// byte-identical command to the pre-existing behavior.
+func buildClaudeInvocation(model string) string {
+	if model == "" {
+		return `claude --dangerously-skip-permissions "$prompt"`
+	}
+	return fmt.Sprintf(`claude --dangerously-skip-permissions --model '%s' "$prompt"`, model)
 }
 
 // BuildWindowName creates a window name from repo and number.

--- a/internal/flow/spawn/tmux_test.go
+++ b/internal/flow/spawn/tmux_test.go
@@ -50,3 +50,31 @@ func TestIsInTmux(t *testing.T) {
 	// The actual result depends on the test environment.
 	_ = IsInTmux()
 }
+
+func TestBuildClaudeInvocation(t *testing.T) {
+	tests := []struct {
+		name  string
+		model string
+		want  string
+	}{
+		{
+			name:  "empty model is unchanged from pre-existing behavior",
+			model: "",
+			want:  `claude --dangerously-skip-permissions "$prompt"`,
+		},
+		{
+			name:  "model is passed through as --model",
+			model: "opus",
+			want:  `claude --dangerously-skip-permissions --model 'opus' "$prompt"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildClaudeInvocation(tt.model)
+			if got != tt.want {
+				t.Errorf("buildClaudeInvocation(%q) = %q, want %q", tt.model, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
🤖
## Summary
- Adds a `--model` string flag to `bip spawn`, threaded through both `spawnWindow` call sites (`runSpawn` and `runAdhocSpawn`) into `spawn.CreateWindow`.
- The launcher script emits `claude --dangerously-skip-permissions --model '<name>' "$prompt"` when `--model` is set, and the unchanged `claude --dangerously-skip-permissions "$prompt"` when it's omitted.
- This overrides the org's `orgModelDefaultCache.override_user_selection` policy that forces spawned sessions onto Sonnet 5 regardless of user config.

## Test plan
- `go build`, `go vet`, `go test ./...` all pass.
- Added `TestBuildClaudeInvocation` covering both the empty-model (byte-identical to prior behavior) and model-set cases.

Closes #174