### PR TITLE
Extract clone_root/spawn-intent resolution into a tested script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ symlink-skills:
 			rm -rf ~/.claude/skills/$$(basename "$$d") && ln -s "$$d" ~/.claude/skills/$$(basename "$$d"); \
 		fi; \
 	done
+	@rm -rf ~/.claude/skills/lib && ln -s $(REPO_DIR)/skills/lib ~/.claude/skills/lib
 	@echo "Symlinked skills to ~/.claude/skills/"
 
 symlink-statusline:

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,9 @@ symlink-agents:
 symlink-skills:
 	mkdir -p ~/.claude/skills
 	@for d in $(REPO_DIR)/skills/*/; do \
-		[ -d "$$d" ] && rm -rf ~/.claude/skills/$$(basename "$$d") && ln -s "$$d" ~/.claude/skills/$$(basename "$$d"); \
+		if [ -f "$$d/SKILL.md" ]; then \
+			rm -rf ~/.claude/skills/$$(basename "$$d") && ln -s "$$d" ~/.claude/skills/$$(basename "$$d"); \
+		fi; \
 	done
 	@echo "Symlinked skills to ~/.claude/skills/"
 

--- a/skills/bip-conductor-spawn/SKILL.md
+++ b/skills/bip-conductor-spawn/SKILL.md
@@ -37,10 +37,16 @@ directory — `<N>.md` (current) or `spawn-<N>.txt` (older, still
 written by some sessions):
 
 ```bash
-CLONE_ROOT=$(jq -r .clone_root .epic-config.json | sed "s|^~|$HOME|")
-INTENT=$(ls "$CLONE_ROOT"/.spawn-prompts/{<N>.md,spawn-<N>.txt} 2>/dev/null | head -1)
+source "$(dirname "<this-skill's-base-directory>")/lib/spawn-intent.sh"
+CLONE_ROOT=$(resolve_clone_root .epic-config.json)
+INTENT=$(find_spawn_intent "$CLONE_ROOT" <N>)
 [ -n "$INTENT" ] && cat "$INTENT"
 ```
+
+`<this-skill's-base-directory>` is this skill's base directory as given at
+invocation (e.g. `/home/user/.claude/skills/bip-conductor-spawn`); the
+shared helper lives at `lib/spawn-intent.sh`, a sibling of every skill
+directory (see `skills/lib/spawn-intent.sh` in the `bipartite` repo).
 
 Checking only `<N>.md` silently misses a real, live `spawn-<N>.txt` and
 falls through to the escape hatch below with no warning — exactly the

--- a/skills/bip-epic/SKILL.md
+++ b/skills/bip-epic/SKILL.md
@@ -203,10 +203,16 @@ semantic brief — why it matters, scope, any dependency/collision
 warnings from Step 4 — and write it to:
 
 ```bash
-CLONE_ROOT=$(jq -r .clone_root .epic-config.json | sed "s|^~|$HOME|")
+source "$(dirname "<this-skill's-base-directory>")/lib/spawn-intent.sh"
+CLONE_ROOT=$(resolve_clone_root .epic-config.json)
 mkdir -p "$CLONE_ROOT/.spawn-prompts"
 # Use the Write tool to create "$CLONE_ROOT/.spawn-prompts/<N>.md" with the brief
 ```
+
+`<this-skill's-base-directory>` is this skill's base directory as given
+at invocation (e.g. `/home/user/.claude/skills/bip-epic`); the shared
+helper lives at `lib/spawn-intent.sh`, a sibling of every skill
+directory (see `skills/lib/spawn-intent.sh` in the `bipartite` repo).
 
 `clone_root` in `.epic-config.json` is tilde-form — resolve it the same
 way every `/bip-conductor*` skill does, or the brief silently lands in

--- a/skills/lib/spawn-intent.sh
+++ b/skills/lib/spawn-intent.sh
@@ -1,0 +1,34 @@
+# Sourceable helpers for resolving .epic-config.json's clone_root and
+# locating spawn-intent files under either live naming convention.
+#
+# Shared by skills/bip-epic (write side, Step 6) and
+# skills/bip-conductor-spawn (read side, "Where the prompt comes from") —
+# extracted per issue #195 after the same two bugs (missing tilde
+# expansion, single-pattern glob) were independently fixed three times
+# across the split skills.
+#
+# Usage:
+#   source "<path-to-this-file>"
+#   CLONE_ROOT=$(resolve_clone_root .epic-config.json)
+#   INTENT=$(find_spawn_intent "$CLONE_ROOT" 302)
+
+# resolve_clone_root <config-file>
+# Reads .clone_root from the given JSON config and tilde-expands it.
+# Defaults to .epic-config.json in the current directory.
+resolve_clone_root() {
+    local config_file="${1:-.epic-config.json}"
+    jq -r '.clone_root' "$config_file" | sed "s|^~|$HOME|"
+}
+
+# find_spawn_intent <clone_root> <issue-number>
+# Locates a spawn-intent file for the given issue number under either
+# naming convention live in .spawn-prompts/: "<N>.md" (current) or
+# "spawn-<N>.txt" (older, still written by some sessions). Prefers
+# "<N>.md" when both exist. Prints the path, or nothing if neither
+# exists.
+find_spawn_intent() {
+    local clone_root="$1"
+    local issue_number="$2"
+    ls "$clone_root/.spawn-prompts/$issue_number.md" \
+       "$clone_root/.spawn-prompts/spawn-$issue_number.txt" 2>/dev/null | head -1
+}

--- a/skills/lib/spawn-intent.sh
+++ b/skills/lib/spawn-intent.sh
@@ -14,18 +14,27 @@
 
 # resolve_clone_root <config-file>
 # Reads .clone_root from the given JSON config and tilde-expands it.
-# Defaults to .epic-config.json in the current directory.
+# Defaults to .epic-config.json in the current directory. Fails with a
+# message on stderr if the file is unreadable or .clone_root is
+# missing/null, rather than silently resolving to an empty string.
 resolve_clone_root() {
     local config_file="${1:-.epic-config.json}"
-    jq -r '.clone_root' "$config_file" | sed "s|^~|$HOME|"
+    local root
+    root=$(jq -r '.clone_root' "$config_file") || return 1
+    if [ -z "$root" ] || [ "$root" = "null" ]; then
+        echo "resolve_clone_root: no .clone_root in $config_file" >&2
+        return 1
+    fi
+    echo "$root" | sed "s|^~|$HOME|"
 }
 
 # find_spawn_intent <clone_root> <issue-number>
 # Locates a spawn-intent file for the given issue number under either
 # naming convention live in .spawn-prompts/: "<N>.md" (current) or
 # "spawn-<N>.txt" (older, still written by some sessions). Prefers
-# "<N>.md" when both exist. Prints the path, or nothing if neither
-# exists.
+# "<N>.md" when both exist — relying on `ls`'s alphabetical ordering of
+# its (unglobbed) arguments, where a leading digit sorts before "s", not
+# on argument order. Prints the path, or nothing if neither exists.
 find_spawn_intent() {
     local clone_root="$1"
     local issue_number="$2"

--- a/tests/integration/edge_test.go
+++ b/tests/integration/edge_test.go
@@ -18,17 +18,22 @@ var (
 	bpBinaryErr  error
 )
 
+// moduleRoot returns the absolute path to the repository root, derived from
+// this file's own location (tests/integration/edge_test.go).
+func moduleRoot(t *testing.T) string {
+	t.Helper()
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("could not determine test file path")
+	}
+	return filepath.Dir(filepath.Dir(filepath.Dir(filename)))
+}
+
 // getBPBinary builds the bp binary once and returns its path.
 func getBPBinary(t *testing.T) string {
 	t.Helper()
 	bpBinaryOnce.Do(func() {
-		// Get module root directory
-		_, filename, _, ok := runtime.Caller(0)
-		if !ok {
-			bpBinaryErr = os.ErrInvalid
-			return
-		}
-		moduleRoot := filepath.Dir(filepath.Dir(filepath.Dir(filename)))
+		moduleRoot := moduleRoot(t)
 
 		// Build bp to a temp location
 		tmpDir, err := os.MkdirTemp("", "bp-test-*")

--- a/tests/integration/spawn_intent_test.go
+++ b/tests/integration/spawn_intent_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 )
@@ -13,12 +12,7 @@ import (
 // spawnIntentScriptPath returns the absolute path to skills/lib/spawn-intent.sh.
 func spawnIntentScriptPath(t *testing.T) string {
 	t.Helper()
-	_, filename, _, ok := runtime.Caller(0)
-	if !ok {
-		t.Fatal("could not determine test file path")
-	}
-	moduleRoot := filepath.Dir(filepath.Dir(filepath.Dir(filename)))
-	return filepath.Join(moduleRoot, "skills", "lib", "spawn-intent.sh")
+	return filepath.Join(moduleRoot(t), "skills", "lib", "spawn-intent.sh")
 }
 
 // runSpawnIntentShell sources spawn-intent.sh and runs the given shell

--- a/tests/integration/spawn_intent_test.go
+++ b/tests/integration/spawn_intent_test.go
@@ -72,6 +72,25 @@ func TestResolveCloneRootAbsoluteForm(t *testing.T) {
 	}
 }
 
+func TestResolveCloneRootMissingFailsFast(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, ".epic-config.json")
+	if err := os.WriteFile(configPath, []byte(`{}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	script := "source " + shellQuote(spawnIntentScriptPath(t)) + "\n" +
+		"resolve_clone_root " + shellQuote(configPath)
+	cmd := exec.Command("bash", "-c", script)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("resolve_clone_root with no .clone_root succeeded, want non-zero exit; output: %s", out)
+	}
+	if !strings.Contains(string(out), "no .clone_root in") {
+		t.Fatalf("resolve_clone_root error output = %q, want mention of missing .clone_root", out)
+	}
+}
+
 func TestFindSpawnIntent(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/tests/integration/spawn_intent_test.go
+++ b/tests/integration/spawn_intent_test.go
@@ -1,0 +1,135 @@
+// Package integration provides integration tests for bipartite commands.
+package integration
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// spawnIntentScriptPath returns the absolute path to skills/lib/spawn-intent.sh.
+func spawnIntentScriptPath(t *testing.T) string {
+	t.Helper()
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("could not determine test file path")
+	}
+	moduleRoot := filepath.Dir(filepath.Dir(filepath.Dir(filename)))
+	return filepath.Join(moduleRoot, "skills", "lib", "spawn-intent.sh")
+}
+
+// runSpawnIntentShell sources spawn-intent.sh and runs the given shell
+// snippet, returning trimmed stdout.
+func runSpawnIntentShell(t *testing.T, script string) string {
+	t.Helper()
+	full := "source " + spawnIntentScriptPath(t) + "\n" + script
+	cmd := exec.Command("bash", "-c", full)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("shell snippet failed: %v\nOutput: %s", err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func TestResolveCloneRootTildeForm(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, ".epic-config.json")
+	if err := os.WriteFile(configPath, []byte(`{"clone_root": "~/re/pz"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(home, "re", "pz")
+
+	got := runSpawnIntentShell(t, "resolve_clone_root "+configPath)
+	if got != want {
+		t.Fatalf("resolve_clone_root(~/re/pz) = %q, want %q", got, want)
+	}
+}
+
+func TestResolveCloneRootAbsoluteForm(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, ".epic-config.json")
+	absPath := "/opt/repos/pz"
+	if err := os.WriteFile(configPath, []byte(`{"clone_root": "`+absPath+`"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := runSpawnIntentShell(t, "resolve_clone_root "+configPath)
+	if got != absPath {
+		t.Fatalf("resolve_clone_root(%s) = %q, want unchanged %q", absPath, got, absPath)
+	}
+}
+
+func TestFindSpawnIntentMdOnly(t *testing.T) {
+	cloneRoot := t.TempDir()
+	promptsDir := filepath.Join(cloneRoot, ".spawn-prompts")
+	if err := os.MkdirAll(promptsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	mdPath := filepath.Join(promptsDir, "302.md")
+	if err := os.WriteFile(mdPath, []byte("intent"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := runSpawnIntentShell(t, "find_spawn_intent "+cloneRoot+" 302")
+	if got != mdPath {
+		t.Fatalf("find_spawn_intent = %q, want %q", got, mdPath)
+	}
+}
+
+func TestFindSpawnIntentTxtOnly(t *testing.T) {
+	cloneRoot := t.TempDir()
+	promptsDir := filepath.Join(cloneRoot, ".spawn-prompts")
+	if err := os.MkdirAll(promptsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	txtPath := filepath.Join(promptsDir, "spawn-302.txt")
+	if err := os.WriteFile(txtPath, []byte("intent"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := runSpawnIntentShell(t, "find_spawn_intent "+cloneRoot+" 302")
+	if got != txtPath {
+		t.Fatalf("find_spawn_intent = %q, want %q", got, txtPath)
+	}
+}
+
+func TestFindSpawnIntentPrefersMdWhenBothPresent(t *testing.T) {
+	cloneRoot := t.TempDir()
+	promptsDir := filepath.Join(cloneRoot, ".spawn-prompts")
+	if err := os.MkdirAll(promptsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	mdPath := filepath.Join(promptsDir, "302.md")
+	txtPath := filepath.Join(promptsDir, "spawn-302.txt")
+	if err := os.WriteFile(mdPath, []byte("intent"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(txtPath, []byte("intent"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := runSpawnIntentShell(t, "find_spawn_intent "+cloneRoot+" 302")
+	if got != mdPath {
+		t.Fatalf("find_spawn_intent with both present = %q, want %q (should prefer <N>.md)", got, mdPath)
+	}
+}
+
+func TestFindSpawnIntentNoneFound(t *testing.T) {
+	cloneRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cloneRoot, ".spawn-prompts"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	got := runSpawnIntentShell(t, "find_spawn_intent "+cloneRoot+" 302")
+	if got != "" {
+		t.Fatalf("find_spawn_intent with no intent files = %q, want empty", got)
+	}
+}

--- a/tests/integration/spawn_intent_test.go
+++ b/tests/integration/spawn_intent_test.go
@@ -15,12 +15,23 @@ func spawnIntentScriptPath(t *testing.T) string {
 	return filepath.Join(moduleRoot(t), "skills", "lib", "spawn-intent.sh")
 }
 
-// runSpawnIntentShell sources spawn-intent.sh and runs the given shell
-// snippet, returning trimmed stdout.
-func runSpawnIntentShell(t *testing.T, script string) string {
+// shellQuote wraps s in single quotes for safe interpolation into a shell
+// command string, escaping any single quotes it contains.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// callSpawnIntentFunc sources spawn-intent.sh and calls fn with the given
+// arguments, returning trimmed stdout.
+func callSpawnIntentFunc(t *testing.T, fn string, args ...string) string {
 	t.Helper()
-	full := "source " + spawnIntentScriptPath(t) + "\n" + script
-	cmd := exec.Command("bash", "-c", full)
+	quoted := make([]string, len(args))
+	for i, a := range args {
+		quoted[i] = shellQuote(a)
+	}
+	script := "source " + shellQuote(spawnIntentScriptPath(t)) + "\n" +
+		fn + " " + strings.Join(quoted, " ")
+	cmd := exec.Command("bash", "-c", script)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("shell snippet failed: %v\nOutput: %s", err, out)
@@ -41,7 +52,7 @@ func TestResolveCloneRootTildeForm(t *testing.T) {
 	}
 	want := filepath.Join(home, "re", "pz")
 
-	got := runSpawnIntentShell(t, "resolve_clone_root "+configPath)
+	got := callSpawnIntentFunc(t, "resolve_clone_root", configPath)
 	if got != want {
 		t.Fatalf("resolve_clone_root(~/re/pz) = %q, want %q", got, want)
 	}
@@ -55,75 +66,52 @@ func TestResolveCloneRootAbsoluteForm(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got := runSpawnIntentShell(t, "resolve_clone_root "+configPath)
+	got := callSpawnIntentFunc(t, "resolve_clone_root", configPath)
 	if got != absPath {
 		t.Fatalf("resolve_clone_root(%s) = %q, want unchanged %q", absPath, got, absPath)
 	}
 }
 
-func TestFindSpawnIntentMdOnly(t *testing.T) {
-	cloneRoot := t.TempDir()
-	promptsDir := filepath.Join(cloneRoot, ".spawn-prompts")
-	if err := os.MkdirAll(promptsDir, 0755); err != nil {
-		t.Fatal(err)
-	}
-	mdPath := filepath.Join(promptsDir, "302.md")
-	if err := os.WriteFile(mdPath, []byte("intent"), 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	got := runSpawnIntentShell(t, "find_spawn_intent "+cloneRoot+" 302")
-	if got != mdPath {
-		t.Fatalf("find_spawn_intent = %q, want %q", got, mdPath)
-	}
-}
-
-func TestFindSpawnIntentTxtOnly(t *testing.T) {
-	cloneRoot := t.TempDir()
-	promptsDir := filepath.Join(cloneRoot, ".spawn-prompts")
-	if err := os.MkdirAll(promptsDir, 0755); err != nil {
-		t.Fatal(err)
-	}
-	txtPath := filepath.Join(promptsDir, "spawn-302.txt")
-	if err := os.WriteFile(txtPath, []byte("intent"), 0644); err != nil {
-		t.Fatal(err)
+func TestFindSpawnIntent(t *testing.T) {
+	tests := []struct {
+		name       string
+		createMd   bool
+		createTxt  bool
+		wantSuffix string // relative to .spawn-prompts/, or "" for none found
+	}{
+		{name: "md only", createMd: true, wantSuffix: "302.md"},
+		{name: "txt only", createTxt: true, wantSuffix: "spawn-302.txt"},
+		{name: "both present prefers md", createMd: true, createTxt: true, wantSuffix: "302.md"},
+		{name: "none found", wantSuffix: ""},
 	}
 
-	got := runSpawnIntentShell(t, "find_spawn_intent "+cloneRoot+" 302")
-	if got != txtPath {
-		t.Fatalf("find_spawn_intent = %q, want %q", got, txtPath)
-	}
-}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cloneRoot := t.TempDir()
+			promptsDir := filepath.Join(cloneRoot, ".spawn-prompts")
+			if err := os.MkdirAll(promptsDir, 0755); err != nil {
+				t.Fatal(err)
+			}
+			if tc.createMd {
+				if err := os.WriteFile(filepath.Join(promptsDir, "302.md"), []byte("intent"), 0644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if tc.createTxt {
+				if err := os.WriteFile(filepath.Join(promptsDir, "spawn-302.txt"), []byte("intent"), 0644); err != nil {
+					t.Fatal(err)
+				}
+			}
 
-func TestFindSpawnIntentPrefersMdWhenBothPresent(t *testing.T) {
-	cloneRoot := t.TempDir()
-	promptsDir := filepath.Join(cloneRoot, ".spawn-prompts")
-	if err := os.MkdirAll(promptsDir, 0755); err != nil {
-		t.Fatal(err)
-	}
-	mdPath := filepath.Join(promptsDir, "302.md")
-	txtPath := filepath.Join(promptsDir, "spawn-302.txt")
-	if err := os.WriteFile(mdPath, []byte("intent"), 0644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(txtPath, []byte("intent"), 0644); err != nil {
-		t.Fatal(err)
-	}
+			want := ""
+			if tc.wantSuffix != "" {
+				want = filepath.Join(promptsDir, tc.wantSuffix)
+			}
 
-	got := runSpawnIntentShell(t, "find_spawn_intent "+cloneRoot+" 302")
-	if got != mdPath {
-		t.Fatalf("find_spawn_intent with both present = %q, want %q (should prefer <N>.md)", got, mdPath)
-	}
-}
-
-func TestFindSpawnIntentNoneFound(t *testing.T) {
-	cloneRoot := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(cloneRoot, ".spawn-prompts"), 0755); err != nil {
-		t.Fatal(err)
-	}
-
-	got := runSpawnIntentShell(t, "find_spawn_intent "+cloneRoot+" 302")
-	if got != "" {
-		t.Fatalf("find_spawn_intent with no intent files = %q, want empty", got)
+			got := callSpawnIntentFunc(t, "find_spawn_intent", cloneRoot, "302")
+			if got != want {
+				t.Fatalf("find_spawn_intent = %q, want %q", got, want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

`skills/lib/spawn-intent.sh` now holds `resolve_clone_root` and `find_spawn_intent` as sourceable shell functions, covered by `tests/integration/spawn_intent_test.go`. `skills/bip-conductor-spawn`'s "Where the prompt comes from" snippet and `skills/bip-epic`'s Step 6 snippet both call it instead of inlining the logic. `Makefile`'s `symlink-skills` target now symlinks only `SKILL.md`-bearing directories into `~/.claude/skills/` (so `skills/lib`, which has no `SKILL.md`, doesn't show up as a fake invocable skill), with an explicit separate symlink for `skills/lib` itself so the two SKILL.md snippets' `$(dirname "<base-dir>")/lib/spawn-intent.sh` sourcing path stays reachable post-install.

- Three review rounds on #194 each caught a bug in this exact inline snippet (missing tilde-expansion, single-pattern glob, missing write-side resolution), every time only because a reviewer ran the shell by hand — there was no executable coverage. This closes that gap.
- Chose a Go integration test (`tests/integration/`) over a standalone shell-test harness: it's the existing convention (`go test ./...`, `go fmt`/`go vet` gates) and needs no new tooling.
- `resolve_clone_root` fails fast (stderr message, exit 1) on a missing or null `.clone_root` instead of silently resolving to an empty string, which previously would have sent both call sites' `mkdir -p "$CLONE_ROOT/..."` to the filesystem root.
- Filed #197 to migrate the 13 remaining `jq -r .clone_root ... | sed "s|^~|$HOME|"` occurrences elsewhere in `bip-conductor*` — out of scope here per #195's own success criteria, which name only these two call sites.

Closes #195

## Test plan

- `go test ./tests/integration/ -run 'TestResolveCloneRoot|TestFindSpawnIntent'` — covers tilde vs. absolute `clone_root`, a missing/null `.clone_root` (fails fast), `<N>.md`-only, `spawn-<N>.txt`-only, both present (prefers `<N>.md`), and neither present.
- `go fmt ./...` / `go vet ./...` / `go test ./...` all pass unchanged.
- Manually verified post-install reachability: `make symlink-skills` followed by `source ~/.claude/skills/bip-epic/../lib/spawn-intent.sh` from the real symlinked install location.

🤖 Generated with [Claude Code](https://claude.com/claude-code)