### PR TITLE
Fix duplicate detection: normalized DOIs, title grouping, importer dedup

### DIFF
--- a/cmd/bip/check.go
+++ b/cmd/bip/check.go
@@ -4,8 +4,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 
 	"github.com/matsen/bipartite/internal/config"
+	"github.com/matsen/bipartite/internal/reference"
+	"github.com/matsen/bipartite/internal/s2"
 	"github.com/matsen/bipartite/internal/storage"
 	"github.com/spf13/cobra"
 )
@@ -17,7 +20,7 @@ func init() {
 var checkCmd = &cobra.Command{
 	Use:   "check",
 	Short: "Verify repository integrity",
-	Long:  `Verify repository integrity, checking for missing PDFs and duplicate DOIs.`,
+	Long:  `Verify repository integrity, checking for missing PDFs and duplicate DOIs (normalized, case-insensitive).`,
 	RunE:  runCheck,
 }
 
@@ -40,6 +43,38 @@ type CheckIssue struct {
 	Reason   string   `json:"reason,omitempty"`
 }
 
+// findDuplicateDOIs groups references by normalized DOI and returns a
+// duplicate_doi issue for every DOI held by 2+ references. Issues are sorted
+// by DOI so output is stable across runs.
+func findDuplicateDOIs(refs []reference.Reference) []CheckIssue {
+	doiMap := make(map[string][]string) // normalized DOI -> list of IDs
+	for _, ref := range refs {
+		key := s2.NormalizeDOI(ref.DOI)
+		if key == "" {
+			continue
+		}
+		doiMap[key] = append(doiMap[key], ref.ID)
+	}
+
+	var dois []string
+	for doi, ids := range doiMap {
+		if len(ids) > 1 {
+			dois = append(dois, doi)
+		}
+	}
+	sort.Strings(dois)
+
+	issues := make([]CheckIssue, 0, len(dois))
+	for _, doi := range dois {
+		issues = append(issues, CheckIssue{
+			Type: "duplicate_doi",
+			IDs:  doiMap[doi],
+			DOI:  doi,
+		})
+	}
+	return issues
+}
+
 func runCheck(cmd *cobra.Command, args []string) error {
 	repoRoot := mustFindRepository()
 	cfg := mustLoadConfig(repoRoot)
@@ -54,21 +89,7 @@ func runCheck(cmd *cobra.Command, args []string) error {
 	var issues []CheckIssue
 
 	// Check for duplicate DOIs
-	doiMap := make(map[string][]string) // DOI -> list of IDs
-	for _, ref := range refs {
-		if ref.DOI != "" {
-			doiMap[ref.DOI] = append(doiMap[ref.DOI], ref.ID)
-		}
-	}
-	for doi, ids := range doiMap {
-		if len(ids) > 1 {
-			issues = append(issues, CheckIssue{
-				Type: "duplicate_doi",
-				IDs:  ids,
-				DOI:  doi,
-			})
-		}
-	}
+	issues = append(issues, findDuplicateDOIs(refs)...)
 
 	// Check for missing PDFs (only if pdf_root is configured)
 	if cfg.PDFRoot != "" {

--- a/cmd/bip/check_test.go
+++ b/cmd/bip/check_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/matsen/bipartite/internal/reference"
+)
+
+func TestFindDuplicateDOIs(t *testing.T) {
+	tests := []struct {
+		name       string
+		refs       []reference.Reference
+		wantGroups int
+		wantIDs    []string // IDs of the first (only) group, if wantGroups == 1
+	}{
+		{
+			name: "identical DOIs differing only in case are one group",
+			refs: []reference.Reference{
+				{ID: "A", DOI: "10.1093/molbev/msl010"},
+				{ID: "B", DOI: "10.1093/MOLBEV/MSL010"},
+			},
+			wantGroups: 1,
+			wantIDs:    []string{"A", "B"},
+		},
+		{
+			name: "genuinely different DOIs are not grouped",
+			refs: []reference.Reference{
+				{ID: "A", DOI: "10.1/aaa"},
+				{ID: "B", DOI: "10.1/bbb"},
+			},
+			wantGroups: 0,
+		},
+		{
+			name: "blank and prefix-only DOIs normalize to empty and are skipped",
+			refs: []reference.Reference{
+				{ID: "A", DOI: "  "},
+				{ID: "B", DOI: "DOI:"},
+				{ID: "C", DOI: ""},
+			},
+			wantGroups: 0,
+		},
+		{
+			name: "URL prefix and case variant normalize to the same DOI",
+			refs: []reference.Reference{
+				{ID: "A", DOI: "https://doi.org/10.1234/x"},
+				{ID: "B", DOI: "10.1234/X"},
+			},
+			wantGroups: 1,
+			wantIDs:    []string{"A", "B"},
+		},
+		{
+			name: "same DOI groups even when year and authors disagree",
+			refs: []reference.Reference{
+				{ID: "Unknown2004-fc", DOI: "10.1023/a:1017067816551", Published: reference.PublicationDate{Year: 2004}},
+				{ID: "Gerrish1998-bv", DOI: "10.1023/A:1017067816551", Published: reference.PublicationDate{Year: 1998}},
+			},
+			wantGroups: 1,
+			wantIDs:    []string{"Unknown2004-fc", "Gerrish1998-bv"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			issues := findDuplicateDOIs(tt.refs)
+			if len(issues) != tt.wantGroups {
+				t.Fatalf("got %d groups, want %d: %+v", len(issues), tt.wantGroups, issues)
+			}
+			if tt.wantGroups == 1 {
+				if len(issues[0].IDs) != len(tt.wantIDs) {
+					t.Fatalf("got IDs %v, want %v", issues[0].IDs, tt.wantIDs)
+				}
+				for i, id := range tt.wantIDs {
+					if issues[0].IDs[i] != id {
+						t.Errorf("IDs[%d] = %q, want %q", i, issues[0].IDs[i], id)
+					}
+				}
+			}
+		})
+	}
+}

--- a/cmd/bip/dedupe.go
+++ b/cmd/bip/dedupe.go
@@ -8,6 +8,7 @@ import (
 	"github.com/matsen/bipartite/internal/config"
 	"github.com/matsen/bipartite/internal/importer"
 	"github.com/matsen/bipartite/internal/reference"
+	"github.com/matsen/bipartite/internal/s2"
 	"github.com/matsen/bipartite/internal/storage"
 	"github.com/spf13/cobra"
 )
@@ -217,11 +218,13 @@ func findSourceIDGroups(refs []reference.Reference) []DuplicateGroup {
 
 // findTitleGroups finds references sharing a normalized title. Refs whose
 // normalized title is empty, or whose raw title is the unknown-title
-// sentinel, are skipped.
+// sentinel, are skipped. A group is suppressed entirely if `supersedes`
+// already connects every member (e.g. after `bip s2 link-published` has run)
+// — the relationship is already known, so re-reporting it is noise.
 func findTitleGroups(refs []reference.Reference) []DuplicateGroup {
-	titleMap := make(map[string][]string) // normalized title -> list of ref IDs
+	titleMap := make(map[string][]int) // normalized title -> ref indices
 
-	for _, ref := range refs {
+	for i, ref := range refs {
 		if ref.Title == importer.UnknownTitle {
 			continue
 		}
@@ -229,13 +232,20 @@ func findTitleGroups(refs []reference.Reference) []DuplicateGroup {
 		if key == "" {
 			continue
 		}
-		titleMap[key] = append(titleMap[key], ref.ID)
+		titleMap[key] = append(titleMap[key], i)
 	}
 
 	var groups []DuplicateGroup
-	for title, ids := range titleMap {
-		if len(ids) < 2 {
+	for title, idxs := range titleMap {
+		if len(idxs) < 2 {
 			continue
+		}
+		if allSupersedesConnected(refs, idxs) {
+			continue
+		}
+		ids := make([]string, len(idxs))
+		for i, idx := range idxs {
+			ids[i] = refs[idx].ID
 		}
 		groups = append(groups, DuplicateGroup{
 			MatchBasis: "title",
@@ -249,6 +259,54 @@ func findTitleGroups(refs []reference.Reference) []DuplicateGroup {
 	})
 
 	return groups
+}
+
+// allSupersedesConnected reports whether every member of idxs (indices into
+// refs) is connected to every other member via a chain of `supersedes` ->
+// DOI links, i.e. the relationship between all of them is already recorded
+// and there is nothing left for a human to resolve.
+func allSupersedesConnected(refs []reference.Reference, idxs []int) bool {
+	n := len(idxs)
+	parent := make([]int, n)
+	for i := range parent {
+		parent[i] = i
+	}
+	var find func(int) int
+	find = func(x int) int {
+		if parent[x] != x {
+			parent[x] = find(parent[x])
+		}
+		return parent[x]
+	}
+	union := func(a, b int) {
+		ra, rb := find(a), find(b)
+		if ra != rb {
+			parent[ra] = rb
+		}
+	}
+
+	doi := func(i int) string { return s2.NormalizeDOI(refs[idxs[i]].DOI) }
+	supersedes := func(i int) string { return s2.NormalizeDOI(refs[idxs[i]].Supersedes) }
+
+	for i := 0; i < n; i++ {
+		sup := supersedes(i)
+		if sup == "" {
+			continue
+		}
+		for j := 0; j < n; j++ {
+			if i != j && doi(j) == sup {
+				union(i, j)
+			}
+		}
+	}
+
+	root := find(0)
+	for i := 1; i < n; i++ {
+		if find(i) != root {
+			return false
+		}
+	}
+	return true
 }
 
 // performMerge removes duplicate references.

--- a/cmd/bip/dedupe.go
+++ b/cmd/bip/dedupe.go
@@ -2,8 +2,11 @@ package main
 
 import (
 	"fmt"
+	"sort"
+	"unicode"
 
 	"github.com/matsen/bipartite/internal/config"
+	"github.com/matsen/bipartite/internal/importer"
 	"github.com/matsen/bipartite/internal/reference"
 	"github.com/matsen/bipartite/internal/storage"
 	"github.com/spf13/cobra"
@@ -23,20 +26,29 @@ func init() {
 var dedupeCmd = &cobra.Command{
 	Use:   "dedupe",
 	Short: "Find and remove duplicate references",
-	Long: `Find and remove duplicate references by their import source ID.
+	Long: `Find duplicate references by import source ID, and report references
+that share a normalized title (a broader signal that includes source-ID
+duplicates plus other likely matches for human review).
+
+Only source-ID groups are actionable by --merge; title groups are reported
+for review and never merged automatically.
 
 Examples:
   bip dedupe --dry-run    # Show duplicates without making changes
-  bip dedupe --merge      # Merge duplicates: keep first, remove others`,
+  bip dedupe --merge      # Merge source-ID duplicates: keep first, remove others`,
 	RunE: runDedupe,
 }
 
-// DuplicateGroup represents a set of duplicate references.
+// DuplicateGroup represents a set of duplicate or likely-duplicate references.
+// MatchBasis is "source_id" (actionable by --merge) or "title" (report only).
 type DuplicateGroup struct {
-	SourceType string   `json:"source_type"`
-	SourceID   string   `json:"source_id"`
-	Primary    string   `json:"primary"`    // ID of the entry to keep
-	Duplicates []string `json:"duplicates"` // IDs of entries to remove
+	MatchBasis string   `json:"match_basis"`
+	SourceType string   `json:"source_type,omitempty"`
+	SourceID   string   `json:"source_id,omitempty"`
+	Primary    string   `json:"primary,omitempty"`    // ID of the entry to keep; set for match_basis=="source_id"
+	Duplicates []string `json:"duplicates,omitempty"` // IDs of entries to remove; set for match_basis=="source_id"
+	Members    []string `json:"members,omitempty"`    // all ids; set for match_basis=="title"
+	Title      string   `json:"title,omitempty"`      // normalized title; set for match_basis=="title"
 }
 
 // DedupeResult represents the result of a dedupe operation.
@@ -75,6 +87,8 @@ func runDedupe(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
+	// TotalDupes counts only source-id groups; title groups leave
+	// Duplicates empty since --merge never acts on them.
 	totalDupes := 0
 	for _, g := range groups {
 		totalDupes += len(g.Duplicates)
@@ -84,9 +98,15 @@ func runDedupe(cmd *cobra.Command, args []string) error {
 		if humanOutput {
 			fmt.Printf("Found %d duplicate groups (%d total duplicates):\n\n", len(groups), totalDupes)
 			for _, g := range groups {
-				fmt.Printf("Source: %s/%s\n", g.SourceType, g.SourceID)
-				fmt.Printf("  Keep:   %s\n", g.Primary)
-				fmt.Printf("  Remove: %v\n\n", g.Duplicates)
+				switch g.MatchBasis {
+				case "source_id":
+					fmt.Printf("Source: %s/%s\n", g.SourceType, g.SourceID)
+					fmt.Printf("  Keep:   %s\n", g.Primary)
+					fmt.Printf("  Remove: %v\n\n", g.Duplicates)
+				case "title":
+					fmt.Printf("Title match: %q\n", g.Title)
+					fmt.Printf("  Members: %v\n\n", g.Members)
+				}
 			}
 		} else {
 			outputJSON(DedupeResult{
@@ -98,13 +118,20 @@ func runDedupe(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	// Merge mode: actually remove duplicates
-	if err := performMerge(repoRoot, refs, groups); err != nil {
+	// Merge mode only acts on source-id groups; title groups are report-only.
+	mergeGroups := make([]DuplicateGroup, 0, len(groups))
+	for _, g := range groups {
+		if g.MatchBasis == "source_id" {
+			mergeGroups = append(mergeGroups, g)
+		}
+	}
+
+	if err := performMerge(repoRoot, refs, mergeGroups); err != nil {
 		exitWithError(ExitDataError, "performing merge: %v", err)
 	}
 
 	if humanOutput {
-		fmt.Printf("Merged %d duplicate groups (%d duplicates removed)\n", len(groups), totalDupes)
+		fmt.Printf("Merged %d duplicate groups (%d duplicates removed)\n", len(mergeGroups), totalDupes)
 	} else {
 		outputJSON(DedupeResult{
 			DryRun:     false,
@@ -122,8 +149,35 @@ type sourceKey struct {
 	ID   string
 }
 
-// findDuplicateGroups finds references with the same source ID.
+// normalizeTitleAlnum normalizes a title for duplicate grouping: lowercase,
+// keeping only Unicode letters and digits. This deliberately differs from
+// normalizeTitleStrict, which preserves word boundaries for S2-lookup
+// verification — here punctuation and spacing variants should collide.
+func normalizeTitleAlnum(title string) string {
+	var result []rune
+	for _, r := range title {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			result = append(result, unicode.ToLower(r))
+		}
+	}
+	return string(result)
+}
+
+// findDuplicateGroups finds references with the same source ID, then
+// separately groups references sharing a normalized title. Source-ID groups
+// come first, then title groups; both are sorted for stable output.
 func findDuplicateGroups(refs []reference.Reference) []DuplicateGroup {
+	sourceGroups := findSourceIDGroups(refs)
+	titleGroups := findTitleGroups(refs)
+
+	groups := make([]DuplicateGroup, 0, len(sourceGroups)+len(titleGroups))
+	groups = append(groups, sourceGroups...)
+	groups = append(groups, titleGroups...)
+	return groups
+}
+
+// findSourceIDGroups finds references with the same import source ID.
+func findSourceIDGroups(refs []reference.Reference) []DuplicateGroup {
 	// Map source key -> list of ref IDs
 	sourceMap := make(map[sourceKey][]string)
 
@@ -143,12 +197,56 @@ func findDuplicateGroups(refs []reference.Reference) []DuplicateGroup {
 		}
 
 		groups = append(groups, DuplicateGroup{
+			MatchBasis: "source_id",
 			SourceType: key.Type,
 			SourceID:   key.ID,
 			Primary:    ids[0],  // Keep first occurrence
 			Duplicates: ids[1:], // Remove rest
 		})
 	}
+
+	sort.Slice(groups, func(i, j int) bool {
+		if groups[i].SourceType != groups[j].SourceType {
+			return groups[i].SourceType < groups[j].SourceType
+		}
+		return groups[i].SourceID < groups[j].SourceID
+	})
+
+	return groups
+}
+
+// findTitleGroups finds references sharing a normalized title. Refs whose
+// normalized title is empty, or whose raw title is the unknown-title
+// sentinel, are skipped.
+func findTitleGroups(refs []reference.Reference) []DuplicateGroup {
+	titleMap := make(map[string][]string) // normalized title -> list of ref IDs
+
+	for _, ref := range refs {
+		if ref.Title == importer.UnknownTitle {
+			continue
+		}
+		key := normalizeTitleAlnum(ref.Title)
+		if key == "" {
+			continue
+		}
+		titleMap[key] = append(titleMap[key], ref.ID)
+	}
+
+	var groups []DuplicateGroup
+	for title, ids := range titleMap {
+		if len(ids) < 2 {
+			continue
+		}
+		groups = append(groups, DuplicateGroup{
+			MatchBasis: "title",
+			Members:    ids,
+			Title:      title,
+		})
+	}
+
+	sort.Slice(groups, func(i, j int) bool {
+		return groups[i].Title < groups[j].Title
+	})
 
 	return groups
 }

--- a/cmd/bip/dedupe.go
+++ b/cmd/bip/dedupe.go
@@ -40,8 +40,15 @@ Examples:
 	RunE: runDedupe,
 }
 
+// Match bases for DuplicateGroup. Only MatchBasisSourceID is actionable by
+// --merge; MatchBasisTitle is report-only, since title identity is not paper
+// identity (preprint/published pairs, unrelated papers sharing a title).
+const (
+	MatchBasisSourceID = "source_id"
+	MatchBasisTitle    = "title"
+)
+
 // DuplicateGroup represents a set of duplicate or likely-duplicate references.
-// MatchBasis is "source_id" (actionable by --merge) or "title" (report only).
 type DuplicateGroup struct {
 	MatchBasis string   `json:"match_basis"`
 	SourceType string   `json:"source_type,omitempty"`
@@ -100,11 +107,11 @@ func runDedupe(cmd *cobra.Command, args []string) error {
 			fmt.Printf("Found %d duplicate groups (%d total duplicates):\n\n", len(groups), totalDupes)
 			for _, g := range groups {
 				switch g.MatchBasis {
-				case "source_id":
+				case MatchBasisSourceID:
 					fmt.Printf("Source: %s/%s\n", g.SourceType, g.SourceID)
 					fmt.Printf("  Keep:   %s\n", g.Primary)
 					fmt.Printf("  Remove: %v\n\n", g.Duplicates)
-				case "title":
+				case MatchBasisTitle:
 					fmt.Printf("Title match: %q\n", g.Title)
 					fmt.Printf("  Members: %v\n\n", g.Members)
 				}
@@ -120,12 +127,9 @@ func runDedupe(cmd *cobra.Command, args []string) error {
 	}
 
 	// Merge mode only acts on source-id groups; title groups are report-only.
-	mergeGroups := make([]DuplicateGroup, 0, len(groups))
-	for _, g := range groups {
-		if g.MatchBasis == "source_id" {
-			mergeGroups = append(mergeGroups, g)
-		}
-	}
+	// performMerge re-applies this filter itself, since it is the function
+	// that actually drops references.
+	mergeGroups := sourceIDGroups(groups)
 
 	if err := performMerge(repoRoot, refs, mergeGroups); err != nil {
 		exitWithError(ExitDataError, "performing merge: %v", err)
@@ -198,7 +202,7 @@ func findSourceIDGroups(refs []reference.Reference) []DuplicateGroup {
 		}
 
 		groups = append(groups, DuplicateGroup{
-			MatchBasis: "source_id",
+			MatchBasis: MatchBasisSourceID,
 			SourceType: key.Type,
 			SourceID:   key.ID,
 			Primary:    ids[0],  // Keep first occurrence
@@ -248,7 +252,7 @@ func findTitleGroups(refs []reference.Reference) []DuplicateGroup {
 			ids[i] = refs[idx].ID
 		}
 		groups = append(groups, DuplicateGroup{
-			MatchBasis: "title",
+			MatchBasis: MatchBasisTitle,
 			Members:    ids,
 			Title:      title,
 		})
@@ -309,11 +313,26 @@ func allSupersedesConnected(refs []reference.Reference, idxs []int) bool {
 	return true
 }
 
-// performMerge removes duplicate references.
+// sourceIDGroups returns only the groups that --merge may act on. Title
+// groups are never mergeable: a shared title is a hint for a human, not
+// evidence that two references are the same paper.
+func sourceIDGroups(groups []DuplicateGroup) []DuplicateGroup {
+	mergeable := make([]DuplicateGroup, 0, len(groups))
+	for _, g := range groups {
+		if g.MatchBasis == MatchBasisSourceID {
+			mergeable = append(mergeable, g)
+		}
+	}
+	return mergeable
+}
+
+// performMerge removes duplicate references. It filters to source-ID groups
+// itself rather than trusting the caller, since this is the function that
+// drops references from the nexus.
 func performMerge(repoRoot string, refs []reference.Reference, groups []DuplicateGroup) error {
 	// Build the set of duplicate IDs to drop
 	dupeSet := make(map[string]bool)
-	for _, g := range groups {
+	for _, g := range sourceIDGroups(groups) {
 		for _, dupeID := range g.Duplicates {
 			dupeSet[dupeID] = true
 		}

--- a/cmd/bip/dedupe_test.go
+++ b/cmd/bip/dedupe_test.go
@@ -208,6 +208,58 @@ func TestFindTitleGroups(t *testing.T) {
 	}
 }
 
+func TestFindTitleGroups_SupersedesSuppression(t *testing.T) {
+	tests := []struct {
+		name       string
+		refs       []reference.Reference
+		wantGroups int
+	}{
+		{
+			name: "pair fully linked by supersedes is suppressed",
+			refs: []reference.Reference{
+				{ID: "Preprint", Title: "A Shared Title", DOI: "10.1/preprint"},
+				{ID: "Published", Title: "a shared title", DOI: "10.1/published", Supersedes: "10.1/PREPRINT"},
+			},
+			wantGroups: 0,
+		},
+		{
+			name: "pair with no supersedes link is still reported",
+			refs: []reference.Reference{
+				{ID: "Preprint", Title: "A Shared Title", DOI: "10.1/preprint"},
+				{ID: "Published", Title: "a shared title", DOI: "10.1/published"},
+			},
+			wantGroups: 1,
+		},
+		{
+			name: "three-member group fully chained by supersedes is suppressed",
+			refs: []reference.Reference{
+				{ID: "A", Title: "A Shared Title", DOI: "10.1/a"},
+				{ID: "B", Title: "a shared title", DOI: "10.1/b", Supersedes: "10.1/a"},
+				{ID: "C", Title: "A SHARED TITLE", DOI: "10.1/c", Supersedes: "10.1/b"},
+			},
+			wantGroups: 0,
+		},
+		{
+			name: "three-member group only partially linked is still reported",
+			refs: []reference.Reference{
+				{ID: "A", Title: "A Shared Title", DOI: "10.1/a"},
+				{ID: "B", Title: "a shared title", DOI: "10.1/b", Supersedes: "10.1/a"},
+				{ID: "C", Title: "A SHARED TITLE", DOI: "10.1/c"},
+			},
+			wantGroups: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			groups := findTitleGroups(tt.refs)
+			if len(groups) != tt.wantGroups {
+				t.Fatalf("got %d groups, want %d: %+v", len(groups), tt.wantGroups, groups)
+			}
+		})
+	}
+}
+
 func TestFindTitleGroups_ThreeMemberGroupHasAllMembers(t *testing.T) {
 	refs := []reference.Reference{
 		{ID: "Barbulescu2025-xt", Title: "A Shared Title"},

--- a/cmd/bip/dedupe_test.go
+++ b/cmd/bip/dedupe_test.go
@@ -121,3 +121,166 @@ func TestFindDuplicateGroups_PrimaryIsFirst(t *testing.T) {
 		}
 	}
 }
+
+func TestFindTitleGroups(t *testing.T) {
+	tests := []struct {
+		name       string
+		refs       []reference.Reference
+		wantGroups int
+	}{
+		{
+			name: "same normalized title, different DOIs and source IDs",
+			refs: []reference.Reference{
+				{ID: "A", Title: "A Great Paper", DOI: "10.1/aaa", Source: reference.ImportSource{Type: "paperpile", ID: "uuid-1"}},
+				{ID: "B", Title: "a great paper", DOI: "10.2/bbb", Source: reference.ImportSource{Type: "paperpile", ID: "uuid-2"}},
+			},
+			wantGroups: 1,
+		},
+		{
+			name: "titles differing only in punctuation and case",
+			refs: []reference.Reference{
+				{ID: "A", Title: "Some: Paper-Title"},
+				{ID: "B", Title: "some paper title"},
+			},
+			wantGroups: 1,
+		},
+		{
+			name: "three-member title group",
+			refs: []reference.Reference{
+				{ID: "X", Title: "Restricted after Ligation"},
+				{ID: "Y", Title: "restricted after ligation"},
+				{ID: "Z", Title: "Restricted After Ligation!"},
+			},
+			wantGroups: 1,
+		},
+		{
+			name: "unknown-title sentinel is never grouped",
+			refs: []reference.Reference{
+				{ID: "A", Title: "[no title]"},
+				{ID: "B", Title: "[no title]"},
+			},
+			wantGroups: 0,
+		},
+		{
+			name: "HTML markup breaks title match (documented limitation)",
+			refs: []reference.Reference{
+				{ID: "A", Title: "Restricted after <i>IGHG2</i>"},
+				{ID: "B", Title: "Restricted after IGHG2"},
+			},
+			wantGroups: 0,
+		},
+		{
+			name: "unicode-aware normalization treats umlaut and ASCII as distinct",
+			refs: []reference.Reference{
+				{ID: "A", Title: "Müller cells"},
+				{ID: "B", Title: "Muller cells"},
+			},
+			wantGroups: 0,
+		},
+		{
+			name: "empty title is never grouped",
+			refs: []reference.Reference{
+				{ID: "A", Title: ""},
+				{ID: "B", Title: ""},
+			},
+			wantGroups: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			groups := findTitleGroups(tt.refs)
+			if len(groups) != tt.wantGroups {
+				t.Fatalf("got %d groups, want %d: %+v", len(groups), tt.wantGroups, groups)
+			}
+			for _, g := range groups {
+				if g.MatchBasis != "title" {
+					t.Errorf("MatchBasis = %q, want %q", g.MatchBasis, "title")
+				}
+				if g.Primary != "" {
+					t.Errorf("Primary = %q, want empty for title group", g.Primary)
+				}
+				if len(g.Members) < 2 {
+					t.Errorf("Members = %v, want 2+", g.Members)
+				}
+			}
+		})
+	}
+}
+
+func TestFindTitleGroups_ThreeMemberGroupHasAllMembers(t *testing.T) {
+	refs := []reference.Reference{
+		{ID: "Barbulescu2025-xt", Title: "A Shared Title"},
+		{ID: "Mesin2026-ra", Title: "a shared title"},
+		{ID: "Barbulescu2026-ub", Title: "A SHARED TITLE"},
+	}
+
+	groups := findTitleGroups(refs)
+	if len(groups) != 1 {
+		t.Fatalf("expected 1 group, got %d", len(groups))
+	}
+	if len(groups[0].Members) != 3 {
+		t.Fatalf("expected 3 members, got %d: %v", len(groups[0].Members), groups[0].Members)
+	}
+}
+
+func TestFindDuplicateGroups_SourceIDAndTitleDoNotDoubleCount(t *testing.T) {
+	// A pair that matches on both source ID and title should produce
+	// exactly one group (source_id), not two.
+	refs := []reference.Reference{
+		{ID: "A", Title: "Same Title", Source: reference.ImportSource{Type: "paperpile", ID: "uuid-1"}},
+		{ID: "B", Title: "same title", Source: reference.ImportSource{Type: "paperpile", ID: "uuid-1"}},
+	}
+
+	groups := findDuplicateGroups(refs)
+
+	sourceIDGroups := 0
+	titleGroups := 0
+	totalDupes := 0
+	for _, g := range groups {
+		switch g.MatchBasis {
+		case "source_id":
+			sourceIDGroups++
+			totalDupes += len(g.Duplicates)
+		case "title":
+			titleGroups++
+		}
+	}
+
+	if sourceIDGroups != 1 {
+		t.Errorf("sourceIDGroups = %d, want 1", sourceIDGroups)
+	}
+	if titleGroups != 1 {
+		t.Errorf("titleGroups = %d, want 1", titleGroups)
+	}
+	if totalDupes != 1 {
+		t.Errorf("TotalDupes-equivalent = %d, want 1", totalDupes)
+	}
+}
+
+func TestFindDuplicateGroups_MixedFixtureMergeGuardsToSourceID(t *testing.T) {
+	// One source-ID pair plus one title-only pair: --merge's guard
+	// (mirrored here) must act only on the source-ID pair.
+	refs := []reference.Reference{
+		{ID: "A", Title: "Source Dupe", Source: reference.ImportSource{Type: "paperpile", ID: "uuid-1"}},
+		{ID: "A-2", Title: "Source Dupe (copy)", Source: reference.ImportSource{Type: "paperpile", ID: "uuid-1"}},
+		{ID: "P", Title: "Title Only Match", DOI: "10.1/preprint"},
+		{ID: "Q", Title: "title only match", DOI: "10.2/published"},
+	}
+
+	groups := findDuplicateGroups(refs)
+
+	var mergeGroups []DuplicateGroup
+	for _, g := range groups {
+		if g.MatchBasis == "source_id" {
+			mergeGroups = append(mergeGroups, g)
+		}
+	}
+
+	if len(mergeGroups) != 1 {
+		t.Fatalf("expected 1 mergeable group, got %d", len(mergeGroups))
+	}
+	if mergeGroups[0].Primary != "A" || len(mergeGroups[0].Duplicates) != 1 || mergeGroups[0].Duplicates[0] != "A-2" {
+		t.Errorf("unexpected merge group: %+v", mergeGroups[0])
+	}
+}

--- a/cmd/bip/dedupe_test.go
+++ b/cmd/bip/dedupe_test.go
@@ -1,9 +1,14 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
+	"slices"
 	"testing"
 
+	"github.com/matsen/bipartite/internal/config"
 	"github.com/matsen/bipartite/internal/reference"
+	"github.com/matsen/bipartite/internal/storage"
 )
 
 func TestFindDuplicateGroups(t *testing.T) {
@@ -277,8 +282,9 @@ func TestFindTitleGroups_ThreeMemberGroupHasAllMembers(t *testing.T) {
 }
 
 func TestFindDuplicateGroups_SourceIDAndTitleDoNotDoubleCount(t *testing.T) {
-	// A pair that matches on both source ID and title should produce
-	// exactly one group (source_id), not two.
+	// A pair that matches on both source ID and title is reported once per
+	// basis — one source_id group and one title group — and contributes
+	// exactly one entry to the duplicate count, not two.
 	refs := []reference.Reference{
 		{ID: "A", Title: "Same Title", Source: reference.ImportSource{Type: "paperpile", ID: "uuid-1"}},
 		{ID: "B", Title: "same title", Source: reference.ImportSource{Type: "paperpile", ID: "uuid-1"}},
@@ -310,29 +316,91 @@ func TestFindDuplicateGroups_SourceIDAndTitleDoNotDoubleCount(t *testing.T) {
 	}
 }
 
-func TestFindDuplicateGroups_MixedFixtureMergeGuardsToSourceID(t *testing.T) {
-	// One source-ID pair plus one title-only pair: --merge's guard
-	// (mirrored here) must act only on the source-ID pair.
-	refs := []reference.Reference{
+// mixedGroupFixture is one source-ID pair (A / A-2) plus one title-only pair
+// (P / Q) — the shape that makes the report-only contract observable.
+func mixedGroupFixture() []reference.Reference {
+	return []reference.Reference{
 		{ID: "A", Title: "Source Dupe", Source: reference.ImportSource{Type: "paperpile", ID: "uuid-1"}},
 		{ID: "A-2", Title: "Source Dupe (copy)", Source: reference.ImportSource{Type: "paperpile", ID: "uuid-1"}},
 		{ID: "P", Title: "Title Only Match", DOI: "10.1/preprint"},
 		{ID: "Q", Title: "title only match", DOI: "10.2/published"},
 	}
+}
 
-	groups := findDuplicateGroups(refs)
+func TestSourceIDGroupsSelectsOnlyMergeableGroups(t *testing.T) {
+	groups := findDuplicateGroups(mixedGroupFixture())
 
-	var mergeGroups []DuplicateGroup
-	for _, g := range groups {
-		if g.MatchBasis == "source_id" {
-			mergeGroups = append(mergeGroups, g)
-		}
-	}
-
+	mergeGroups := sourceIDGroups(groups)
 	if len(mergeGroups) != 1 {
 		t.Fatalf("expected 1 mergeable group, got %d", len(mergeGroups))
 	}
 	if mergeGroups[0].Primary != "A" || len(mergeGroups[0].Duplicates) != 1 || mergeGroups[0].Duplicates[0] != "A-2" {
 		t.Errorf("unexpected merge group: %+v", mergeGroups[0])
+	}
+}
+
+// TestFindTitleGroupsLeavesDuplicatesEmpty pins the invariant that keeps
+// title groups harmless: they carry Members for review and never a
+// Duplicates list that a merge could act on.
+func TestFindTitleGroupsLeavesDuplicatesEmpty(t *testing.T) {
+	groups := findTitleGroups(mixedGroupFixture())
+	if len(groups) == 0 {
+		t.Fatal("fixture should produce a title group")
+	}
+	for _, g := range groups {
+		if len(g.Duplicates) != 0 || g.Primary != "" {
+			t.Errorf("title group %q has merge fields set: Primary=%q Duplicates=%v", g.Title, g.Primary, g.Duplicates)
+		}
+	}
+}
+
+// TestPerformMergeNeverDropsTitleGroupMembers exercises the destructive path
+// itself. The title group here is handed a populated Duplicates list — the
+// shape a future caller could construct by mistake — and performMerge must
+// still refuse to act on it, since a shared title is not paper identity.
+func TestPerformMergeNeverDropsTitleGroupMembers(t *testing.T) {
+	repoRoot := t.TempDir()
+	refsPath := config.RefsPath(repoRoot)
+	if err := os.MkdirAll(filepath.Dir(refsPath), 0o755); err != nil {
+		t.Fatalf("creating refs dir: %v", err)
+	}
+
+	refs := mixedGroupFixture()
+	if err := storage.WriteAll(refsPath, refs); err != nil {
+		t.Fatalf("writing refs: %v", err)
+	}
+
+	groups := []DuplicateGroup{
+		{
+			MatchBasis: MatchBasisSourceID,
+			SourceType: "paperpile",
+			SourceID:   "uuid-1",
+			Primary:    "A",
+			Duplicates: []string{"A-2"},
+		},
+		{
+			MatchBasis: MatchBasisTitle,
+			Title:      "titleonlymatch",
+			Members:    []string{"P", "Q"},
+			Primary:    "P",
+			Duplicates: []string{"Q"}, // must be ignored
+		},
+	}
+
+	if err := performMerge(repoRoot, refs, groups); err != nil {
+		t.Fatalf("performMerge: %v", err)
+	}
+
+	got, err := storage.ReadAll(refsPath)
+	if err != nil {
+		t.Fatalf("reading refs back: %v", err)
+	}
+	var gotIDs []string
+	for _, ref := range got {
+		gotIDs = append(gotIDs, ref.ID)
+	}
+	want := []string{"A", "P", "Q"} // only A-2, the source-ID duplicate, is dropped
+	if !slices.Equal(gotIDs, want) {
+		t.Errorf("refs after merge = %v, want %v", gotIDs, want)
 	}
 }

--- a/cmd/bip/import.go
+++ b/cmd/bip/import.go
@@ -7,6 +7,7 @@ import (
 	"github.com/matsen/bipartite/internal/config"
 	"github.com/matsen/bipartite/internal/importer"
 	"github.com/matsen/bipartite/internal/reference"
+	"github.com/matsen/bipartite/internal/s2"
 	"github.com/matsen/bipartite/internal/storage"
 	"github.com/spf13/cobra"
 )
@@ -262,6 +263,17 @@ func reportImportResults(stats importStats, warnings []importer.ImportWarning, e
 	}
 }
 
+// findByNormalizedDOI searches for a reference whose DOI normalizes to
+// normDOI. normDOI must already be normalized and non-empty.
+func findByNormalizedDOI(refs []reference.Reference, normDOI string) (int, bool) {
+	for i, ref := range refs {
+		if s2.NormalizeDOI(ref.DOI) == normDOI {
+			return i, true
+		}
+	}
+	return -1, false
+}
+
 type importAction struct {
 	action      string // new, update, skip
 	reason      string
@@ -287,9 +299,11 @@ func classifyImport(existing []reference.Reference, newRef reference.Reference) 
 		}
 	}
 
-	// Check for DOI match (secondary deduplication)
-	if newRef.DOI != "" {
-		if idx, found := storage.FindByDOI(existing, newRef.DOI); found {
+	// Check for DOI match (secondary deduplication). Normalized so a
+	// re-import with different DOI casing/prefix updates the existing
+	// record instead of minting a case-variant sibling.
+	if normDOI := s2.NormalizeDOI(newRef.DOI); normDOI != "" {
+		if idx, found := findByNormalizedDOI(existing, normDOI); found {
 			return importAction{
 				action:      "update",
 				reason:      "doi_match",

--- a/cmd/bip/import_test.go
+++ b/cmd/bip/import_test.go
@@ -104,6 +104,28 @@ func TestClassifyImport(t *testing.T) {
 	}
 }
 
+func TestClassifyImportNormalizesDOICase(t *testing.T) {
+	existing := []reference.Reference{
+		{ID: "ref1", DOI: "10.1093/molbev/msl010", Title: "Original casing"},
+	}
+
+	got := classifyImport(existing, reference.Reference{
+		ID:    "new-id",
+		DOI:   "10.1093/MOLBEV/MSL010",
+		Title: "Re-imported with different DOI casing",
+	})
+
+	if got.action != "update" {
+		t.Errorf("action = %q, want %q", got.action, "update")
+	}
+	if got.reason != "doi_match" {
+		t.Errorf("reason = %q, want %q", got.reason, "doi_match")
+	}
+	if got.existingIdx != 0 {
+		t.Errorf("existingIdx = %d, want 0", got.existingIdx)
+	}
+}
+
 func TestClassifyImportEmptyIDPanics(t *testing.T) {
 	existing := []reference.Reference{
 		{ID: "ref1", DOI: "10.1234/abc", Title: "Paper One"},

--- a/cmd/bip/s2_linkpub.go
+++ b/cmd/bip/s2_linkpub.go
@@ -109,6 +109,11 @@ func runS2LinkPub(cmd *cobra.Command, args []string) error {
 		published, err := findPublishedVersion(ctx, client, ref)
 		if err != nil {
 			if s2.IsRateLimited(err) {
+				// Persist any links already found this run before bailing —
+				// otherwise a mid-run 429 silently discards that progress.
+				if writeErr := writeUpdatedRefs(refsPath, refs, updatedRefs); writeErr != nil {
+					return outputLinkPubError(ExitS2APIError, "saving refs before rate-limit exit", writeErr)
+				}
 				return outputS2RateLimited(err)
 			}
 			// Warn about unexpected errors instead of silently ignoring
@@ -159,16 +164,23 @@ func runS2LinkPub(cmd *cobra.Command, args []string) error {
 	}
 
 	// Write updated refs if any links were made
-	if len(updatedRefs) > 0 {
-		for idx, updated := range updatedRefs {
-			refs[idx] = updated
-		}
-		if err := storage.WriteAll(refsPath, refs); err != nil {
-			return outputLinkPubError(ExitS2APIError, "saving refs", err)
-		}
+	if err := writeUpdatedRefs(refsPath, refs, updatedRefs); err != nil {
+		return outputLinkPubError(ExitS2APIError, "saving refs", err)
 	}
 
 	return outputLinkPubResult(result)
+}
+
+// writeUpdatedRefs applies updatedRefs (index -> updated reference) onto refs
+// and writes the result, if there is anything to write.
+func writeUpdatedRefs(refsPath string, refs []reference.Reference, updatedRefs map[int]reference.Reference) error {
+	if len(updatedRefs) == 0 {
+		return nil
+	}
+	for idx, updated := range updatedRefs {
+		refs[idx] = updated
+	}
+	return storage.WriteAll(refsPath, refs)
 }
 
 func findPreprints(refs []reference.Reference) []reference.Reference {

--- a/cmd/bip/s2_linkpub.go
+++ b/cmd/bip/s2_linkpub.go
@@ -40,11 +40,21 @@ func init() {
 
 // S2LinkPubResult is the JSON output for the link-published command.
 type S2LinkPubResult struct {
-	Linked           []S2LinkInfo   `json:"linked"`
-	NoPublishedFound []string       `json:"no_published_found"`
-	AlreadyLinked    []string       `json:"already_linked"`
-	TotalPreprints   int            `json:"total_preprints"`
-	Error            *S2ErrorResult `json:"error,omitempty"`
+	Linked           []S2LinkInfo    `json:"linked"`
+	NoPublishedFound []string        `json:"no_published_found"`
+	AlreadyLinked    []string        `json:"already_linked"`
+	Failed           []S2LinkFailure `json:"failed,omitempty"`
+	TotalPreprints   int             `json:"total_preprints"`
+	Error            *S2ErrorResult  `json:"error,omitempty"`
+}
+
+// S2LinkFailure records a preprint whose published-version lookup hit a
+// non-rate-limit error (network blip, decode error, etc). Unlike
+// NoPublishedFound, this ref was never actually checked and should be
+// retried — surfaced here so a JSON-mode run doesn't silently drop it.
+type S2LinkFailure struct {
+	PreprintID string `json:"preprint_id"`
+	Reason     string `json:"reason"`
 }
 
 // S2LinkInfo represents a linked preprint-published pair.
@@ -116,7 +126,9 @@ func runS2LinkPub(cmd *cobra.Command, args []string) error {
 				}
 				return outputS2RateLimited(err)
 			}
-			// Warn about unexpected errors instead of silently ignoring
+			// Record and warn about unexpected errors instead of silently
+			// dropping the ref (JSON mode has no other trace of this).
+			result.Failed = append(result.Failed, S2LinkFailure{PreprintID: ref.ID, Reason: err.Error()})
 			warnAPIError("Failed to find published version", ref.ID, err)
 			continue
 		}
@@ -240,8 +252,8 @@ func findPublishedVersion(ctx context.Context, client *s2.Client, preprint refer
 
 func outputLinkPubResult(result S2LinkPubResult) error {
 	if humanOutput {
-		fmt.Printf("Summary: %d linked, %d no published version, %d already linked\n",
-			len(result.Linked), len(result.NoPublishedFound), len(result.AlreadyLinked))
+		fmt.Printf("Summary: %d linked, %d no published version, %d already linked, %d failed (retry these)\n",
+			len(result.Linked), len(result.NoPublishedFound), len(result.AlreadyLinked), len(result.Failed))
 	} else {
 		outputJSON(result)
 	}

--- a/cmd/bip/s2_linkpub_test.go
+++ b/cmd/bip/s2_linkpub_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/matsen/bipartite/internal/config"
+	"github.com/matsen/bipartite/internal/reference"
+	"github.com/matsen/bipartite/internal/storage"
+)
+
+// linkpubRefsPath sets up a temp repo containing refs and returns its path.
+func linkpubRefsPath(t *testing.T, refs []reference.Reference) string {
+	t.Helper()
+	repoRoot := t.TempDir()
+	refsPath := config.RefsPath(repoRoot)
+	if err := os.MkdirAll(filepath.Dir(refsPath), 0o755); err != nil {
+		t.Fatalf("creating refs dir: %v", err)
+	}
+	if err := storage.WriteAll(refsPath, refs); err != nil {
+		t.Fatalf("writing refs: %v", err)
+	}
+	return refsPath
+}
+
+// TestWriteUpdatedRefsPersistsPartialProgress covers the mid-run rate-limit
+// path: link-published calls writeUpdatedRefs before bailing out on a 429, so
+// links already found in that run survive. Before this fix a mid-run rate
+// limit discarded them.
+func TestWriteUpdatedRefsPersistsPartialProgress(t *testing.T) {
+	refs := []reference.Reference{
+		{ID: "P1", DOI: "10.1101/preprint-1", Venue: "bioRxiv"},
+		{ID: "P2", DOI: "10.1101/preprint-2", Venue: "bioRxiv"},
+		{ID: "P3", DOI: "10.1101/preprint-3", Venue: "bioRxiv"},
+	}
+	refsPath := linkpubRefsPath(t, refs)
+
+	// P1 was linked before the rate limit hit; P2 and P3 were never reached.
+	linked := refs[0]
+	linked.Supersedes = "10.1038/published-1"
+	updated := map[int]reference.Reference{0: linked}
+
+	if err := writeUpdatedRefs(refsPath, refs, updated); err != nil {
+		t.Fatalf("writeUpdatedRefs: %v", err)
+	}
+
+	got, err := storage.ReadAll(refsPath)
+	if err != nil {
+		t.Fatalf("reading refs back: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("got %d refs, want 3", len(got))
+	}
+	if got[0].Supersedes != "10.1038/published-1" {
+		t.Errorf("P1.Supersedes = %q, want the link found before the rate limit", got[0].Supersedes)
+	}
+	for _, ref := range got[1:] {
+		if ref.Supersedes != "" {
+			t.Errorf("%s.Supersedes = %q, want empty (never reached)", ref.ID, ref.Supersedes)
+		}
+	}
+}
+
+// TestWriteUpdatedRefsNoopWhenNothingLinked guards the other direction: a run
+// that linked nothing must not rewrite refs.jsonl at all.
+func TestWriteUpdatedRefsNoopWhenNothingLinked(t *testing.T) {
+	refs := []reference.Reference{{ID: "P1", DOI: "10.1101/preprint-1", Venue: "bioRxiv"}}
+	refsPath := linkpubRefsPath(t, refs)
+
+	before, err := os.Stat(refsPath)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+
+	if err := writeUpdatedRefs(refsPath, refs, map[int]reference.Reference{}); err != nil {
+		t.Fatalf("writeUpdatedRefs: %v", err)
+	}
+
+	after, err := os.Stat(refsPath)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if !after.ModTime().Equal(before.ModTime()) {
+		t.Error("refs.jsonl was rewritten despite no links being found")
+	}
+}
+
+func TestIsPreprint(t *testing.T) {
+	tests := []struct {
+		venue string
+		want  bool
+	}{
+		{"bioRxiv", true},
+		{"biorxiv", true},
+		{"medRxiv", true},
+		{"arXiv", true},
+		{"arXiv preprint arXiv:2301.00001", true},
+		{"Nature", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.venue, func(t *testing.T) {
+			if got := isPreprint(reference.Reference{Venue: tt.venue}); got != tt.want {
+				t.Errorf("isPreprint(venue=%q) = %v, want %v", tt.venue, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/bip/search.go
+++ b/cmd/bip/search.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/matsen/bipartite/internal/reference"
+	"github.com/matsen/bipartite/internal/s2"
 	"github.com/matsen/bipartite/internal/storage"
 	"github.com/spf13/cobra"
 )
@@ -116,7 +117,7 @@ func runSearch(cmd *cobra.Command, args []string) error {
 			Authors: searchAuthors,
 			Title:   searchTitle,
 			Venue:   searchVenue,
-			DOI:     searchDOI,
+			DOI:     s2.NormalizeDOI(searchDOI),
 			Tag:     searchTag,
 		}
 

--- a/docs/guides/reference-management.md
+++ b/docs/guides/reference-management.md
@@ -148,9 +148,9 @@ bip resolve --interactive # Prompt for true conflicts
 ## Maintenance
 
 ```bash
-bip dedupe --dry-run      # Find duplicates by source ID
-bip dedupe --merge        # Merge duplicates, keeping the first
-bip check                 # Verify repository integrity
+bip dedupe --dry-run      # Find duplicates by source ID, plus title-match groups for review
+bip dedupe --merge        # Merge source-ID duplicates, keeping the first
+bip check                 # Verify repository integrity (includes normalized duplicate-DOI detection)
 ```
 
 ## Agent Usage

--- a/internal/conflict/matcher.go
+++ b/internal/conflict/matcher.go
@@ -7,6 +7,7 @@ package conflict
 
 import (
 	"github.com/matsen/bipartite/internal/reference"
+	"github.com/matsen/bipartite/internal/s2"
 )
 
 // MatchPapers matches papers between ours and theirs sides of a conflict region.
@@ -20,8 +21,8 @@ func MatchPapers(region ConflictRegion) MatchResult {
 	oursMatched := make(map[string]bool) // Track which ours papers have been matched
 
 	for _, ref := range region.OursRefs {
-		if ref.DOI != "" {
-			oursByDOI[ref.DOI] = ref
+		if key := s2.NormalizeDOI(ref.DOI); key != "" {
+			oursByDOI[key] = ref
 		}
 		if ref.ID != "" {
 			oursByID[ref.ID] = ref
@@ -31,10 +32,10 @@ func MatchPapers(region ConflictRegion) MatchResult {
 	// Track which theirs papers have been matched
 	theirsMatched := make(map[string]bool)
 
-	// First pass: match by DOI
+	// First pass: match by DOI (normalized, case-insensitive)
 	for _, theirs := range region.TheirsRefs {
-		if theirs.DOI != "" {
-			if ours, ok := oursByDOI[theirs.DOI]; ok {
+		if key := s2.NormalizeDOI(theirs.DOI); key != "" {
+			if ours, ok := oursByDOI[key]; ok {
 				result.Matches = append(result.Matches, PaperMatch{
 					Ours:      ours,
 					Theirs:    theirs,

--- a/internal/conflict/matcher_test.go
+++ b/internal/conflict/matcher_test.go
@@ -41,6 +41,32 @@ func TestMatchPapers_ByDOI(t *testing.T) {
 	}
 }
 
+func TestMatchPapers_ByDOI_CaseInsensitive(t *testing.T) {
+	region := ConflictRegion{
+		OursRefs: []reference.Reference{
+			{ID: "paper1", DOI: "10.1093/molbev/msl010", Title: "Paper One"},
+		},
+		TheirsRefs: []reference.Reference{
+			{ID: "paper1-different-id", DOI: "10.1093/MOLBEV/MSL010", Title: "Paper One"},
+		},
+	}
+
+	result := MatchPapers(region)
+
+	if len(result.Matches) != 1 {
+		t.Fatalf("expected 1 match, got %d", len(result.Matches))
+	}
+	if match := result.Matches[0]; match.MatchedBy != "doi" {
+		t.Errorf("expected match by doi, got %s", match.MatchedBy)
+	}
+	if len(result.OursOnly) != 0 {
+		t.Errorf("expected 0 ours only, got %d", len(result.OursOnly))
+	}
+	if len(result.TheirsOnly) != 0 {
+		t.Errorf("expected 0 theirs only, got %d", len(result.TheirsOnly))
+	}
+}
+
 func TestMatchPapers_ByID(t *testing.T) {
 	region := ConflictRegion{
 		OursRefs: []reference.Reference{

--- a/internal/export/bibtex_parse.go
+++ b/internal/export/bibtex_parse.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"regexp"
 	"strings"
+
+	"github.com/matsen/bipartite/internal/s2"
 )
 
 // BibTeXIndex indexes existing BibTeX entries for deduplication.
@@ -28,7 +30,7 @@ func NewBibTeXIndex() *BibTeXIndex {
 func (idx *BibTeXIndex) HasEntry(key, doi string) bool {
 	// Primary: match by DOI if available
 	if doi != "" {
-		if _, exists := idx.DOIs[normalizeDOI(doi)]; exists {
+		if _, exists := idx.DOIs[s2.NormalizeDOI(doi)]; exists {
 			return true
 		}
 	}
@@ -71,7 +73,7 @@ func ParseBibTeXFile(path string) (*BibTeXIndex, error) {
 
 		// Check for DOI field
 		if matches := doiFieldRegex.FindStringSubmatch(line); len(matches) > 1 {
-			doi := normalizeDOI(matches[1])
+			doi := s2.NormalizeDOI(matches[1])
 			if doi != "" && currentKey != "" {
 				idx.DOIs[doi] = currentKey
 			}
@@ -79,18 +81,6 @@ func ParseBibTeXFile(path string) (*BibTeXIndex, error) {
 	}
 
 	return idx, scanner.Err()
-}
-
-// normalizeDOI normalizes a DOI for comparison.
-// Removes common prefixes like "https://doi.org/" and lowercases.
-func normalizeDOI(doi string) string {
-	doi = strings.TrimSpace(doi)
-	doi = strings.TrimPrefix(doi, "https://doi.org/")
-	doi = strings.TrimPrefix(doi, "http://doi.org/")
-	doi = strings.TrimPrefix(doi, "doi.org/")
-	doi = strings.TrimPrefix(doi, "DOI:")
-	doi = strings.TrimPrefix(doi, "doi:")
-	return strings.ToLower(doi)
 }
 
 // AppendToBibFile appends BibTeX content to a file.

--- a/internal/s2/parser.go
+++ b/internal/s2/parser.go
@@ -64,12 +64,16 @@ func (p PaperIdentifier) IsExternalID() bool {
 }
 
 // NormalizeDOI normalizes a DOI to a consistent format for comparison.
-// It removes common URL prefixes (https://doi.org/, DOI:) and converts to lowercase.
+// It removes common URL prefixes (https://doi.org/, DOI:) and converts to
+// lowercase. This is the single DOI normalizer for the whole codebase — any
+// place that compares two DOIs must route through it, or case variants of the
+// same DOI read as distinct papers.
 func NormalizeDOI(doi string) string {
 	doi = strings.TrimSpace(doi)
 	doi = strings.TrimPrefix(doi, "https://doi.org/")
 	doi = strings.TrimPrefix(doi, "http://doi.org/")
 	doi = strings.TrimPrefix(doi, "doi.org/")
 	doi = strings.TrimPrefix(doi, "DOI:")
+	doi = strings.TrimPrefix(doi, "doi:")
 	return strings.ToLower(doi)
 }

--- a/internal/storage/jsonl.go
+++ b/internal/storage/jsonl.go
@@ -109,19 +109,6 @@ func WriteAll(path string, refs []reference.Reference) error {
 	return nil
 }
 
-// FindByDOI searches for a reference by DOI.
-func FindByDOI(refs []reference.Reference, doi string) (int, bool) {
-	if doi == "" {
-		return -1, false
-	}
-	for i, ref := range refs {
-		if ref.DOI == doi {
-			return i, true
-		}
-	}
-	return -1, false
-}
-
 // FindByID searches for a reference by ID.
 func FindByID(refs []reference.Reference, id string) (int, bool) {
 	for i, ref := range refs {

--- a/internal/storage/jsonl_test.go
+++ b/internal/storage/jsonl_test.go
@@ -256,34 +256,6 @@ func TestWriteAll_Overwrites(t *testing.T) {
 	}
 }
 
-func TestFindByDOI(t *testing.T) {
-	refs := []reference.Reference{
-		{ID: "A", DOI: "10.1234/a"},
-		{ID: "B", DOI: "10.1234/b"},
-		{ID: "C", DOI: ""},
-	}
-
-	tests := []struct {
-		doi     string
-		wantIdx int
-		wantOK  bool
-	}{
-		{"10.1234/a", 0, true},
-		{"10.1234/b", 1, true},
-		{"10.1234/c", -1, false},
-		{"", -1, false}, // Empty DOI always returns not found
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.doi, func(t *testing.T) {
-			idx, ok := FindByDOI(refs, tt.doi)
-			if idx != tt.wantIdx || ok != tt.wantOK {
-				t.Errorf("FindByDOI(%q) = (%d, %v), want (%d, %v)", tt.doi, idx, ok, tt.wantIdx, tt.wantOK)
-			}
-		})
-	}
-}
-
 func TestFindByID(t *testing.T) {
 	refs := []reference.Reference{
 		{ID: "Smith2026"},

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -342,7 +342,7 @@ type SearchFilters struct {
 	YearTo   int      // Maximum publication year (0 = no maximum)
 	Title    string   // Search in title only (FTS)
 	Venue    string   // Filter by venue (SQL LIKE, case-insensitive)
-	DOI      string   // Exact DOI match (SQL)
+	DOI      string   // Exact DOI match, case-insensitive; pass s2.NormalizeDOI output
 	Tag      string   // Filter by tag (SQL LIKE on tags_json, partial match)
 }
 
@@ -445,7 +445,8 @@ func buildFiltersQuery(filters SearchFilters, authorQueries []author.Query) (str
 		args = append(args, "%"+filters.Venue+"%")
 	}
 	if filters.DOI != "" {
-		query += " AND doi = ?"
+		// Stored DOIs vary in case; callers pass a normalized DOI.
+		query += " AND LOWER(doi) = ?"
 		args = append(args, filters.DOI)
 	}
 	if filters.Tag != "" {


### PR DESCRIPTION
🤖

## Summary
`bip check` and `bip dedupe --dry-run` both reported zero duplicates while real duplicate-DOI pairs (differing only in case) sat undetected in the nexus, and the Paperpile importer kept minting new case-variant duplicates on re-import.

- `bip check` now keys duplicate-DOI detection on `s2.NormalizeDOI` (case/prefix-insensitive) instead of the raw DOI string, extracted into a testable `findDuplicateDOIs`, sorted for stable output.
- `bip dedupe --dry-run` adds a second pass, `findTitleGroups`, that groups references sharing a Unicode-aware alnum-normalized title (`match_basis: "title"`) alongside the existing source-ID groups (`match_basis: "source_id"`). `--merge` and `TotalDupes` still act only on source-ID groups — title groups are report-only, since title identity isn't paper identity (preprint/published pairs, unrelated papers with common titles, etc.). `performMerge` re-applies that filter itself rather than trusting its caller.
- `classifyImport`'s DOI-match branch now compares normalized DOIs, so a re-import with different DOI casing updates the existing record instead of creating a sibling.

**Follow-through on this issue's own deferred items** (done in this PR rather than filed separately):
- `internal/conflict/matcher.go`'s `MatchPapers` (used by `bip resolve`) had the identical raw-DOI case-sensitivity bug — fixed with the same `s2.NormalizeDOI` treatment.
- `findTitleGroups` now suppresses a title group entirely once its members are fully connected via `supersedes` (union-find over normalized DOI/supersedes links), so running `bip s2 link-published` stops leaving resolved preprint/published pairs as permanent report noise.
- While wiring up `link-published` to exercise the suppression, found and fixed a pre-existing bug: a mid-run S2 rate limit (`429`) returned before the end-of-run `storage.WriteAll`, silently discarding any links already found in that run. Refs are now persisted before bailing out on rate limit. Non-rate-limit failures (S2 500s, network blips) are now reported in a `failed` array instead of being silently skipped.
- Finishing the DOI sweep the issue implies: `storage.FindByDOI` (raw, case-sensitive) lost its last production caller and is deleted rather than left as a trap; `internal/export` had a second hand-maintained DOI normalizer, now routed through `s2.NormalizeDOI`; and `bip search --doi` compared raw DOIs in SQL, so a case-variant query missed real records.

## Verified against the live nexus (6834 refs, on a copy)
Every number below is from running the built binary against a copy of the real nexus, comparing against a binary built from `main`.

| Behavior | `main` | this branch |
|---|---|---|
| `bip check` duplicate-DOI groups | 0 | **1** |
| `bip dedupe --dry-run` groups | 0 | 86 title groups |
| `bip search --doi 10.1016/s1074-7613(00)80595-6` | 1 of 2 refs | both refs |

The duplicate `main` misses is real and still in the nexus: `Rada1998-rl` (`10.1016/S1074-7613(00)80595-6`) and `Rada1998-rq` (`10.1016/s1074-7613(00)80595-6`) — same paper, same title, DOIs differing only in one character's case. The 7 pairs originally named in #182 had already been manually resolved, so unit tests reproduce all 7 pair-shapes (case-only variants, URL-prefixed DOIs, disagreeing year/authors) and fail without the fix.

`bip dedupe --dry-run` reports 86 title groups, including the exact 3-member group named in the issue:

```
Barbulescu2025-xt / Mesin2026-ra / Barbulescu2026-ub
```

with correct `match_basis`, empty `primary`, and populated `members`.

**Supersedes suppression, measured end-to-end.** `bip s2 link-published --auto` completed against the corpus copy — 949 preprints, 195 newly linked, 16 already linked, 668 with no published version, 70 failures (all S2 `500`s, now visible in `failed` rather than silently dropped). Title groups before that run: **86**. After: **70**. Sixteen groups dropped out, none newly appeared — the resolved preprint/published pairs stop being permanent report noise, which is exactly what the suppression is for.

`--merge` was exercised on the same corpus copy with a synthetic source-ID duplicate injected: it removed that one reference and left all 86 title groups intact.

## Test plan
- `cmd/bip/check_test.go` (new): normalized-DOI grouping, including case-only, URL-prefix, blank/prefix-only, and disagreeing-metadata cases.
- `cmd/bip/dedupe_test.go`: title-group normalization, three-member groups, sentinel/empty-title skip, HTML-markup and Unicode-umlaut non-matches (documented limitations), no-double-counting when a pair matches on both source ID and title, and supersedes-suppression (full pair/chain suppressed, partial chain still reported). `TestPerformMergeNeverDropsTitleGroupMembers` drives the destructive path with a title group carrying a populated `Duplicates` list and asserts it is refused — mutation-checked, it fails if the guard is removed.
- `cmd/bip/s2_linkpub_test.go` (new): mid-run rate-limit persistence, the no-op case, and `isPreprint`.
- `cmd/bip/import_test.go`: DOI-case-insensitive re-import matches the existing record.
- `internal/conflict/matcher_test.go`: DOI-case-insensitive match in `MatchPapers`.
- `go test ./... && go vet ./...` pass.

## Review
Rebased onto `main` after #220 removed the concepts/edges subsystem; all four conflicts were edge-related. Reviewed by clean-code, code-reuse, and test-audit agents — no correctness blockers; the merge-guard test gap, the missing `link-published` coverage, the duplicate `internal/export` normalizer, and the raw-DOI `bip search` filter are all addressed above.
