### PR TITLE
Migrate remaining inline clone_root resolutions to resolve_clone_root

### DIFF
--- a/skills/bip-conductor-handoff/SKILL.md
+++ b/skills/bip-conductor-handoff/SKILL.md
@@ -84,13 +84,21 @@ Then select or create a slot:
 
 **Clone mode** (`local_worktrees` absent or false):
 ```bash
-CLONE_ROOT=$(jq -r .clone_root .epic-config.json | sed "s|^~|$HOME|")
+source "$(dirname "<this-skill's-base-directory>")/lib/spawn-intent.sh"
+CLONE_ROOT=$(resolve_clone_root .epic-config.json)
 # Find an idle clone (on main, clean worktree)
 for name in $(jq -r '.clone_names[]' .epic-config.json); do
   branch=$(git -C "$CLONE_ROOT/$name" branch --show-current 2>/dev/null)
   [ "$branch" = "main" ] && echo "$name"
 done
 ```
+
+`<this-skill's-base-directory>` is this skill's base directory as given
+at invocation (e.g. `/home/user/.claude/skills/bip-conductor-handoff`);
+the shared helper lives at `lib/spawn-intent.sh`, a sibling of every
+skill directory (see `skills/lib/spawn-intent.sh` in the `bipartite`
+repo).
+
 Pick the first idle clone **that is not the current clone**. The
 handoff should move work to a different slot so the current session
 can wind down cleanly. If all other clones are busy, use the current
@@ -100,7 +108,8 @@ from `new_clone_names` in the config.
 
 **Worktree mode** (`local_worktrees: true`):
 ```bash
-CLONE_ROOT=$(jq -r .clone_root "$MAIN_CHECKOUT/.epic-config.json" | sed "s|^~|$HOME|")
+source "$(dirname "<this-skill's-base-directory>")/lib/spawn-intent.sh"
+CLONE_ROOT=$(resolve_clone_root "$MAIN_CHECKOUT/.epic-config.json")
 SLOT="$CLONE_ROOT/issue-<N>"
 SLUG=$(gh issue view <N> --json title -q '.title' | tr '[:upper:]' '[:lower:]' | awk '{for(i=1;i<=4&&i<=NF;i++) printf "%s%s",$i,(i<4&&i<NF?"-":"")}')
 
@@ -150,7 +159,8 @@ Follow `/bip-conductor-spawn` Steps 3-4 to compose the prompt:
 Then launch with the correct flags for your mode:
 
 ```bash
-CLONE_ROOT=$(jq -r .clone_root .epic-config.json | sed "s|^~|$HOME|")
+source "$(dirname "<this-skill's-base-directory>")/lib/spawn-intent.sh"
+CLONE_ROOT=$(resolve_clone_root .epic-config.json)
 
 # Clone mode: --name is NNN-clone (e.g. "281-cedar")
 bip spawn --prompt-file /tmp/spawn-<N>.txt \

--- a/skills/bip-conductor-poll/SKILL.md
+++ b/skills/bip-conductor-poll/SKILL.md
@@ -200,7 +200,8 @@ check 1 with slot branches):
 
 **Worktree mode**:
 ```bash
-CLONE_ROOT=$(jq -r .clone_root .epic-config.json | sed "s|^~|$HOME|")
+source "$(dirname "<this-skill's-base-directory>")/lib/spawn-intent.sh"
+CLONE_ROOT=$(resolve_clone_root .epic-config.json)
 # Confirm PR is merged before removing
 gh pr list --head <branch> --state merged --json number | jq length
 # If merged:
@@ -208,9 +209,15 @@ git worktree remove "$CLONE_ROOT/issue-<N>"
 git branch -d <branch>
 ```
 
+`<this-skill's-base-directory>` is this skill's base directory as given
+at invocation (e.g. `/home/user/.claude/skills/bip-conductor-poll`); the
+shared helper lives at `lib/spawn-intent.sh`, a sibling of every skill
+directory (see `skills/lib/spawn-intent.sh` in the `bipartite` repo).
+
 **Clone mode**:
 ```bash
-CLONE_ROOT=$(jq -r .clone_root .epic-config.json | sed "s|^~|$HOME|")
+source "$(dirname "<this-skill's-base-directory>")/lib/spawn-intent.sh"
+CLONE_ROOT=$(resolve_clone_root .epic-config.json)
 git -C "$CLONE_ROOT/<clone>" checkout main
 git -C "$CLONE_ROOT/<clone>" pull --ff-only origin main
 rm -f "$CLONE_ROOT/<clone>/.epic-status.json" "$CLONE_ROOT/<clone>/.epic-worklog.md"

--- a/skills/bip-conductor-spawn/SKILL.md
+++ b/skills/bip-conductor-spawn/SKILL.md
@@ -100,7 +100,8 @@ across operators and finishing workers self-claim slots via
 `/bip-conductor-handoff`, so filter these out to avoid choosing one that's
 already taken:
 ```bash
-CLONE_ROOT=$(jq -r .clone_root .epic-config.json | sed "s|^~|$HOME|")
+source "$(dirname "<this-skill's-base-directory>")/lib/spawn-intent.sh"
+CLONE_ROOT=$(resolve_clone_root .epic-config.json)
 OCCUPIED=$(tmux list-panes -a -F '#{pane_current_path}' 2>/dev/null)
 for name in $(jq -r '.clone_names[]' .epic-config.json); do
   dir="$CLONE_ROOT/$name"
@@ -127,7 +128,8 @@ is the first 4 words of the issue title, lowercased and hyphenated.
 
 Check if slot already exists:
 ```bash
-CLONE_ROOT=$(jq -r .clone_root .epic-config.json | sed "s|^~|$HOME|")
+source "$(dirname "<this-skill's-base-directory>")/lib/spawn-intent.sh"
+CLONE_ROOT=$(resolve_clone_root .epic-config.json)
 SLOT="$CLONE_ROOT/issue-<N>"
 if [ -d "$SLOT" ]; then
   # Worktree exists — check for active tmux window
@@ -151,7 +153,8 @@ fi
 
 **Clone mode**:
 ```bash
-CLONE_ROOT=$(jq -r .clone_root .epic-config.json | sed "s|^~|$HOME|")
+source "$(dirname "<this-skill's-base-directory>")/lib/spawn-intent.sh"
+CLONE_ROOT=$(resolve_clone_root .epic-config.json)
 cd "$CLONE_ROOT/<clone>"
 git checkout main && git pull --ff-only origin main
 rm -f .epic-status.json .epic-worklog.md
@@ -529,7 +532,8 @@ pick another idle clone. Pass `--force` only when you deliberately want a
 second session in the same directory.
 
 ```bash
-CLONE_ROOT=$(jq -r .clone_root .epic-config.json | sed "s|^~|$HOME|")
+source "$(dirname "<this-skill's-base-directory>")/lib/spawn-intent.sh"
+CLONE_ROOT=$(resolve_clone_root .epic-config.json)
 
 # Write prompt to temp file (conductor does this, NOT via shell expansion)
 # Use the Write tool to create /tmp/spawn-<N>.txt with the full prompt
@@ -582,7 +586,8 @@ If no monitor is running, suggest starting one or using
 
 **Clone mode** — create a new clone and register it:
 ```bash
-CLONE_ROOT=$(jq -r .clone_root .epic-config.json | sed "s|^~|$HOME|")
+source "$(dirname "<this-skill's-base-directory>")/lib/spawn-intent.sh"
+CLONE_ROOT=$(resolve_clone_root .epic-config.json)
 REPO=$(jq -r .github_repo .epic-config.json)
 cd "$CLONE_ROOT"
 git clone "git@github.com:$REPO.git" <new-name>
@@ -601,7 +606,8 @@ in Step 1 and named `issue-<N>`. No config changes required.
 
 **Worktree mode** — when an issue's PR is merged:
 ```bash
-CLONE_ROOT=$(jq -r .clone_root .epic-config.json | sed "s|^~|$HOME|")
+source "$(dirname "<this-skill's-base-directory>")/lib/spawn-intent.sh"
+CLONE_ROOT=$(resolve_clone_root .epic-config.json)
 git worktree remove "$CLONE_ROOT/issue-<N>"
 git branch -d <N>-short-desc
 ```

--- a/skills/bip-conductor-tuckin/SKILL.md
+++ b/skills/bip-conductor-tuckin/SKILL.md
@@ -35,7 +35,8 @@ For each slot the conductor interacted with this session:
 2. If the conductor has newer information (e.g., a slot finished,
    got blocked, or changed phase), update the file:
    ```bash
-   CLONE_ROOT=$(jq -r .clone_root .epic-config.json | sed "s|^~|$HOME|")
+   source "$(dirname "<this-skill's-base-directory>")/lib/spawn-intent.sh"
+   CLONE_ROOT=$(resolve_clone_root .epic-config.json)
    cat > "$CLONE_ROOT/<slot>/.epic-status.json" << 'EOF'
    {
      "issue": <N>,
@@ -47,6 +48,12 @@ For each slot the conductor interacted with this session:
    }
    EOF
    ```
+
+   `<this-skill's-base-directory>` is this skill's base directory as
+   given at invocation (e.g. `/home/user/.claude/skills/bip-conductor-tuckin`);
+   the shared helper lives at `lib/spawn-intent.sh`, a sibling of every
+   skill directory (see `skills/lib/spawn-intent.sh` in the `bipartite`
+   repo).
 
 Update slots the conductor has direct knowledge about. This includes:
 - Slots whose PRs were merged this session (even if the slot's own

--- a/skills/bip-conductor/SKILL.md
+++ b/skills/bip-conductor/SKILL.md
@@ -227,9 +227,15 @@ reuses the file in place, so a draft that's mid-revision on an existing
 issue is expected here too — don't treat those as orphans).
 
 ```bash
-CLONE_ROOT=$(jq -r .clone_root .epic-config.json | sed "s|^~|$HOME|")
+source "$(dirname "<this-skill's-base-directory>")/lib/spawn-intent.sh"
+CLONE_ROOT=$(resolve_clone_root .epic-config.json)
 find "$CLONE_ROOT" -maxdepth 2 -name 'ISSUE-*.md' -not -path '*/_ignore/*'
 ```
+
+`<this-skill's-base-directory>` is this skill's base directory as given
+at invocation (e.g. `/home/user/.claude/skills/bip-conductor`); the
+shared helper lives at `lib/spawn-intent.sh`, a sibling of every skill
+directory (see `skills/lib/spawn-intent.sh` in the `bipartite` repo).
 
 **Never auto-delete or auto-file these.** An unfiled draft is authored
 state — the only copy of someone's unfinished thinking — and at least


### PR DESCRIPTION
## Summary
PR #196 extracted `resolve_clone_root`/`find_spawn_intent` into `skills/lib/spawn-intent.sh` but, per its scope boundary, only migrated the two call sites named in its success criteria. This PR migrates the remaining 13 inline `jq -r .clone_root <config> | sed "s|^~|$HOME|"` snippets across the `bip-conductor*` skill family to call the shared helper instead, so a future edit to any of these can't silently reintroduce the tilde-expansion bug in a spot the #195 test suite doesn't cover.

- `skills/bip-conductor-handoff/SKILL.md` (3 sites — one reads from `$MAIN_CHECKOUT/.epic-config.json` instead of the cwd, passed through as `resolve_clone_root`'s argument)
- `skills/bip-conductor/SKILL.md` (1 site)
- `skills/bip-conductor-tuckin/SKILL.md` (1 site)
- `skills/bip-conductor-spawn/SKILL.md` (6 sites, excluding the one #196 already migrated)
- `skills/bip-conductor-poll/SKILL.md` (2 sites)

## Test plan
- `go test ./tests/integration/... -run 'TestResolveCloneRoot|TestFindSpawnIntent|TestMarkSpawnIntentConsumed'` — all pass unchanged, as expected for a call-site-only migration with no behavior change to the helper.
- `grep -rn 'jq -r .clone_root' skills/` — zero remaining inline snippets.
- Since these snippets are prose-embedded bash rather than executable code, no test harness runs them directly. Extracted and `bash -n`-checked all edited blocks; the only "errors" are pre-existing `<placeholder>` template syntax (e.g. `<N>`, `<clone>`) that bash misparses as redirection — identical on `main` before this change, confirmed by diffing against the pre-edit blocks.

Closes #197