### PR TITLE
Document SendMessage as a nudge channel for live EPIC workers

### DIFF
--- a/skills/bip-epic-poll/SKILL.md
+++ b/skills/bip-epic-poll/SKILL.md
@@ -121,6 +121,21 @@ but don't need a table row.
 **Mention recent merges** only if they unblock something or change
 the plan.
 
+**Correcting a live worker mid-flight**: `ListAgents`/`SendMessage`
+reach other local Claude tmux sessions and can push an immediate
+correction without waiting for the worker's next lead evaluation or
+killing its tmux window. `.epic-status.json`'s `lead_guidance` remains
+the durable, canonical instruction — any `SendMessage` correction MUST
+also be written to `lead_guidance` in the same step, so a compacted or
+restarted worker can reconstruct it from files alone. Delivery lands
+at the worker's next tool call, not instantly, and `SendMessage` only
+reaches addressable Claude sessions — run `ListAgents` first to
+confirm, and fall back to the file-only correction (edit
+`lead_guidance`, wait for the worker's own loop) when it isn't
+addressable. Send a pointer ("updated .epic-status.json lead_guidance
+for iN — re-read it"), not the instruction payload, so nothing
+important lives only in the ephemeral channel.
+
 ### Output structure
 
 1. **Unblocked issues**: Issues ready for work, not assigned to a clone.

--- a/skills/bip-epic/SKILL.md
+++ b/skills/bip-epic/SKILL.md
@@ -43,6 +43,32 @@ seems trivial. The conductor can do light triage (reading files, checking
 CI output, running `gh` commands) but should not write code or create
 branches for numbered issues.
 
+### Correcting a live worker: SendMessage as a nudge channel
+
+`ListAgents`/`SendMessage` reach other local Claude tmux sessions and
+let the conductor push an immediate correction to a live worker
+without killing and respawning its tmux window. This supplements —
+never replaces — the file-based correction path:
+
+- **`.epic-status.json`'s `lead_guidance` remains the durable, canonical
+  instruction.** Any correction sent via `SendMessage` MUST also be
+  written to `lead_guidance` in the same step, so a compacted or
+  restarted worker (or a fresh conductor cold-starting via `/bip-epic`)
+  can reconstruct the correction from files alone.
+- Delivery is not instant: the message drains at the worker's *next
+  tool call*, not mid-tool-call. It is not a substitute for `tmux
+  capture-pane` when the conductor needs to see current state right now.
+- `SendMessage` only reaches addressable Claude sessions (tmux Claude
+  windows on this machine, or connected cloud/Remote Control sessions)
+  — never a plain shell, a remote SSH job, or a non-Claude compute node.
+  Run `ListAgents` first to confirm the target session is actually
+  addressable; fall back to editing `.epic-status.json` and waiting for
+  the worker's own loop when it isn't.
+- Do not use `SendMessage` to route around the conductor's own
+  restrictions (cross-session permission laundering) — the "should not
+  write code or create branches for numbered issues" rule above applies
+  equally to instructions phrased as a message to a worker.
+
 ## Configuration
 
 The epic skill reads `.epic-config.json` from the repo root. This file
@@ -270,6 +296,15 @@ Then propose spawning work for ready issues:
 > "Ready to spawn: `i302` (retry logic) and `i315` (scoring refactor). 2 clones available. Shall I spawn them?"
 
 Wait for user confirmation, then run `/bip-epic-spawn` (do NOT improvise tmux/claude commands).
+
+If a live worker's scope needs correcting *before* its next natural
+stopping point (rather than waiting for the next `needs-human`/
+`completed` transition): update `.epic-status.json`'s `lead_guidance`
+(and append to `lead_notes`) as usual, then optionally `ListAgents` to
+confirm the worker's session is addressable and `SendMessage` a short
+pointer — "updated .epic-status.json lead_guidance for iN — re-read it
+before continuing" — rather than the instruction itself. See
+"Correcting a live worker" above.
 
 ### Step 7: Start slot monitor
 


### PR DESCRIPTION
🤖

## Summary

`bip-epic` and `bip-epic-poll` only correct a live worker by writing `.epic-status.json`'s `lead_guidance` and waiting for the worker's own loop to notice it. `ListAgents`/`SendMessage` are now available and reach other local Claude tmux sessions, closing the delivery-latency gap without touching the durable state model.

- Adds a "Correcting a live worker: SendMessage as a nudge channel" subsection to `skills/bip-epic/SKILL.md` (under Conductor role) and wires a pointer into Step 6 ("Propose next action").
- Adds the equivalent guidance to `skills/bip-epic-poll/SKILL.md` near the needs-human escalation section.
- Both make explicit: `lead_guidance` remains the durable source of truth (any `SendMessage` correction must also be written there), delivery lands at the worker's next tool call (not instant, not a state-read substitute), and `SendMessage` only reaches addressable Claude sessions (verify via `ListAgents` first, fall back to file-only correction otherwise).

No code changes — documentation only.

Closes #188

## Test plan

- Manual: with a live worker in a tmux window, `ListAgents` to confirm addressability, edit `.epic-status.json` `lead_guidance`, `SendMessage` a pointer, confirm the worker picks it up on its next tool call.
- Reviewed both SKILL.md diffs for consistency with the existing file-based-state conventions in the rest of the doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)