### PR TITLE
bip search: surface truncation, rank by relevance, --limit 0 unlimited

### DIFF
--- a/cmd/bip/search.go
+++ b/cmd/bip/search.go
@@ -32,7 +32,7 @@ func hasAnyFilterFlags() bool {
 }
 
 func init() {
-	searchCmd.Flags().IntVar(&searchLimit, "limit", DefaultSearchLimit, "Maximum results to return")
+	searchCmd.Flags().IntVar(&searchLimit, "limit", DefaultSearchLimit, "Maximum results to return (0 or -1 for unlimited)")
 	searchCmd.Flags().StringArrayVarP(&searchAuthors, "author", "a", nil, "Search by author name (can be repeated, uses AND logic)")
 	searchCmd.Flags().StringVar(&searchYear, "year", "", "Filter by year: exact (2024), range (2020:2024), or open (2020: or :2024)")
 	searchCmd.Flags().StringVarP(&searchTitle, "title", "t", "", "Search in title only")
@@ -52,6 +52,13 @@ Query Syntax (positional argument):
   author:name    - Search author names only (legacy syntax)
   title:text     - Search title only
 
+Plain-text matching is exact-token (AND logic) and unstemmed: "germinal
+center" will not match a title containing only "germinal centers". Try
+--author or --doi for a definitive check before concluding a paper is
+absent from the library.
+
+Results are ranked by relevance (best match first), not alphabetically.
+
 Flags:
   --author, -a   - Search by author (repeatable, AND logic, exact last name)
   --title, -t    - Search in title only
@@ -59,6 +66,7 @@ Flags:
   --venue        - Filter by venue/journal (partial match)
   --doi          - Lookup by exact DOI
   --tag          - Filter by tag/label (partial match)
+  --limit        - Maximum results to return (default 50; 0 or -1 for unlimited)
 
 Author matching uses exact last name matching to avoid false positives:
   -a "Yu"           - Matches last name "Yu" exactly (not "Yujia")
@@ -90,6 +98,7 @@ func runSearch(cmd *cobra.Command, args []string) error {
 	defer db.Close()
 
 	var refs []reference.Reference
+	var total int
 	var err error
 
 	// Check if using flag-based search
@@ -117,7 +126,7 @@ func runSearch(cmd *cobra.Command, args []string) error {
 			filters.YearTo = to
 		}
 
-		refs, err = db.SearchWithFilters(filters, searchLimit)
+		refs, total, err = db.SearchWithFilters(filters, searchLimit)
 	} else if len(args) > 0 {
 		// Legacy behavior: positional query argument
 		query := args[0]
@@ -125,12 +134,12 @@ func runSearch(cmd *cobra.Command, args []string) error {
 		// Check for field-specific searches (legacy syntax)
 		if strings.HasPrefix(query, "author:") {
 			value := strings.TrimPrefix(query, "author:")
-			refs, err = db.SearchField("author", value, searchLimit)
+			refs, total, err = db.SearchField("author", value, searchLimit)
 		} else if strings.HasPrefix(query, "title:") {
 			value := strings.TrimPrefix(query, "title:")
-			refs, err = db.SearchField("title", value, searchLimit)
+			refs, total, err = db.SearchField("title", value, searchLimit)
 		} else {
-			refs, err = db.Search(query, searchLimit)
+			refs, total, err = db.Search(query, searchLimit)
 		}
 	} else {
 		exitWithError(ExitError, "must specify a query or at least one filter (--author, --year)")
@@ -148,6 +157,11 @@ func runSearch(cmd *cobra.Command, args []string) error {
 	if humanOutput {
 		if len(refs) == 0 {
 			fmt.Println("No references found")
+		} else if len(refs) < total {
+			fmt.Printf("Found %d references (showing %d; use --limit to see more):\n\n", total, len(refs))
+			for i, ref := range refs {
+				printRefSummary(i+1, ref)
+			}
 		} else {
 			fmt.Printf("Found %d references:\n\n", len(refs))
 			for i, ref := range refs {

--- a/cmd/bip/search.go
+++ b/cmd/bip/search.go
@@ -20,6 +20,13 @@ var (
 	searchTag     string
 )
 
+// SearchResult is the --json shape for `bip search`. Total may exceed
+// len(References) when the result was truncated by --limit.
+type SearchResult struct {
+	References []reference.Reference `json:"references"`
+	Total      int                   `json:"total"`
+}
+
 // hasAnyFilterFlags returns true if any field-specific search flags were provided.
 // This determines whether to use the new flag-based search or legacy positional query.
 func hasAnyFilterFlags() bool {
@@ -157,19 +164,18 @@ func runSearch(cmd *cobra.Command, args []string) error {
 	if humanOutput {
 		if len(refs) == 0 {
 			fmt.Println("No references found")
-		} else if len(refs) < total {
-			fmt.Printf("Found %d references (showing %d; use --limit to see more):\n\n", total, len(refs))
-			for i, ref := range refs {
-				printRefSummary(i+1, ref)
-			}
 		} else {
-			fmt.Printf("Found %d references:\n\n", len(refs))
+			if len(refs) < total {
+				fmt.Printf("Found %d references (showing %d; use --limit to see more):\n\n", total, len(refs))
+			} else {
+				fmt.Printf("Found %d references:\n\n", len(refs))
+			}
 			for i, ref := range refs {
 				printRefSummary(i+1, ref)
 			}
 		}
 	} else {
-		outputJSON(refs)
+		outputJSON(SearchResult{References: refs, Total: total})
 	}
 
 	return nil

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -24,13 +24,33 @@ const selectRefFields = `id, doi, title, abstract, venue,
 	authors_json, supplement_paths_json,
 	pmid, pmcid, arxiv_id, s2_id, notes, tags_json`
 
-// bm25Weights assigns per-column relevance weight for ranking FTS matches,
-// in refs_fts column order (id, title, abstract, authors_text, pub_year,
-// notes, tags_text). A title match is the strongest relevance signal, so it
-// is weighted well above an incidental hit in the abstract or notes; id and
-// pub_year are excluded from the FTS query itself but still need a weight
-// entry per bm25()'s column-count requirement.
-const bm25Weights = "0.0, 10.0, 2.0, 4.0, 0.0, 1.0, 2.0"
+// Per-column relevance weights for ranking FTS matches, in refs_fts column
+// order (id, title, abstract, authors_text, pub_year, notes, tags_text). A
+// title match is the strongest relevance signal, so it is weighted well
+// above an incidental hit in the abstract or notes; id and pub_year are
+// excluded from the FTS query itself but still need a weight entry per
+// bm25()'s column-count requirement.
+const (
+	bm25WeightID       = 0.0
+	bm25WeightTitle    = 10.0
+	bm25WeightAbstract = 2.0
+	bm25WeightAuthors  = 4.0
+	bm25WeightPubYear  = 0.0
+	bm25WeightNotes    = 1.0
+	bm25WeightTags     = 2.0
+)
+
+// bm25Weights is the comma-separated weight list bm25() expects, built from
+// the named constants above so the column order stays traceable to the
+// refs_fts schema (createSchema) rather than a bare literal.
+var bm25Weights = fmt.Sprintf("%g, %g, %g, %g, %g, %g, %g",
+	bm25WeightID, bm25WeightTitle, bm25WeightAbstract, bm25WeightAuthors,
+	bm25WeightPubYear, bm25WeightNotes, bm25WeightTags)
+
+// ftsRankJoin joins refs to their bm25 relevance rank for a `refs_fts MATCH
+// ?` query. Shared by Search, SearchField, and SearchWithFilters so the
+// ranking expression only needs to change in one place.
+var ftsRankJoin = "JOIN (SELECT id AS mid, bm25(refs_fts, " + bm25Weights + ") AS rank FROM refs_fts WHERE refs_fts MATCH ?) m ON m.mid = refs.id"
 
 // OpenDB opens or creates a SQLite database at the given path.
 func OpenDB(path string) (*DB, error) {
@@ -230,7 +250,7 @@ func (d *DB) Search(query string, limit int) ([]reference.Reference, int, error)
 	rows, err := d.db.Query(`
 		SELECT `+selectRefFields+`
 		FROM refs
-		JOIN (SELECT id AS mid, bm25(refs_fts, `+bm25Weights+`) AS rank FROM refs_fts WHERE refs_fts MATCH ?) m ON m.mid = refs.id
+		`+ftsRankJoin+`
 		ORDER BY m.rank`, ftsQuery)
 	if err != nil {
 		return nil, 0, fmt.Errorf("searching: %w", err)
@@ -241,8 +261,8 @@ func (d *DB) Search(query string, limit int) ([]reference.Reference, int, error)
 	if err != nil {
 		return nil, 0, err
 	}
-	total := len(refs)
-	return limitRefs(refs, limit), total, nil
+	truncated, total := splitByLimit(refs, limit)
+	return truncated, total, nil
 }
 
 // SearchField performs a search on a specific field, ranked by relevance.
@@ -262,7 +282,7 @@ func (d *DB) SearchField(field, value string, limit int) ([]reference.Reference,
 	rows, err := d.db.Query(`
 		SELECT `+selectRefFields+`
 		FROM refs
-		JOIN (SELECT id AS mid, bm25(refs_fts, `+bm25Weights+`) AS rank FROM refs_fts WHERE refs_fts MATCH ?) m ON m.mid = refs.id
+		`+ftsRankJoin+`
 		ORDER BY m.rank
 	`, ftsQuery)
 	if err != nil {
@@ -274,8 +294,8 @@ func (d *DB) SearchField(field, value string, limit int) ([]reference.Reference,
 	if err != nil {
 		return nil, 0, err
 	}
-	total := len(refs)
-	return limitRefs(refs, limit), total, nil
+	truncated, total := splitByLimit(refs, limit)
+	return truncated, total, nil
 }
 
 // limitRefs returns refs truncated to limit entries. limit <= 0 means unlimited.
@@ -284,6 +304,12 @@ func limitRefs(refs []reference.Reference, limit int) []reference.Reference {
 		return refs
 	}
 	return refs[:limit]
+}
+
+// splitByLimit truncates refs to limit entries and reports the total match
+// count before truncation. limit <= 0 means unlimited.
+func splitByLimit(refs []reference.Reference, limit int) ([]reference.Reference, int) {
+	return limitRefs(refs, limit), len(refs)
 }
 
 // SearchFilters contains optional filters for SearchWithFilters.
@@ -317,10 +343,6 @@ type SearchFilters struct {
 // Author filtering uses exact last name matching to avoid false positives.
 // For example, -a "Yu" matches "Timothy Yu" but not "Yujia Chan".
 func (d *DB) SearchWithFilters(filters SearchFilters, limit int) ([]reference.Reference, int, error) {
-	var ftsTerms []string
-	var sqlConditions []string
-	var args []interface{}
-
 	// Parse author queries upfront for post-filtering
 	var authorQueries []author.Query
 	for _, a := range filters.Authors {
@@ -328,6 +350,36 @@ func (d *DB) SearchWithFilters(filters SearchFilters, limit int) ([]reference.Re
 			authorQueries = append(authorQueries, author.ParseQuery(a))
 		}
 	}
+
+	query, args := buildFiltersQuery(filters, authorQueries)
+
+	rows, err := d.db.Query(query, args...)
+	if err != nil {
+		return nil, 0, fmt.Errorf("searching with filters: %w", err)
+	}
+	defer rows.Close()
+
+	refs, err := scanReferences(rows)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	// Post-filter by authors for case-insensitive matching and first name prefixes
+	if len(authorQueries) > 0 {
+		refs = filterByAuthors(refs, authorQueries)
+	}
+
+	truncated, total := splitByLimit(refs, limit)
+	return truncated, total, nil
+}
+
+// buildFiltersQuery assembles the SQL query and args for SearchWithFilters
+// from filters and its pre-parsed author queries. Ranked by bm25 relevance
+// when a keyword/title FTS term is present, else by id.
+func buildFiltersQuery(filters SearchFilters, authorQueries []author.Query) (string, []interface{}) {
+	var ftsTerms []string
+	var sqlConditions []string
+	var args []interface{}
 
 	// Build FTS query parts (keyword and title searches)
 	if filters.Keyword != "" {
@@ -355,7 +407,7 @@ func (d *DB) SearchWithFilters(filters SearchFilters, limit int) ([]reference.Re
 		ftsQuery := strings.Join(ftsTerms, " AND ")
 		query = `SELECT ` + selectRefFields + `
 			FROM refs
-			JOIN (SELECT id AS mid, bm25(refs_fts, ` + bm25Weights + `) AS rank FROM refs_fts WHERE refs_fts MATCH ?) m ON m.mid = refs.id
+			` + ftsRankJoin + `
 			WHERE 1=1`
 		args = append([]interface{}{ftsQuery}, args...) // FTS arg must be first
 	} else {
@@ -395,24 +447,7 @@ func (d *DB) SearchWithFilters(filters SearchFilters, limit int) ([]reference.Re
 		query += " ORDER BY id"
 	}
 
-	rows, err := d.db.Query(query, args...)
-	if err != nil {
-		return nil, 0, fmt.Errorf("searching with filters: %w", err)
-	}
-	defer rows.Close()
-
-	refs, err := scanReferences(rows)
-	if err != nil {
-		return nil, 0, err
-	}
-
-	// Post-filter by authors for case-insensitive matching and first name prefixes
-	if len(authorQueries) > 0 {
-		refs = filterByAuthors(refs, authorQueries)
-	}
-
-	total := len(refs)
-	return limitRefs(refs, limit), total, nil
+	return query, args
 }
 
 // filterByAuthors filters references to those matching all author queries.

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -24,6 +24,14 @@ const selectRefFields = `id, doi, title, abstract, venue,
 	authors_json, supplement_paths_json,
 	pmid, pmcid, arxiv_id, s2_id, notes, tags_json`
 
+// bm25Weights assigns per-column relevance weight for ranking FTS matches,
+// in refs_fts column order (id, title, abstract, authors_text, pub_year,
+// notes, tags_text). A title match is the strongest relevance signal, so it
+// is weighted well above an incidental hit in the abstract or notes; id and
+// pub_year are excluded from the FTS query itself but still need a weight
+// entry per bm25()'s column-count requirement.
+const bm25Weights = "0.0, 10.0, 2.0, 4.0, 0.0, 1.0, 2.0"
+
 // OpenDB opens or creates a SQLite database at the given path.
 func OpenDB(path string) (*DB, error) {
 	db, err := sql.Open("sqlite", path)
@@ -222,7 +230,7 @@ func (d *DB) Search(query string, limit int) ([]reference.Reference, int, error)
 	rows, err := d.db.Query(`
 		SELECT `+selectRefFields+`
 		FROM refs
-		JOIN (SELECT id AS mid, bm25(refs_fts) AS rank FROM refs_fts WHERE refs_fts MATCH ?) m ON m.mid = refs.id
+		JOIN (SELECT id AS mid, bm25(refs_fts, `+bm25Weights+`) AS rank FROM refs_fts WHERE refs_fts MATCH ?) m ON m.mid = refs.id
 		ORDER BY m.rank`, ftsQuery)
 	if err != nil {
 		return nil, 0, fmt.Errorf("searching: %w", err)
@@ -254,7 +262,7 @@ func (d *DB) SearchField(field, value string, limit int) ([]reference.Reference,
 	rows, err := d.db.Query(`
 		SELECT `+selectRefFields+`
 		FROM refs
-		JOIN (SELECT id AS mid, bm25(refs_fts) AS rank FROM refs_fts WHERE refs_fts MATCH ?) m ON m.mid = refs.id
+		JOIN (SELECT id AS mid, bm25(refs_fts, `+bm25Weights+`) AS rank FROM refs_fts WHERE refs_fts MATCH ?) m ON m.mid = refs.id
 		ORDER BY m.rank
 	`, ftsQuery)
 	if err != nil {
@@ -347,7 +355,7 @@ func (d *DB) SearchWithFilters(filters SearchFilters, limit int) ([]reference.Re
 		ftsQuery := strings.Join(ftsTerms, " AND ")
 		query = `SELECT ` + selectRefFields + `
 			FROM refs
-			JOIN (SELECT id AS mid, bm25(refs_fts) AS rank FROM refs_fts WHERE refs_fts MATCH ?) m ON m.mid = refs.id
+			JOIN (SELECT id AS mid, bm25(refs_fts, ` + bm25Weights + `) AS rank FROM refs_fts WHERE refs_fts MATCH ?) m ON m.mid = refs.id
 			WHERE 1=1`
 		args = append([]interface{}{ftsQuery}, args...) // FTS arg must be first
 	} else {

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -211,26 +211,35 @@ func (d *DB) GetByID(id string) (*reference.Reference, error) {
 	return scanReference(row)
 }
 
-// Search performs a full-text search and returns matching references.
-func (d *DB) Search(query string, limit int) ([]reference.Reference, error) {
+// Search performs a full-text search, ranked by relevance (FTS5 bm25), and
+// returns matching references. limit caps the returned slice; limit <= 0
+// means unlimited. The second return value is the total number of matches,
+// which may exceed len(refs) when the result was truncated by limit.
+func (d *DB) Search(query string, limit int) ([]reference.Reference, int, error) {
 	// Escape special FTS5 characters and prepare query
 	ftsQuery := prepareFTSQuery(query)
 
 	rows, err := d.db.Query(`
 		SELECT `+selectRefFields+`
 		FROM refs
-		WHERE id IN (SELECT id FROM refs_fts WHERE refs_fts MATCH ?)
-		LIMIT ?`, ftsQuery, limit)
+		JOIN (SELECT id AS mid, bm25(refs_fts) AS rank FROM refs_fts WHERE refs_fts MATCH ?) m ON m.mid = refs.id
+		ORDER BY m.rank`, ftsQuery)
 	if err != nil {
-		return nil, fmt.Errorf("searching: %w", err)
+		return nil, 0, fmt.Errorf("searching: %w", err)
 	}
 	defer rows.Close()
 
-	return scanReferences(rows)
+	refs, err := scanReferences(rows)
+	if err != nil {
+		return nil, 0, err
+	}
+	total := len(refs)
+	return limitRefs(refs, limit), total, nil
 }
 
-// SearchField performs a search on a specific field.
-func (d *DB) SearchField(field, value string, limit int) ([]reference.Reference, error) {
+// SearchField performs a search on a specific field, ranked by relevance.
+// limit <= 0 means unlimited; the second return value is the total match count.
+func (d *DB) SearchField(field, value string, limit int) ([]reference.Reference, int, error) {
 	var ftsQuery string
 
 	switch field {
@@ -239,21 +248,34 @@ func (d *DB) SearchField(field, value string, limit int) ([]reference.Reference,
 	case "title":
 		ftsQuery = "title:" + prepareFTSQuery(value)
 	default:
-		return nil, fmt.Errorf("unknown search field: %s", field)
+		return nil, 0, fmt.Errorf("unknown search field: %s", field)
 	}
 
 	rows, err := d.db.Query(`
 		SELECT `+selectRefFields+`
 		FROM refs
-		WHERE id IN (SELECT id FROM refs_fts WHERE refs_fts MATCH ?)
-		LIMIT ?
-	`, ftsQuery, limit)
+		JOIN (SELECT id AS mid, bm25(refs_fts) AS rank FROM refs_fts WHERE refs_fts MATCH ?) m ON m.mid = refs.id
+		ORDER BY m.rank
+	`, ftsQuery)
 	if err != nil {
-		return nil, fmt.Errorf("searching %s: %w", field, err)
+		return nil, 0, fmt.Errorf("searching %s: %w", field, err)
 	}
 	defer rows.Close()
 
-	return scanReferences(rows)
+	refs, err := scanReferences(rows)
+	if err != nil {
+		return nil, 0, err
+	}
+	total := len(refs)
+	return limitRefs(refs, limit), total, nil
+}
+
+// limitRefs returns refs truncated to limit entries. limit <= 0 means unlimited.
+func limitRefs(refs []reference.Reference, limit int) []reference.Reference {
+	if limit <= 0 || limit >= len(refs) {
+		return refs
+	}
+	return refs[:limit]
 }
 
 // SearchFilters contains optional filters for SearchWithFilters.
@@ -279,11 +301,14 @@ type SearchFilters struct {
 }
 
 // SearchWithFilters performs a search with multiple optional filters.
-// Returns references matching ALL specified criteria (AND logic).
+// Returns references matching ALL specified criteria (AND logic), ranked by
+// relevance when a keyword/title FTS term is present. limit <= 0 means
+// unlimited; the second return value is the total number of matches, which
+// may exceed len(refs) when the result was truncated by limit.
 //
 // Author filtering uses exact last name matching to avoid false positives.
 // For example, -a "Yu" matches "Timothy Yu" but not "Yujia Chan".
-func (d *DB) SearchWithFilters(filters SearchFilters, limit int) ([]reference.Reference, error) {
+func (d *DB) SearchWithFilters(filters SearchFilters, limit int) ([]reference.Reference, int, error) {
 	var ftsTerms []string
 	var sqlConditions []string
 	var args []interface{}
@@ -317,11 +342,13 @@ func (d *DB) SearchWithFilters(filters SearchFilters, limit int) ([]reference.Re
 
 	// Build the query
 	var query string
-	if len(ftsTerms) > 0 {
+	hasFTS := len(ftsTerms) > 0
+	if hasFTS {
 		ftsQuery := strings.Join(ftsTerms, " AND ")
 		query = `SELECT ` + selectRefFields + `
 			FROM refs
-			WHERE id IN (SELECT id FROM refs_fts WHERE refs_fts MATCH ?)`
+			JOIN (SELECT id AS mid, bm25(refs_fts) AS rank FROM refs_fts WHERE refs_fts MATCH ?) m ON m.mid = refs.id
+			WHERE 1=1`
 		args = append([]interface{}{ftsQuery}, args...) // FTS arg must be first
 	} else {
 		query = `SELECT ` + selectRefFields + ` FROM refs WHERE 1=1`
@@ -354,37 +381,38 @@ func (d *DB) SearchWithFilters(filters SearchFilters, limit int) ([]reference.Re
 		args = append(args, "%"+filters.Tag+"%")
 	}
 
-	query += " LIMIT ?"
-	args = append(args, limit)
+	if hasFTS {
+		query += " ORDER BY m.rank"
+	} else {
+		query += " ORDER BY id"
+	}
 
 	rows, err := d.db.Query(query, args...)
 	if err != nil {
-		return nil, fmt.Errorf("searching with filters: %w", err)
+		return nil, 0, fmt.Errorf("searching with filters: %w", err)
 	}
 	defer rows.Close()
 
 	refs, err := scanReferences(rows)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	// Post-filter by authors for case-insensitive matching and first name prefixes
 	if len(authorQueries) > 0 {
-		refs = filterByAuthors(refs, authorQueries, limit)
+		refs = filterByAuthors(refs, authorQueries)
 	}
 
-	return refs, nil
+	total := len(refs)
+	return limitRefs(refs, limit), total, nil
 }
 
 // filterByAuthors filters references to those matching all author queries.
-func filterByAuthors(refs []reference.Reference, queries []author.Query, limit int) []reference.Reference {
+func filterByAuthors(refs []reference.Reference, queries []author.Query) []reference.Reference {
 	var result []reference.Reference
 	for _, ref := range refs {
 		if author.AllMatch(queries, ref.Authors) {
 			result = append(result, ref)
-			if len(result) >= limit {
-				break
-			}
 		}
 	}
 	return result

--- a/internal/storage/sqlite_test.go
+++ b/internal/storage/sqlite_test.go
@@ -90,6 +90,33 @@ func setupTestDB(t *testing.T) (*DB, string, func()) {
 	return db, tmpDir, cleanup
 }
 
+// setupDBWithRefs creates a test database from the given references,
+// bypassing setupTestDB's fixed 3-ref fixture for tests that need a larger
+// or differently-shaped synthetic corpus.
+func setupDBWithRefs(t *testing.T, refs []reference.Reference) (*DB, func()) {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.db")
+	jsonlPath := filepath.Join(tmpDir, "refs.jsonl")
+
+	if err := WriteAll(jsonlPath, refs); err != nil {
+		t.Fatalf("WriteAll() error = %v", err)
+	}
+
+	db, err := OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB() error = %v", err)
+	}
+
+	if _, err := db.RebuildFromJSONL(jsonlPath); err != nil {
+		db.Close()
+		t.Fatalf("RebuildFromJSONL() error = %v", err)
+	}
+
+	return db, func() { db.Close() }
+}
+
 func TestOpenDB_CreatesSchema(t *testing.T) {
 	tmpDir := t.TempDir()
 	dbPath := filepath.Join(tmpDir, "test.db")
@@ -592,10 +619,6 @@ func TestDB_SearchWithFilters(t *testing.T) {
 // author-only searches would miss results because the query used an arbitrary
 // LIMIT before filtering by author.
 func TestDB_SearchWithFilters_LargeDB(t *testing.T) {
-	tmpDir := t.TempDir()
-	dbPath := filepath.Join(tmpDir, "test.db")
-	jsonlPath := filepath.Join(tmpDir, "refs.jsonl")
-
 	// Create 150 refs with common authors, plus a few with a rare author
 	var refs []reference.Reference
 	for i := 0; i < 150; i++ {
@@ -618,19 +641,8 @@ func TestDB_SearchWithFilters_LargeDB(t *testing.T) {
 		})
 	}
 
-	if err := WriteAll(jsonlPath, refs); err != nil {
-		t.Fatalf("WriteAll() error = %v", err)
-	}
-
-	db, err := OpenDB(dbPath)
-	if err != nil {
-		t.Fatalf("OpenDB() error = %v", err)
-	}
-	defer db.Close()
-
-	if _, err := db.RebuildFromJSONL(jsonlPath); err != nil {
-		t.Fatalf("RebuildFromJSONL() error = %v", err)
-	}
+	db, cleanup := setupDBWithRefs(t, refs)
+	defer cleanup()
 
 	// Search for rare author - should find all 5 papers
 	results, _, err := db.SearchWithFilters(SearchFilters{Authors: []string{"Rareauthor"}}, 50)
@@ -653,10 +665,6 @@ func TestDB_SearchWithFilters_LargeDB(t *testing.T) {
 // TestDB_Search_TotalAndUnlimited verifies truncation reporting (total vs.
 // len(refs)) and that limit <= 0 means unlimited, per issue #180.
 func TestDB_Search_TotalAndUnlimited(t *testing.T) {
-	tmpDir := t.TempDir()
-	dbPath := filepath.Join(tmpDir, "test.db")
-	jsonlPath := filepath.Join(tmpDir, "refs.jsonl")
-
 	// 60 refs share a common keyword so a default-ish limit truncates them.
 	var refs []reference.Reference
 	for i := 0; i < 60; i++ {
@@ -668,19 +676,8 @@ func TestDB_Search_TotalAndUnlimited(t *testing.T) {
 		})
 	}
 
-	if err := WriteAll(jsonlPath, refs); err != nil {
-		t.Fatalf("WriteAll() error = %v", err)
-	}
-
-	db, err := OpenDB(dbPath)
-	if err != nil {
-		t.Fatalf("OpenDB() error = %v", err)
-	}
-	defer db.Close()
-
-	if _, err := db.RebuildFromJSONL(jsonlPath); err != nil {
-		t.Fatalf("RebuildFromJSONL() error = %v", err)
-	}
+	db, cleanup := setupDBWithRefs(t, refs)
+	defer cleanup()
 
 	// Truncated: limit smaller than total match count.
 	results, total, err := db.Search("widgets", 10)

--- a/internal/storage/sqlite_test.go
+++ b/internal/storage/sqlite_test.go
@@ -257,7 +257,7 @@ func TestDB_Search_Notes(t *testing.T) {
 	defer cleanup()
 
 	// Search for text that only appears in notes
-	refs, err := db.Search("SONIA", 10)
+	refs, _, err := db.Search("SONIA", 10)
 	if err != nil {
 		t.Fatalf("Search() error = %v", err)
 	}
@@ -310,7 +310,7 @@ func TestDB_Search(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.query, func(t *testing.T) {
-			refs, err := db.Search(tt.query, tt.limit)
+			refs, _, err := db.Search(tt.query, tt.limit)
 			if err != nil {
 				t.Fatalf("Search() error = %v", err)
 			}
@@ -342,7 +342,7 @@ func TestDB_SearchField(t *testing.T) {
 	defer cleanup()
 
 	// Author search
-	refs, err := db.SearchField("author", "Smith", 10)
+	refs, _, err := db.SearchField("author", "Smith", 10)
 	if err != nil {
 		t.Fatalf("SearchField(author) error = %v", err)
 	}
@@ -351,7 +351,7 @@ func TestDB_SearchField(t *testing.T) {
 	}
 
 	// Title search
-	refs, err = db.SearchField("title", "Machine", 10)
+	refs, _, err = db.SearchField("title", "Machine", 10)
 	if err != nil {
 		t.Fatalf("SearchField(title) error = %v", err)
 	}
@@ -360,7 +360,7 @@ func TestDB_SearchField(t *testing.T) {
 	}
 
 	// Invalid field
-	_, err = db.SearchField("invalid", "test", 10)
+	_, _, err = db.SearchField("invalid", "test", 10)
 	if err == nil {
 		t.Error("SearchField(invalid) should return error")
 	}
@@ -557,7 +557,7 @@ func TestDB_SearchWithFilters(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			refs, err := db.SearchWithFilters(tt.filters, tt.limit)
+			refs, _, err := db.SearchWithFilters(tt.filters, tt.limit)
 			if err != nil {
 				t.Fatalf("SearchWithFilters() error = %v", err)
 			}
@@ -633,7 +633,7 @@ func TestDB_SearchWithFilters_LargeDB(t *testing.T) {
 	}
 
 	// Search for rare author - should find all 5 papers
-	results, err := db.SearchWithFilters(SearchFilters{Authors: []string{"Rareauthor"}}, 50)
+	results, _, err := db.SearchWithFilters(SearchFilters{Authors: []string{"Rareauthor"}}, 50)
 	if err != nil {
 		t.Fatalf("SearchWithFilters() error = %v", err)
 	}
@@ -647,6 +647,89 @@ func TestDB_SearchWithFilters_LargeDB(t *testing.T) {
 		if len(ref.Authors) == 0 || ref.Authors[0].Last != "Rareauthor" {
 			t.Errorf("Result %s has wrong author: %+v", ref.ID, ref.Authors)
 		}
+	}
+}
+
+// TestDB_Search_TotalAndUnlimited verifies truncation reporting (total vs.
+// len(refs)) and that limit <= 0 means unlimited, per issue #180.
+func TestDB_Search_TotalAndUnlimited(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.db")
+	jsonlPath := filepath.Join(tmpDir, "refs.jsonl")
+
+	// 60 refs share a common keyword so a default-ish limit truncates them.
+	var refs []reference.Reference
+	for i := 0; i < 60; i++ {
+		refs = append(refs, reference.Reference{
+			ID:        fmt.Sprintf("Common%03d", i),
+			Title:     fmt.Sprintf("Paper %d about widgets", i),
+			Published: reference.PublicationDate{Year: 2020},
+			Source:    reference.ImportSource{Type: "test"},
+		})
+	}
+
+	if err := WriteAll(jsonlPath, refs); err != nil {
+		t.Fatalf("WriteAll() error = %v", err)
+	}
+
+	db, err := OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB() error = %v", err)
+	}
+	defer db.Close()
+
+	if _, err := db.RebuildFromJSONL(jsonlPath); err != nil {
+		t.Fatalf("RebuildFromJSONL() error = %v", err)
+	}
+
+	// Truncated: limit smaller than total match count.
+	results, total, err := db.Search("widgets", 10)
+	if err != nil {
+		t.Fatalf("Search() error = %v", err)
+	}
+	if len(results) != 10 {
+		t.Errorf("Search(limit=10) returned %d results, want 10", len(results))
+	}
+	if total != 60 {
+		t.Errorf("Search(limit=10) total = %d, want 60", total)
+	}
+
+	// Unlimited via 0.
+	results, total, err = db.Search("widgets", 0)
+	if err != nil {
+		t.Fatalf("Search(limit=0) error = %v", err)
+	}
+	if len(results) != 60 || total != 60 {
+		t.Errorf("Search(limit=0) = %d results, total %d, want 60/60", len(results), total)
+	}
+
+	// Unlimited via -1 (documented alias).
+	results, total, err = db.Search("widgets", -1)
+	if err != nil {
+		t.Fatalf("Search(limit=-1) error = %v", err)
+	}
+	if len(results) != 60 || total != 60 {
+		t.Errorf("Search(limit=-1) = %d results, total %d, want 60/60", len(results), total)
+	}
+}
+
+// TestDB_Search_RelevanceOrder verifies results are ranked by relevance
+// (FTS5 bm25) rather than alphabetically by citation key, per issue #180.
+func TestDB_Search_RelevanceOrder(t *testing.T) {
+	db, _, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	refs, _, err := db.Search("machine learning", 10)
+	if err != nil {
+		t.Fatalf("Search() error = %v", err)
+	}
+	if len(refs) == 0 {
+		t.Fatal("Search(machine learning) returned no results")
+	}
+	// The exact title match should rank first, not wherever it falls
+	// alphabetically among the fixture's other IDs.
+	if refs[0].ID != "Smith2026-ab" {
+		t.Errorf("Search(machine learning)[0] = %s, want Smith2026-ab (best title match first)", refs[0].ID)
 	}
 }
 

--- a/skills/bip-lit/SKILL.md
+++ b/skills/bip-lit/SKILL.md
@@ -42,7 +42,14 @@ The nexus library has ~6000 papers. Most relevant papers are already there.
    ```
    Then use `mcp__pdf-navigator__search_pdf_text` (jump to the page) and `mcp__pdf-navigator__read_pdf_text` to find the answer directly in the paper. For a figure or equation you need to *see*, use the built-in `Read` tool on a narrow `pages` range instead. The PDF base path is `/Users/matsen/Google Drive/My Drive/Paperpile`.
 
-4. **Only if not found locally AND user confirms**, use ASTA:
+4. **Before concluding a paper is absent, try an exact-match check** —
+   `bip search -a "LastName"` or `bip search --doi "..."` — rather than another
+   keyword permutation. `bip search` reports when results are truncated
+   (`Found N references (showing M; ...)`), so a plain "not found" is
+   trustworthy, but a truncated keyword search on its own is not proof of
+   absence.
+
+5. **Only if not found locally AND user confirms**, use ASTA:
    ```
    "I couldn't find that paper in the local library. Would you like me to search Semantic Scholar (ASTA)?"
    ```
@@ -86,6 +93,8 @@ Suggest creating concepts when you notice:
 | Search by venue | `bip search --venue "Nature" --human` |
 | Lookup by DOI | `bip search --doi "10.1234/..." --human` |
 | Combined search | `bip search "topic" -a "Author" --year 2020: --human` |
+| Limit results | `bip search "topic" --limit 100 --human` (default 50, ranked by relevance) |
+| Unlimited results | `bip search "topic" --limit 0 --human` (`-1` also works) |
 | Semantic search | `bip semantic "query"` |
 | Get paper details | `bip get <id>` |
 | Export to BibTeX | `bip export --bibtex <id>...` |
@@ -134,7 +143,10 @@ bip search "deep mutational scanning" --author "Bloom" --year 2023:
 
 ### Query Formulation Tips
 
-**Keep queries short and specific** - Long conceptual queries perform poorly:
+**Keep queries short and specific** - long conceptual queries are a correctness
+hazard, not just slow: `bip search` uses exact-token AND matching, so one
+inflected or half-remembered word (e.g. plural vs. singular) can zero out an
+otherwise-matching query:
 - Bad: `"correlation between BME criterion and Felsenstein likelihood around correct tree"`
 - Good: `"BME Felsenstein likelihood phylogeny"` or `"Bruno WEIGHBOR likelihood"`
 


### PR DESCRIPTION
🤖

## Summary
`bip search` presented a silently-truncated, alphabetically-ordered result set as if complete, making a negative local search unreliable as an existence check (see #180 for the full repro). This closes both phases from the issue.

- Report `Found N references (showing M; use --limit to see more)` when `--limit` truncates the result, instead of a bare `Found M references:` that reads as complete.
- Rank results by FTS5 relevance (`bm25`) with per-column weights (title highest, then authors, then abstract/tags/notes) instead of alphabetically by citation key, for `Search`, `SearchField`, and the keyword/title terms in `SearchWithFilters`.
- `--limit 0` now means unlimited (matching the existing undocumented `-1` sentinel); both are documented in `--help`.
- Updated the `bip-lit` skill: a guardrail at the ASTA-escalation step (try `-a`/`--doi` before concluding absence), reframed the query-formulation tip as a correctness hazard rather than a speed tip, and added `--limit`/unlimited rows to the Quick Reference. Kept small per the issue's sizing guidance, since Phase 1 delivered both visible truncation and relevance ordering.

## Deferred
- Stemming/plural-insensitivity for plain-text matching (issue's optional item 4) — not implemented. Documented in `--help` instead that matching is exact-token and unstemmed, per the issue's stated fallback ("if not wanted, say plainly in --help"). A stemming tokenizer is a larger, separate change.

## Test plan
- `go test ./...` passes, including new tests: `TestDB_Search_TotalAndUnlimited` (truncation count + `0`/`-1` unlimited semantics) and `TestDB_Search_RelevanceOrder` (exact title match ranks first).
- Manually verified against the live library: `bip search "germinal centers" --human` now reports `Found 120 references (showing 50; use --limit to see more)` and `Roco2019-lc` moved from position #86 to #26 (both remaining results ahead of it are genuine title matches containing the exact query phrase). `--limit 0` and `--limit -1` both return all 120 with no truncation message. Spot-checked several other queries ("deep mutational scanning", "antibody affinity maturation", "WEIGHBOR") and in each case the top-ranked result is a genuine title match.

Closes #180