### PR TITLE
Warn on suspect Paperpile placeholder pages

### DIFF
--- a/cmd/bip/export.go
+++ b/cmd/bip/export.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -88,6 +89,8 @@ func runExport(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	warnSuspectPages(refs)
+
 	// Handle --append mode
 	if exportAppend != "" {
 		return runExportAppend(refs, exportAppend)
@@ -98,6 +101,17 @@ func runExport(cmd *cobra.Command, args []string) error {
 	fmt.Print(bibtex)
 
 	return nil
+}
+
+// warnSuspectPages prints a stderr warning for each reference whose Pages
+// looks like a Paperpile advance-access placeholder rather than real
+// pagination. Stdout (the BibTeX itself) is left untouched.
+func warnSuspectPages(refs []reference.Reference) {
+	for _, ref := range refs {
+		if export.SuspectPages(ref) {
+			fmt.Fprintf(os.Stderr, "warning: %s: pages %q with no volume/issue — likely a Paperpile placeholder from an advance-access import, verify at the publisher before citing\n", ref.ID, ref.Pages)
+		}
+	}
 }
 
 func runExportAppend(refs []reference.Reference, outputPath string) error {

--- a/cmd/bip/export_test.go
+++ b/cmd/bip/export_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/matsen/bipartite/internal/reference"
+)
+
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+
+	orig := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stderr = w
+
+	fn()
+
+	w.Close()
+	os.Stderr = orig
+
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("reading captured stderr: %v", err)
+	}
+	return string(out)
+}
+
+func TestWarnSuspectPages_FiresForPlaceholder(t *testing.T) {
+	refs := []reference.Reference{
+		{ID: "Pae2025-kp", Pages: "1-9", Volume: ""},
+	}
+
+	stderr := captureStderr(t, func() { warnSuspectPages(refs) })
+
+	if !strings.Contains(stderr, "Pae2025-kp") || !strings.Contains(stderr, "warning:") {
+		t.Errorf("warnSuspectPages() should warn about placeholder pages, got stderr:\n%s", stderr)
+	}
+}
+
+func TestWarnSuspectPages_SilentAfterVolumeAssigned(t *testing.T) {
+	refs := []reference.Reference{
+		{ID: "Pae2025-kp", Pages: "486-494", Volume: "641", Issue: "8062"},
+	}
+
+	stderr := captureStderr(t, func() { warnSuspectPages(refs) })
+
+	if stderr != "" {
+		t.Errorf("warnSuspectPages() should not warn once volume/issue are set, got stderr:\n%s", stderr)
+	}
+}
+
+func TestWarnSuspectPages_SilentForLegitimatePagination(t *testing.T) {
+	refs := []reference.Reference{
+		{ID: "Zhang2024-uh", Pages: "1-56", Volume: "25"},
+	}
+
+	stderr := captureStderr(t, func() { warnSuspectPages(refs) })
+
+	if stderr != "" {
+		t.Errorf("warnSuspectPages() should not warn for legitimate 1-N pagination with a volume, got stderr:\n%s", stderr)
+	}
+}

--- a/cmd/bip/get.go
+++ b/cmd/bip/get.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/matsen/bipartite/internal/export"
 	"github.com/matsen/bipartite/internal/reference"
 	"github.com/spf13/cobra"
 )
@@ -74,7 +75,11 @@ func printRefDetail(ref reference.Reference) {
 	}
 
 	if ref.Pages != "" {
-		fmt.Printf("Pages:    %s\n", ref.Pages)
+		pagesLine := ref.Pages
+		if export.SuspectPages(ref) {
+			pagesLine += " ⚠ possibly preliminary (no volume/issue)"
+		}
+		fmt.Printf("Pages:    %s\n", pagesLine)
 	}
 
 	if ref.PMID != "" {

--- a/internal/export/bibtex.go
+++ b/internal/export/bibtex.go
@@ -3,10 +3,23 @@ package export
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/matsen/bipartite/internal/reference"
 )
+
+var suspectPagesRe = regexp.MustCompile(`^1-\d+$`)
+
+// SuspectPages reports whether ref.Pages looks like a Paperpile-computed
+// placeholder (a PDF-derived page count starting at 1, e.g. "1-9") rather
+// than real pagination. It matches when Pages fits ^1-\d+$ and Volume is
+// empty, which holds for confirmed advance-access placeholders but not for
+// legitimate "1-N" pagination that has a populated Volume (e.g. JMLR
+// articles, IEEE early-access "PP"-volume articles).
+func SuspectPages(ref reference.Reference) bool {
+	return suspectPagesRe.MatchString(ref.Pages) && ref.Volume == ""
+}
 
 // ToBibTeX converts a reference to BibTeX format.
 func ToBibTeX(ref reference.Reference) string {

--- a/internal/export/bibtex_test.go
+++ b/internal/export/bibtex_test.go
@@ -353,3 +353,28 @@ func TestToBibTeX_NoAuthors(t *testing.T) {
 		t.Errorf("ToBibTeX() should still include year, got:\n%s", got)
 	}
 }
+
+func TestSuspectPages(t *testing.T) {
+	tests := []struct {
+		name  string
+		pages string
+		vol   string
+		want  bool
+	}{
+		{"placeholder 1-9 no volume", "1-9", "", true},
+		{"placeholder 1-16 no volume", "1-16", "", true},
+		{"JMLR shape with volume", "1-56", "25", false},
+		{"IEEE early-access PP volume", "1-14", "PP", false},
+		{"elocation id", "msaf186", "42", false},
+		{"no pages", "", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ref := reference.Reference{Pages: tt.pages, Volume: tt.vol}
+			if got := SuspectPages(ref); got != tt.want {
+				t.Errorf("SuspectPages(Pages=%q, Volume=%q) = %v, want %v", tt.pages, tt.vol, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
🤖 ## Summary
Advance-access Paperpile imports sometimes get a PDF-derived page count starting at 1 (e.g. `"1-9"`) instead of real pagination, with no volume/issue set — confirmed on two real entries that later got corrected on re-import (see #186). This adds a heuristic warning so these placeholders don't silently flow into citations.

- `internal/export.SuspectPages(ref)`: true iff `Pages` matches `^1-\d+$` and `Volume` is empty — holds on both confirmed placeholder cases without false-positiving on JMLR/IEEE-early-access/elocation-id shapes that have a populated volume.
- `bip export --bibtex` prints a `warning: ...` line to stderr (stdout/BibTeX stays clean) for each suspect ref.
- `bip get --human` appends `⚠ possibly preliminary (no volume/issue)` to the `Pages:` line.

No importer, schema, or `Tags` change — pure read-time check.

Closes #186

## Test plan
- `internal/export/bibtex_test.go`: `SuspectPages` true/false cases (placeholders, JMLR, IEEE early-access, elocation id, no pages).
- `cmd/bip/export_test.go`: `warnSuspectPages` fires for placeholder shape, stays silent once volume/issue are set, stays silent for legitimate 1-N pagination with a volume.
- Manual: ran `bip export --bibtex` and `bip get --human` against the real library; confirmed no warning for `Zhang2024-uh` (JMLR, has volume) and `Matsen2026-zo` (no Pages field).