### PR TITLE
Add Volume/Issue/Pages fields and parse PMID from Paperpile imports

### DIFF
--- a/cmd/bip/get.go
+++ b/cmd/bip/get.go
@@ -65,6 +65,22 @@ func printRefDetail(ref reference.Reference) {
 		fmt.Printf("Venue:    %s\n", ref.Venue)
 	}
 
+	if ref.Volume != "" {
+		fmt.Printf("Volume:   %s\n", ref.Volume)
+	}
+
+	if ref.Issue != "" {
+		fmt.Printf("Issue:    %s\n", ref.Issue)
+	}
+
+	if ref.Pages != "" {
+		fmt.Printf("Pages:    %s\n", ref.Pages)
+	}
+
+	if ref.PMID != "" {
+		fmt.Printf("PMID:     %s\n", ref.PMID)
+	}
+
 	// Date
 	date := fmt.Sprintf("%d", ref.Published.Year)
 	if ref.Published.Month > 0 {

--- a/internal/export/bibtex.go
+++ b/internal/export/bibtex.go
@@ -45,6 +45,26 @@ func ToBibTeX(ref reference.Reference) string {
 		b.WriteString(fmt.Sprintf("  doi = {%s},\n", ref.DOI))
 	}
 
+	// Volume (optional)
+	if ref.Volume != "" {
+		b.WriteString(fmt.Sprintf("  volume = {%s},\n", ref.Volume))
+	}
+
+	// Issue/number (optional)
+	if ref.Issue != "" {
+		b.WriteString(fmt.Sprintf("  number = {%s},\n", ref.Issue))
+	}
+
+	// Pages (optional)
+	if ref.Pages != "" {
+		b.WriteString(fmt.Sprintf("  pages = {%s},\n", ref.Pages))
+	}
+
+	// PMID (optional)
+	if ref.PMID != "" {
+		b.WriteString(fmt.Sprintf("  pmid = {%s},\n", ref.PMID))
+	}
+
 	// Abstract (optional, if present)
 	if ref.Abstract != "" {
 		b.WriteString(fmt.Sprintf("  abstract = {%s},\n", escapeLatex(ref.Abstract)))

--- a/internal/export/bibtex_test.go
+++ b/internal/export/bibtex_test.go
@@ -229,6 +229,47 @@ func TestToBibTeX_OptionalFields(t *testing.T) {
 	if strings.Contains(got, "journal = ") && strings.Contains(got, "booktitle = ") {
 		t.Errorf("ToBibTeX() should not include empty venue, got:\n%s", got)
 	}
+	if strings.Contains(got, "volume = ") {
+		t.Errorf("ToBibTeX() should not include empty volume, got:\n%s", got)
+	}
+	if strings.Contains(got, "number = ") {
+		t.Errorf("ToBibTeX() should not include empty number, got:\n%s", got)
+	}
+	if strings.Contains(got, "pages = ") {
+		t.Errorf("ToBibTeX() should not include empty pages, got:\n%s", got)
+	}
+	if strings.Contains(got, "pmid = ") {
+		t.Errorf("ToBibTeX() should not include empty pmid, got:\n%s", got)
+	}
+}
+
+func TestToBibTeX_VolumeIssuePagesPMID(t *testing.T) {
+	ref := reference.Reference{
+		ID:    "DeWitt2026-cw",
+		Title: "Replaying germinal center evolution",
+		Authors: []reference.Author{
+			{First: "A", Last: "B"},
+		},
+		Venue:     "Cell",
+		Published: reference.PublicationDate{Year: 2026},
+		Volume:    "189",
+		Issue:     "16",
+		Pages:     "4980-4996.e8",
+		PMID:      "42248140",
+	}
+
+	got := ToBibTeX(ref)
+
+	for _, want := range []string{
+		"volume = {189},",
+		"number = {16},",
+		"pages = {4980-4996.e8},",
+		"pmid = {42248140},",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("ToBibTeX() missing %q, got:\n%s", want, got)
+		}
+	}
 }
 
 func TestToBibTeX_SpecialCharactersInTitle(t *testing.T) {

--- a/internal/importer/paperpile.go
+++ b/internal/importer/paperpile.go
@@ -49,13 +49,17 @@ func (f FlexibleString) String() string {
 
 // PaperpileEntry represents a single entry from a Paperpile JSON export.
 type PaperpileEntry struct {
-	ID        string `json:"_id"`
-	Citekey   string `json:"citekey"`
-	DOI       string `json:"doi"`
-	Title     string `json:"title"`
-	Abstract  string `json:"abstract"`
-	Journal   string `json:"journal"`
-	Booktitle string `json:"booktitle"`
+	ID        string         `json:"_id"`
+	Citekey   string         `json:"citekey"`
+	DOI       string         `json:"doi"`
+	Title     string         `json:"title"`
+	Abstract  string         `json:"abstract"`
+	Journal   string         `json:"journal"`
+	Booktitle string         `json:"booktitle"`
+	Volume    string         `json:"volume"`
+	Issue     string         `json:"issue"`
+	Pages     string         `json:"pages"`
+	PMID      FlexibleString `json:"pmid"`
 	Published struct {
 		Year  FlexibleString `json:"year"`
 		Month FlexibleString `json:"month"`
@@ -274,6 +278,10 @@ func paperpileEntryToReference(entry PaperpileEntry, strict bool) (reference.Ref
 		Authors:         authors,
 		Abstract:        entry.Abstract,
 		Venue:           venue,
+		Volume:          entry.Volume,
+		Issue:           entry.Issue,
+		Pages:           entry.Pages,
+		PMID:            entry.PMID.String(),
 		Note:            entry.Note,
 		Tags:            tags,
 		Published:       pubDate,

--- a/internal/importer/paperpile_test.go
+++ b/internal/importer/paperpile_test.go
@@ -856,6 +856,44 @@ func TestParsePaperpile_LenientUserLabelDedupedWithIncompleteTag(t *testing.T) {
 	}
 }
 
+func TestParsePaperpile_VolumeIssuePagesPMID(t *testing.T) {
+	data := []byte(`[{
+		"_id": "abc123",
+		"citekey": "DeWitt2026-cw",
+		"doi": "10.1234/test",
+		"title": "Test Paper",
+		"journal": "Cell",
+		"volume": "189",
+		"issue": "16",
+		"pages": "4980-4996.e8",
+		"pmid": 42248140,
+		"published": {"year": "2026"},
+		"author": [{"first": "John", "last": "Smith"}]
+	}]`)
+
+	refs, _, errs := ParsePaperpile(data, true)
+	if len(errs) > 0 {
+		t.Fatalf("ParsePaperpile() returned errors: %v", errs)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("ParsePaperpile() returned %d refs, want 1", len(refs))
+	}
+
+	ref := refs[0]
+	if ref.Volume != "189" {
+		t.Errorf("Volume = %v, want 189", ref.Volume)
+	}
+	if ref.Issue != "16" {
+		t.Errorf("Issue = %v, want 16", ref.Issue)
+	}
+	if ref.Pages != "4980-4996.e8" {
+		t.Errorf("Pages = %v, want 4980-4996.e8", ref.Pages)
+	}
+	if ref.PMID != "42248140" {
+		t.Errorf("PMID = %v, want 42248140", ref.PMID)
+	}
+}
+
 // Helper function for comparing references
 func refsEqual(a, b reference.Reference) bool {
 	if a.ID != b.ID || a.DOI != b.DOI || a.Title != b.Title {

--- a/internal/reference/merge.go
+++ b/internal/reference/merge.go
@@ -33,6 +33,15 @@ func MergeUpdate(existing, incoming Reference) Reference {
 	if out.Venue == "" {
 		out.Venue = existing.Venue
 	}
+	if out.Volume == "" {
+		out.Volume = existing.Volume
+	}
+	if out.Issue == "" {
+		out.Issue = existing.Issue
+	}
+	if out.Pages == "" {
+		out.Pages = existing.Pages
+	}
 	if out.Note == "" {
 		out.Note = existing.Note
 	}

--- a/internal/reference/merge_test.go
+++ b/internal/reference/merge_test.go
@@ -43,6 +43,35 @@ func TestMergeUpdate_PreservesExternalIdentifiers(t *testing.T) {
 	}
 }
 
+func TestMergeUpdate_PreservesVolumeIssuePages(t *testing.T) {
+	existing := Reference{
+		ID:     "DeWitt2026-cw",
+		DOI:    "10.1234/foo",
+		Title:  "Foo",
+		Volume: "189",
+		Issue:  "16",
+		Pages:  "4980-4996.e8",
+	}
+	incoming := Reference{
+		ID:     "DeWitt2026-cw",
+		DOI:    "10.1234/foo",
+		Title:  "Foo",
+		Source: ImportSource{Type: "paperpile", ID: "uuid-1"},
+		// No Volume/Issue/Pages — re-import doesn't carry these.
+	}
+
+	got := MergeUpdate(existing, incoming)
+	if got.Volume != "189" {
+		t.Errorf("Volume lost: got %q, want 189", got.Volume)
+	}
+	if got.Issue != "16" {
+		t.Errorf("Issue lost: got %q, want 16", got.Issue)
+	}
+	if got.Pages != "4980-4996.e8" {
+		t.Errorf("Pages lost: got %q, want 4980-4996.e8", got.Pages)
+	}
+}
+
 func TestMergeUpdate_IncomingOverridesWhenNonZero(t *testing.T) {
 	// If both existing and incoming have a value for a field, the incoming
 	// wins. This is the standard "update" behavior — the new import is more

--- a/internal/reference/reference.go
+++ b/internal/reference/reference.go
@@ -11,7 +11,10 @@ type Reference struct {
 	Title    string   `json:"title"`
 	Authors  []Author `json:"authors"`
 	Abstract string   `json:"abstract"`
-	Venue    string   `json:"venue"`          // Journal, conference, or preprint server
+	Venue    string   `json:"venue"` // Journal, conference, or preprint server
+	Volume   string   `json:"volume,omitempty"`
+	Issue    string   `json:"issue,omitempty"`
+	Pages    string   `json:"pages,omitempty"`
 	Note     string   `json:"note,omitempty"` // User note (e.g., from Paperpile)
 
 	// Publication Date

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -22,7 +22,8 @@ const selectRefFields = `id, doi, title, abstract, venue,
 	pub_year, pub_month, pub_day,
 	pdf_path, source_type, source_id, supersedes,
 	authors_json, supplement_paths_json,
-	pmid, pmcid, arxiv_id, s2_id, notes, tags_json`
+	pmid, pmcid, arxiv_id, s2_id, notes, tags_json,
+	volume, issue, pages`
 
 // Per-column relevance weights for ranking FTS matches, in refs_fts column
 // order (id, title, abstract, authors_text, pub_year, notes, tags_text). A
@@ -100,7 +101,10 @@ func createSchema(db *sql.DB) error {
 			arxiv_id TEXT,
 			s2_id TEXT,
 			notes TEXT,
-			tags_json TEXT
+			tags_json TEXT,
+			volume TEXT,
+			issue TEXT,
+			pages TEXT
 		);
 
 		-- Index for DOI lookups
@@ -153,8 +157,9 @@ func (d *DB) RebuildFromJSONL(jsonlPath string) (int, error) {
 			pub_year, pub_month, pub_day,
 			pdf_path, source_type, source_id, supersedes,
 			authors_json, supplement_paths_json,
-			pmid, pmcid, arxiv_id, s2_id, notes, tags_json
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			pmid, pmcid, arxiv_id, s2_id, notes, tags_json,
+			volume, issue, pages
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`)
 	if err != nil {
 		return 0, fmt.Errorf("preparing refs insert: %w", err)
@@ -199,6 +204,8 @@ func (d *DB) RebuildFromJSONL(jsonlPath string) (int, error) {
 			nullableStringValue(ref.PMID), nullableStringValue(ref.PMCID),
 			nullableStringValue(ref.ArXivID), nullableStringValue(ref.S2ID),
 			nullableStringValue(ref.Note), nullableString(tagsJSON),
+			nullableStringValue(ref.Volume), nullableStringValue(ref.Issue),
+			nullableStringValue(ref.Pages),
 		)
 		if err != nil {
 			return 0, fmt.Errorf("inserting ref %s: %w", ref.ID, err)
@@ -521,6 +528,7 @@ func scanReference(s scanner) (*reference.Reference, error) {
 	var authorsJSON, supplementJSON, tagsJSON sql.NullString
 	var doi, abstract, venue, pdfPath, sourceID, supersedes sql.NullString
 	var pmid, pmcid, arxivID, s2id, notes sql.NullString
+	var volume, issue, pages sql.NullString
 	var pubMonth, pubDay sql.NullInt64
 
 	err := s.Scan(
@@ -529,6 +537,7 @@ func scanReference(s scanner) (*reference.Reference, error) {
 		&pdfPath, &ref.Source.Type, &sourceID, &supersedes,
 		&authorsJSON, &supplementJSON,
 		&pmid, &pmcid, &arxivID, &s2id, &notes, &tagsJSON,
+		&volume, &issue, &pages,
 	)
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -549,6 +558,9 @@ func scanReference(s scanner) (*reference.Reference, error) {
 	ref.ArXivID = arxivID.String
 	ref.S2ID = s2id.String
 	ref.Note = notes.String
+	ref.Volume = volume.String
+	ref.Issue = issue.String
+	ref.Pages = pages.String
 
 	if pubMonth.Valid {
 		ref.Published.Month = int(pubMonth.Int64)

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -142,12 +142,17 @@ func (d *DB) RebuildFromJSONL(jsonlPath string) (int, error) {
 		return 0, fmt.Errorf("reading JSONL: %w", err)
 	}
 
-	// Clear existing data
-	if _, err := d.db.Exec("DELETE FROM refs"); err != nil {
-		return 0, fmt.Errorf("clearing refs table: %w", err)
+	// Drop and recreate the refs/refs_fts tables rather than DELETE-ing rows,
+	// so a rebuild also picks up schema changes (new columns) rather than
+	// failing against a stale table created by an older binary.
+	if _, err := d.db.Exec("DROP TABLE IF EXISTS refs"); err != nil {
+		return 0, fmt.Errorf("dropping refs table: %w", err)
 	}
-	if _, err := d.db.Exec("DELETE FROM refs_fts"); err != nil {
-		return 0, fmt.Errorf("clearing refs_fts table: %w", err)
+	if _, err := d.db.Exec("DROP TABLE IF EXISTS refs_fts"); err != nil {
+		return 0, fmt.Errorf("dropping refs_fts table: %w", err)
+	}
+	if err := createSchema(d.db); err != nil {
+		return 0, fmt.Errorf("recreating schema: %w", err)
 	}
 
 	// Prepare statements

--- a/internal/storage/sqlite_test.go
+++ b/internal/storage/sqlite_test.go
@@ -1,12 +1,14 @@
 package storage
 
 import (
+	"database/sql"
 	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/matsen/bipartite/internal/reference"
+	_ "modernc.org/sqlite"
 )
 
 // setupTestDB creates a test database and JSONL file with test data
@@ -171,6 +173,88 @@ func TestDB_RebuildFromJSONL(t *testing.T) {
 	count, _ = db.Count()
 	if count != 1 {
 		t.Errorf("After rebuild, Count() = %d, want 1", count)
+	}
+}
+
+// TestDB_RebuildFromJSONL_SchemaDrift reproduces the case where a cache file
+// was created by an older binary whose refs table lacks columns the current
+// code expects (e.g. before volume/issue/pages were added). RebuildFromJSONL
+// must pick up the new schema rather than failing against the stale table.
+func TestDB_RebuildFromJSONL_SchemaDrift(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.db")
+	jsonlPath := filepath.Join(tmpDir, "refs.jsonl")
+
+	sqlDB, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	if _, err := sqlDB.Exec(`
+		CREATE TABLE refs (
+			id TEXT PRIMARY KEY,
+			doi TEXT,
+			title TEXT NOT NULL,
+			abstract TEXT,
+			venue TEXT,
+			pub_year INTEGER NOT NULL,
+			pub_month INTEGER,
+			pub_day INTEGER,
+			pdf_path TEXT,
+			source_type TEXT NOT NULL,
+			source_id TEXT,
+			supersedes TEXT,
+			authors_json TEXT NOT NULL,
+			supplement_paths_json TEXT,
+			pmid TEXT,
+			pmcid TEXT,
+			arxiv_id TEXT,
+			s2_id TEXT,
+			notes TEXT,
+			tags_json TEXT
+		)
+	`); err != nil {
+		t.Fatalf("creating stale schema: %v", err)
+	}
+	if err := sqlDB.Close(); err != nil {
+		t.Fatalf("closing setup connection: %v", err)
+	}
+
+	refs := []reference.Reference{
+		{
+			ID:        "Smith2026-ab",
+			Title:     "Test Paper",
+			Volume:    "189",
+			Issue:     "16",
+			Pages:     "4980-4996.e8",
+			Authors:   []reference.Author{{Last: "Smith"}},
+			Published: reference.PublicationDate{Year: 2026},
+			Source:    reference.ImportSource{Type: "paperpile"},
+		},
+	}
+	if err := WriteAll(jsonlPath, refs); err != nil {
+		t.Fatalf("WriteAll() error = %v", err)
+	}
+
+	db, err := OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB() error = %v", err)
+	}
+	defer db.Close()
+
+	count, err := db.RebuildFromJSONL(jsonlPath)
+	if err != nil {
+		t.Fatalf("RebuildFromJSONL() error = %v, want nil (rebuild should tolerate a stale pre-existing schema)", err)
+	}
+	if count != 1 {
+		t.Errorf("RebuildFromJSONL() = %d, want 1", count)
+	}
+
+	ref, err := db.GetByID("Smith2026-ab")
+	if err != nil {
+		t.Fatalf("GetByID() error = %v", err)
+	}
+	if ref.Volume != "189" || ref.Issue != "16" || ref.Pages != "4980-4996.e8" {
+		t.Errorf("GetByID() = %+v, want Volume=189 Issue=16 Pages=4980-4996.e8", ref)
 	}
 }
 


### PR DESCRIPTION
🤖

## Summary

`bip export --bibtex` couldn't produce submission-ready BibTeX because it never emitted `volume`, `number` (issue), `pages`, or `pmid`, even for journal articles where Paperpile has all four. This adds `Volume`/`Issue`/`Pages` to `Reference`, parses them (plus `pmid`) from Paperpile imports, and emits all four in BibTeX output.

- `internal/reference/reference.go`: add `Volume`, `Issue`, `Pages` string fields
- `internal/reference/merge.go`: fallback-merge the three new fields (same pattern as `PMID`/`PMCID`)
- `internal/storage/sqlite.go`: add `volume`/`issue`/`pages` columns, thread through insert/scan
- `internal/importer/paperpile.go`: parse `volume`/`issue`/`pages`/`pmid` (via `FlexibleString`) from `PaperpileEntry`
- `internal/export/bibtex.go`: emit `volume`/`number`/`pages`/`pmid` when non-empty
- `cmd/bip/get.go`: print `Volume`/`Issue`/`Pages`/`PMID` in `--human` output

## Test plan

- `internal/importer/paperpile_test.go`: `TestParsePaperpile_VolumeIssuePagesPMID` — all four fields land on the resulting `Reference`
- `internal/export/bibtex_test.go`: `TestToBibTeX_VolumeIssuePagesPMID` (fields present) and updated `TestToBibTeX_OptionalFields` (regression check — no empty lines emitted)
- `internal/reference/merge_test.go`: `TestMergeUpdate_PreservesVolumeIssuePages` — existing values survive a re-import that omits them
- `go build ./... && go vet ./... && go test ./...` all pass

DEFERRED: none — out-of-scope items (backfilling these fields for existing references, parsing volume/issue/pages from S2/ASTA imports) are called out explicitly in the issue as follow-up work, not deferred from this PR's scope.