### PR TITLE
Apply #199's MEMORY.md filter to bip-conductor-poll's Housekeeping

### DIFF
--- a/skills/bip-conductor-poll/SKILL.md
+++ b/skills/bip-conductor-poll/SKILL.md
@@ -223,11 +223,22 @@ If a merge closes an issue tracked in an EPIC, that's signal `/bip-epic`
 needs, not something to act on here — surface it under
 `changes_since_baseline` and move on.
 
-#### Memory
+#### Filter and route fleet-level findings
 
-- Update MEMORY.md only for fleet-level decisions/patterns (clone
-  layout, host quirks). Topic-level decisions belong to `/bip-epic`'s
-  own memory, not here.
+Before recording anything anywhere, run each candidate fleet-level
+finding through this filter (same as `/bip-conductor-tuckin` Step 3):
+
+1. **Is it derived?** Recomputable from `git`, `tmux`, `gh`, or the
+   filesystem — record nothing. Host quirks (which host had a warm
+   cache, which was mid-build) are derived and go stale within hours;
+   don't write them down anywhere, including MEMORY.md.
+2. **Is it already recorded?** A finding that produced an issue, PR,
+   test, or doc needs no second copy.
+
+Only what survives both gates gets a destination: a durable clone-pool
+layout decision → a `CLAUDE.md`; a workflow rule → a skill; a
+topic-level decision → `/bip-epic`'s own memory, not here. Nothing
+else fits → the poll report itself.
 
 ## Conventions
 


### PR DESCRIPTION
## Summary

#199 removed the unconditional "write MEMORY.md" instruction from `bip-conductor-tuckin` and `bip-epic-tuckin`, replacing it with a two-gate filter (is it derived from `git`/`tmux`/`gh`/filesystem? is it already recorded elsewhere?). It missed a third copy of the same mandate: `bip-conductor-poll`'s Housekeeping section still said "Update MEMORY.md only for fleet-level decisions/patterns (clone layout, host quirks)" — unconditional, with "host quirks" as an example that is itself the derived-state anti-pattern the filter exists to rule out.

This applies the identical filter to that section, so all three fleet skills now agree.

Follow-up to #198/#199, caught in review of #199 (phyz-1a).

## Test plan

Docs-only change, no automated test applies. `go build`/`go vet`/`gofmt -l .`/`go test ./...` unaffected and still clean.