### PR TITLE
Prune stale skill symlinks, make tuckin MEMORY.md optional, distinguish consumed spawn intent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,12 @@ symlink-skills:
 		fi; \
 	done
 	@rm -rf ~/.claude/skills/lib && ln -s $(REPO_DIR)/skills/lib ~/.claude/skills/lib
+	@for l in ~/.claude/skills/*; do \
+		if [ -L "$$l" ] && [ ! -e "$$l" ]; then \
+			echo "Pruning stale symlink: $$l"; \
+			rm -f "$$l"; \
+		fi; \
+	done
 	@echo "Symlinked skills to ~/.claude/skills/"
 
 symlink-statusline:

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,12 @@ symlink-agents:
 	@for f in $(REPO_DIR)/agents/*.md; do \
 		ln -sf "$$f" ~/.claude/agents/$$(basename "$$f"); \
 	done
+	@for l in ~/.claude/agents/*; do \
+		if [ -L "$$l" ] && [ ! -e "$$l" ]; then \
+			echo "Pruning stale symlink: $$l"; \
+			rm -f "$$l"; \
+		fi; \
+	done
 	@echo "Symlinked agents to ~/.claude/agents/"
 
 symlink-skills:

--- a/skills/bip-conductor-poll/SKILL.md
+++ b/skills/bip-conductor-poll/SKILL.md
@@ -89,11 +89,13 @@ pattern in `SUBAGENT-SCAN.md` (bipartite repo root). Brief:
 >   issue-lead comments, slot phase changes
 > - `active_items`: per active slot — clone, issue, phase,
 >   stop_reason, lead assessment (one line each)
-> - `action_candidates`: pending spawn intent in `$CLONE_ROOT/.spawn-prompts/`
->   (either `<N>.md` or `spawn-<N>.txt` — check both) waiting to be
->   executed; merged PRs that should trigger slot cleanup. (Deciding *which* open
->   issues are ready to spawn is `/bip-epic`'s call, not this poll's —
->   report raw signal, not a readiness verdict.)
+> - `action_candidates`: pending spawn intent directly in
+>   `$CLONE_ROOT/.spawn-prompts/` (either `<N>.md` or `spawn-<N>.txt` —
+>   check both) waiting to be executed — ignore anything under
+>   `.spawn-prompts/consumed/`, that's already-launched intent, not
+>   pending; merged PRs that should trigger slot cleanup. (Deciding
+>   *which* open issues are ready to spawn is `/bip-epic`'s call, not
+>   this poll's — report raw signal, not a readiness verdict.)
 > - `surprises`: `needs-human`/`completed` slots, stale status
 >   files, contradictions, `RECOMMEND DEEPER LOOK` flags
 

--- a/skills/bip-conductor-spawn/SKILL.md
+++ b/skills/bip-conductor-spawn/SKILL.md
@@ -58,8 +58,10 @@ narrow this check to one pattern.
   says. Your job is to check it against live fleet state (Step 2b) and
   append fleet facts it structurally couldn't know: which host/clone is
   actually free, a concurrent worker editing an overlapping file, a
-  build running on a target remote host. Delete the intent file after a
-  successful launch (Step 5) — it has done its job.
+  build running on a target remote host. Mark the intent file consumed
+  after a successful launch (Step 6) — it has done its job, but the
+  directory lives outside git, so this is a move to `consumed/`, not a
+  delete (see Step 6).
 - **No intent file** (conductor-initiated respawn, routine maintenance,
   quick fix with no upstream epic session): compose the prompt from the
   issue directly, same as before. This is the escape hatch, not the
@@ -552,9 +554,17 @@ Always go through `bip spawn` which handles the full lifecycle correctly.
 ### Step 6: Confirm
 
 If launch succeeded and a `.spawn-prompts/` intent file (`$INTENT` from
-Step 3) was consumed, delete it now — its job is done, and leaving it
-behind is exactly the kind of finished-but-undeleted artifact that
-accretes across a fleet.
+Step 3) was used, mark it consumed now — don't delete it. The
+directory lives outside every clone's git, so deletion there is
+unrecoverable, and a still-open issue may have another live session
+referencing the same brief. Moving it aside is reversible and lets
+`/bip-conductor-tuckin` Step 2 report it as consumed rather than
+queued:
+
+```bash
+source "$(dirname "<this-skill's-base-directory>")/lib/spawn-intent.sh"
+mark_spawn_intent_consumed "$INTENT"
+```
 
 Report to the user:
 - Which clone was spawned

--- a/skills/bip-conductor-tuckin/SKILL.md
+++ b/skills/bip-conductor-tuckin/SKILL.md
@@ -62,9 +62,12 @@ List `$CLONE_ROOT/.spawn-prompts/` and report two groups separately —
 these are the epic's authored intent, not conductor state, so don't
 touch their contents either way:
 
-- **Queued** — files directly in `.spawn-prompts/` (either `<N>.md` or
-  `spawn-<N>.txt` — check both, the directory holds both live
-  conventions). Still waiting on execution.
+- **Queued** — regular files directly in `.spawn-prompts/`:
+  `find "$CLONE_ROOT/.spawn-prompts" -maxdepth 1 -type f \( -name
+  '*.md' -o -name 'spawn-*.txt' \)` (both naming conventions live
+  there). `-type f` matters: a plain `ls` also lists the `consumed/`
+  directory itself as an entry, which is not a queued intent file.
+  Still waiting on execution.
 - **Consumed** — files under `.spawn-prompts/consumed/`. Already
   launched by `/bip-conductor-spawn` Step 6.
 

--- a/skills/bip-conductor-tuckin/SKILL.md
+++ b/skills/bip-conductor-tuckin/SKILL.md
@@ -56,26 +56,47 @@ Update slots the conductor has direct knowledge about. This includes:
 Do not guess status for slots with active sessions that may have
 progressed beyond what the conductor last observed.
 
-### Step 2: Note pending spawn intent
+### Step 2: Note queued and consumed spawn intent
 
-List any `$CLONE_ROOT/.spawn-prompts/` files still waiting on
-execution (either `<N>.md` or `spawn-<N>.txt` — check both, the
-directory holds both live conventions) — these are the epic's authored
-intent, not conductor state, so don't touch their contents, just
-confirm they're still there and
-report them so the next conductor session (or the user) knows what's
-queued.
+List `$CLONE_ROOT/.spawn-prompts/` and report two groups separately —
+these are the epic's authored intent, not conductor state, so don't
+touch their contents either way:
 
-### Step 3: Update MEMORY.md (lightweight)
+- **Queued** — files directly in `.spawn-prompts/` (either `<N>.md` or
+  `spawn-<N>.txt` — check both, the directory holds both live
+  conventions). Still waiting on execution.
+- **Consumed** — files under `.spawn-prompts/consumed/`. Already
+  launched by `/bip-conductor-spawn` Step 6.
 
-Most state should already be in `.epic-status.json` per slot. Only
-update MEMORY.md for fleet-level context that doesn't fit there:
+Reporting these separately matters: a consumed file left in the top
+level (or a queued one reported as consumed) invites either a
+re-spawn of work that's already running or merged, or a queued brief
+getting ignored as if it were stale. Report both groups so the next
+conductor session (or the user) knows what's actually queued vs
+already launched.
 
-- Host/cache quirks (which remote host had a warm cache for what,
-  which host was mid-build)
-- Clone-pool layout decisions
-- Things the next conductor session should know that aren't obvious
-  from the slot files
+### Step 3: Filter and route fleet-level findings
+
+Most state should already be in `.epic-status.json` per slot. Before
+recording anything anywhere, run each candidate fleet-level finding
+through this filter:
+
+1. **Is it derived?** Recomputable from `git`, `tmux`, `gh`, or the
+   filesystem — record nothing, whatever the destination would have
+   been. Which remote host had a warm cache, which host was mid-build,
+   local cache sizes, open-issue counts, which worker was blocked: all
+   of these are re-measurable on demand and go stale within hours, so
+   don't write them down anywhere, including MEMORY.md.
+2. **Is it already recorded?** A finding that produced an issue, PR,
+   test, or doc needs no second copy.
+
+Only what survives both gates gets a destination:
+- A durable repo-level fact → a `CLAUDE.md`.
+- A workflow rule → a skill.
+- A finding → the test, doc, or issue it came from.
+- Nothing else fits → the Step 4 report below. This is where a user
+  who has opted out of auto-memory files will actually see it — don't
+  treat a MEMORY.md write as the only or required destination.
 
 ### Step 4: Report
 
@@ -85,8 +106,9 @@ Print a summary:
 ## Tuckin Complete
 
 - Slot status updated: cedar, issue-295
-- Pending spawn intent: i302 (retry logic)
-- MEMORY.md updated: yes
+- Queued spawn intent: i302 (retry logic)
+- Consumed spawn intent: i298 (already launched, moved to consumed/)
+- Fleet-level findings: <none survived the filter | routed to CLAUDE.md/skill/issue as listed>
 
 Safe to reset context. Topic-side state (EPIC bodies) is unaffected by
 this — run /bip-epic-tuckin if that session is resetting too.

--- a/skills/bip-conductor/SKILL.md
+++ b/skills/bip-conductor/SKILL.md
@@ -258,7 +258,11 @@ dispatch pattern in `SUBAGENT-SCAN.md` (bipartite repo root). Brief:
 > '*.md' -o -name 'spawn-*.txt' \)` — **both patterns**, since
 > `<N>.md` and the older `spawn-<N>.txt` are both live conventions in
 > that directory; a `-name '*.md'`-only find silently misses a real,
-> current `spawn-<N>.txt` intent file.
+> current `spawn-<N>.txt` intent file. `-maxdepth 1` also matters here:
+> `/bip-conductor-spawn` moves a launched intent file into a
+> `.spawn-prompts/consumed/` subdirectory instead of deleting it, and
+> this find must not descend into `consumed/` and report an
+> already-launched file as still pending.
 >
 > Classify each slot:
 > - `occupied`: has tmux window (regardless of agent status — user

--- a/skills/bip-epic-tuckin/SKILL.md
+++ b/skills/bip-epic-tuckin/SKILL.md
@@ -39,11 +39,11 @@ Before recording anything anywhere, run each candidate topic-level
 finding through this filter:
 
 1. **Is it derived?** Recomputable from `git`, `gh`, or the EPIC bodies
-   themselves — record nothing. Dependency-direction or collision
+   themselves — record nothing.
+2. **Does it already have a home?** Dependency-direction or collision
    findings belong in the EPIC body they concern (Step 1), not as a
-   separate copy.
-2. **Is it already recorded?** A finding that produced an issue, PR,
-   or EPIC body update needs no second copy.
+   separate copy. A finding that already produced an issue, PR, or
+   EPIC body update needs no second copy either.
 
 Only what survives both gates gets a destination:
 - A durable repo-level fact → a `CLAUDE.md`.

--- a/skills/bip-epic-tuckin/SKILL.md
+++ b/skills/bip-epic-tuckin/SKILL.md
@@ -32,16 +32,28 @@ pattern, not a separate cleanup pass.
 
 Report which EPICs were pushed (and which were skipped due to conflicts).
 
-### Step 2: Update MEMORY.md (lightweight)
+### Step 2: Filter and route topic-level findings
 
 Most state should already be in EPIC bodies (`ISSUE-EPIC-<N>.md`).
-Only update MEMORY.md for topic-level context that doesn't fit there:
+Before recording anything anywhere, run each candidate topic-level
+finding through this filter:
 
-- Key decisions and their rationale
-- Cross-EPIC patterns or dependencies
-- Dependency-direction or collision findings not yet folded into an
-  EPIC body
-- Things the next session should know that aren't obvious from the files
+1. **Is it derived?** Recomputable from `git`, `gh`, or the EPIC bodies
+   themselves — record nothing. Dependency-direction or collision
+   findings belong in the EPIC body they concern (Step 1), not as a
+   separate copy.
+2. **Is it already recorded?** A finding that produced an issue, PR,
+   or EPIC body update needs no second copy.
+
+Only what survives both gates gets a destination:
+- A durable repo-level fact → a `CLAUDE.md`.
+- A workflow rule → a skill.
+- A cross-EPIC pattern or key decision not yet captured anywhere →
+  the EPIC body it's most relevant to, or the Step 3 report below if
+  none fits.
+- Nothing else fits → the Step 3 report. This is where a user who has
+  opted out of auto-memory files will actually see it — don't treat a
+  MEMORY.md write as the only or required destination.
 
 ### Step 3: Report
 
@@ -52,7 +64,7 @@ Print a summary:
 
 - EPICs pushed: i281, i295
 - EPICs skipped (conflict): i310
-- MEMORY.md updated: yes
+- Topic-level findings: <none survived the filter | routed to CLAUDE.md/skill/EPIC body as listed>
 
 Safe to reset context. Fleet-side state (clones, slots) is unaffected
 by this — run /bip-conductor-tuckin if that session is resetting too.

--- a/skills/bip-epic/SKILL.md
+++ b/skills/bip-epic/SKILL.md
@@ -66,8 +66,12 @@ the rest of the file's fields are about.
 cat .epic-config.json
 ```
 
-Also read MEMORY.md from the auto-memory directory for topic-level
-context from previous sessions (decisions, findings, what's next).
+If this project uses the auto-memory directory, also read its
+MEMORY.md for topic-level context from previous sessions (decisions,
+findings, what's next) — some setups deliberately don't use it (e.g.
+because the directory is keyed by working directory and invisible to
+other clones), in which case skip this and rely on EPIC bodies and
+issue history instead.
 
 ### Step 2: Fan out scanners
 

--- a/skills/lib/spawn-intent.sh
+++ b/skills/lib/spawn-intent.sh
@@ -48,7 +48,11 @@ find_spawn_intent() {
 # queued, without reading file contents. A plain `mv`, not a delete —
 # `.spawn-prompts/` lives outside every clone's git, so deletion there
 # is unrecoverable, and `/bip-conductor-tuckin` needs to report queued
-# vs consumed separately (issue #198).
+# vs consumed separately (issue #198). A repeat consumption of the same
+# issue number (e.g. a re-spawn after the epic writes a fresh intent
+# file under the same name) overwrites the previous consumed file —
+# consumed/ is a queued-vs-consumed marker, not a full history, so only
+# the most recent consumption needs to be preserved.
 mark_spawn_intent_consumed() {
     local intent_path="$1"
     local consumed_dir

--- a/skills/lib/spawn-intent.sh
+++ b/skills/lib/spawn-intent.sh
@@ -41,3 +41,18 @@ find_spawn_intent() {
     ls "$clone_root/.spawn-prompts/$issue_number.md" \
        "$clone_root/.spawn-prompts/spawn-$issue_number.txt" 2>/dev/null | head -1
 }
+
+# mark_spawn_intent_consumed <intent-file-path>
+# Moves a spawn-intent file into a "consumed/" subdirectory sibling to
+# it, so a launched intent is distinguishable on disk from one still
+# queued, without reading file contents. A plain `mv`, not a delete —
+# `.spawn-prompts/` lives outside every clone's git, so deletion there
+# is unrecoverable, and `/bip-conductor-tuckin` needs to report queued
+# vs consumed separately (issue #198).
+mark_spawn_intent_consumed() {
+    local intent_path="$1"
+    local consumed_dir
+    consumed_dir="$(dirname "$intent_path")/consumed"
+    mkdir -p "$consumed_dir"
+    mv "$intent_path" "$consumed_dir/"
+}

--- a/tests/integration/spawn_intent_test.go
+++ b/tests/integration/spawn_intent_test.go
@@ -167,3 +167,16 @@ func TestMarkSpawnIntentConsumed(t *testing.T) {
 		t.Fatalf("find_spawn_intent after consuming = %q, want empty (not still queued)", got)
 	}
 }
+
+func TestMarkSpawnIntentConsumedMissingSourceFailsFast(t *testing.T) {
+	cloneRoot := t.TempDir()
+	missingPath := filepath.Join(cloneRoot, ".spawn-prompts", "302.md")
+
+	script := "source " + shellQuote(spawnIntentScriptPath(t)) + "\n" +
+		"mark_spawn_intent_consumed " + shellQuote(missingPath)
+	cmd := exec.Command("bash", "-c", script)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("mark_spawn_intent_consumed on missing source succeeded, want non-zero exit; output: %s", out)
+	}
+}

--- a/tests/integration/spawn_intent_test.go
+++ b/tests/integration/spawn_intent_test.go
@@ -134,3 +134,36 @@ func TestFindSpawnIntent(t *testing.T) {
 		})
 	}
 }
+
+func TestMarkSpawnIntentConsumed(t *testing.T) {
+	cloneRoot := t.TempDir()
+	promptsDir := filepath.Join(cloneRoot, ".spawn-prompts")
+	if err := os.MkdirAll(promptsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	intentPath := filepath.Join(promptsDir, "302.md")
+	if err := os.WriteFile(intentPath, []byte("intent"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	callSpawnIntentFunc(t, "mark_spawn_intent_consumed", intentPath)
+
+	if _, err := os.Stat(intentPath); !os.IsNotExist(err) {
+		t.Fatalf("intent file still present at original path after consuming: err=%v", err)
+	}
+
+	consumedPath := filepath.Join(promptsDir, "consumed", "302.md")
+	data, err := os.ReadFile(consumedPath)
+	if err != nil {
+		t.Fatalf("expected consumed file at %s: %v", consumedPath, err)
+	}
+	if string(data) != "intent" {
+		t.Fatalf("consumed file contents = %q, want %q", data, "intent")
+	}
+
+	// A file distinguishable as consumed must not still resolve as queued.
+	got := callSpawnIntentFunc(t, "find_spawn_intent", cloneRoot, "302")
+	if got != "" {
+		t.Fatalf("find_spawn_intent after consuming = %q, want empty (not still queued)", got)
+	}
+}


### PR DESCRIPTION
## Summary

Three independent, small fixes surfaced from the first real use of `/bip-conductor-tuckin` (phyz fleet, right after #194's skill rename):

- `make install`'s `symlink-skills` and `symlink-agents` targets now prune broken symlinks under `~/.claude/skills/` and `~/.claude/agents/` after linking, so a renamed or deleted skill/agent doesn't leave a dangling entry under its old name. Only symlinks that fail to resolve are removed — real directories and symlinks that still resolve (e.g. a hand-made or plugin skill) are untouched.
- `/bip-conductor-tuckin` and `/bip-epic-tuckin` no longer mandate a MEMORY.md write. Both now apply a two-gate filter (is it derived from `git`/`tmux`/`gh`/filesystem? does it already have a home — an issue, PR, EPIC body, test, or doc?) before routing whatever survives to a `CLAUDE.md`, a skill, or the tuckin report itself — the destination a project that doesn't use auto-memory files will actually see. `/bip-epic`'s MEMORY.md read is now conditional on the project using auto-memory at all.
- `skills/lib/spawn-intent.sh` gains `mark_spawn_intent_consumed()`, which moves a launched intent file into `.spawn-prompts/consumed/` instead of deleting it (the directory lives outside every clone's git, so deletion there is unrecoverable). `/bip-conductor-spawn` Step 6 calls it after a successful launch; `/bip-conductor-tuckin` Step 2 now reports queued and consumed spawn intent as separate groups, using `find -type f` so the `consumed/` directory itself is never misread as a queued entry. `/bip-conductor` and `/bip-conductor-poll`, the other two readers of `.spawn-prompts/`, are updated to ignore `consumed/` too.

Closes #198

**Migration note**: this convention is forward-looking. Any `.spawn-prompts/` directory that already holds top-level files for intents launched *before* this PR merges (e.g. the phyz fleet's `spawn-2047.txt`, `spawn-2051.txt`) predates `mark_spawn_intent_consumed()` and needs a one-time manual move (`mkdir -p consumed && mv <file> consumed/`) on that machine — this PR does not migrate existing fleets.

## Test plan

- `tests/integration/spawn_intent_test.go`: `TestMarkSpawnIntentConsumed` (moves the file, leaves nothing at the original path, confirms `find_spawn_intent` no longer reports it as queued) and `TestMarkSpawnIntentConsumedMissingSourceFailsFast` (a missing source errors rather than silently no-op-ing, so a failed launch can't look consumed). Existing `spawn-intent.sh` tests still pass.
- Manually verified the `make install` prune for both `symlink-skills` and `symlink-agents`: created a broken symlink, a resolving symlink (standing in for a hand-made skill/agent), and a plain directory under fake `$HOME/.claude/{skills,agents}`, ran the targets, confirmed only the broken symlink was removed.
- `go build`, `go vet`, `gofmt -l .`, and `go test ./...` all clean.