### PR TITLE
Reflow skills/*/SKILL.md to one-sentence-per-line

### DIFF
--- a/skills/CONVENTIONS.md
+++ b/skills/CONVENTIONS.md
@@ -1,0 +1,11 @@
+# Formatting conventions for skill files
+
+This governs `skills/*/SKILL.md` only. It does not apply to GitHub issue, PR, or comment bodies — those follow `PROSE-DISCIPLINE.md` instead, which hard-wraps prose into one line per paragraph so GitHub's renderer controls wrapping.
+
+## One sentence per line
+
+Every prose paragraph, list item, and blockquote in a skill file uses semantic line breaks: each sentence starts a new line. Blank lines still separate paragraphs, list items, and headings as usual. Code fences and table rows are exempt — leave their internal line breaks exactly as needed for the code or table to render and function correctly.
+
+**Why**: skill files are source, read as prompt text, edited with line-based diffs, and checked with `grep`. A sentence hard-wrapped across a fixed column defeats all three — a `grep` for a phrase spanning a line break silently misses it, editing one sentence inside a wrapped paragraph touches every line in that paragraph and buries the real diff, and Markdown rendering is unaffected either way (a human or an agent reading the file doesn't care about source line breaks within a paragraph). See PR #191 and issue #192 for the incident that prompted this.
+
+**How to apply**: when writing or editing a skill file, break after each sentence-ending `.`, `!`, or `?`, not at a fixed column. A list item with multiple sentences gets one sentence per line, with continuation lines indented to align under the marker (`- ` = 2 spaces, `1. ` = 3 spaces, etc.) — the same continuation indent already used for wrapped list items today.

--- a/skills/bip-board/SKILL.md
+++ b/skills/bip-board/SKILL.md
@@ -5,7 +5,8 @@ description: "Manage GitHub project boards. Add, move, and remove issues; boards
 
 # /bip-board
 
-Manage GitHub project boards. Boards are resolved automatically from repo → channel → board mappings in sources.yml.
+Manage GitHub project boards.
+Boards are resolved automatically from repo → channel → board mappings in sources.yml.
 
 ## Quick Reference
 
@@ -41,7 +42,8 @@ Example sources.yml:
 ## Subcommands
 
 ### list
-Show board items grouped by status. Shows ALL boards by default.
+Show board items grouped by status.
+Shows ALL boards by default.
 
 ```bash
 bip board list                  # All boards

--- a/skills/bip-checkin/SKILL.md
+++ b/skills/bip-checkin/SKILL.md
@@ -5,7 +5,8 @@ description: "Check in on recent GitHub activity across tracked repos. Filters t
 
 # /bip-checkin
 
-Check in on recent activity across tracked repos. Shows issues, PRs, and comments that need your attention.
+Check in on recent activity across tracked repos.
+Shows issues, PRs, and comments that need your attention.
 
 ## Instructions
 
@@ -36,12 +37,10 @@ By default, checkin only shows items where you need to act:
 | Your issue/PR, they commented last | Yes | They replied |
 | Your issue/PR, you commented last | No | Waiting for their reply |
 
-*"You're involved" means at least one of: you're an assignee, requested
-reviewer, @mentioned in the body, or have previously commented on the item.
+*"You're involved" means at least one of: you're an assignee, requested reviewer, @mentioned in the body, or have previously commented on the item.
 
-Use `--broad` to restore the older behavior (every teammate item with no
-window activity counts as needing review). Use `--all` to disable filtering
-entirely.
+Use `--broad` to restore the older behavior (every teammate item with no window activity counts as needing review).
+Use `--all` to disable filtering entirely.
 
 ## Options
 
@@ -68,13 +67,15 @@ Each window:
 - Launches Claude Code with context about the issue/PR
 - Named by repo and number (e.g., `repo#123`)
 
-Tmux window existence = item under review. Close the window when done.
+Tmux window existence = item under review.
+Close the window when done.
 
 ## Board triage (optional)
 
 After presenting checkin results, ask the user:
 
-> "Would you like to review board triage? I can check if any issues from this checkin should be added to project boards."
+> "Would you like to review board triage?
+> I can check if any issues from this checkin should be added to project boards."
 
 If they agree, then:
 

--- a/skills/bip-comment-check/SKILL.md
+++ b/skills/bip-comment-check/SKILL.md
@@ -6,7 +6,9 @@ allowed-tools: Agent, Bash, Read, Glob, Grep, Edit
 
 # /bip-comment-check
 
-Fact-check a PR review, comment, or pasted review text against the actual code. Reviews often contain false claims about missing code, broken imports, or incorrect logic. This skill verifies each claim by reading the relevant files.
+Fact-check a PR review, comment, or pasted review text against the actual code.
+Reviews often contain false claims about missing code, broken imports, or incorrect logic.
+This skill verifies each claim by reading the relevant files.
 
 ## Usage
 
@@ -19,7 +21,9 @@ Also works when the user pastes review text directly into the conversation.
 
 ## Core Principle
 
-**Read the code before evaluating any claim.** Never accept a reviewer's assertion at face value. Every factual claim must be verified against the actual source on the PR branch.
+**Read the code before evaluating any claim.**
+Never accept a reviewer's assertion at face value.
+Every factual claim must be verified against the actual source on the PR branch.
 
 ## Workflow
 
@@ -33,7 +37,8 @@ Determine the source of claims to check:
    gh pr view <N> --json reviews,comments
    gh api repos/{owner}/{repo}/pulls/<N>/comments
    ```
-   Note: `reviews` contains top-level review bodies; inline code comments (attached to specific lines) come from the `/pulls/<N>/comments` endpoint. Fetch both to get the full picture.
+Note: `reviews` contains top-level review bodies; inline code comments (attached to specific lines) come from the `/pulls/<N>/comments` endpoint.
+Fetch both to get the full picture.
 3. **If no argument**, detect the current branch's PR:
    ```bash
    gh pr view --json number,reviews,comments
@@ -56,7 +61,8 @@ git show origin/<pr-branch>:path/to/file.py
 
 ### Step 3: Identify checkable claims
 
-Parse the review into discrete, falsifiable claims. Focus on:
+Parse the review into discrete, falsifiable claims.
+Focus on:
 
 - **"File X is missing / not updated"** — verify the file exists and contains what's expected
 - **"Line N does Y"** — read the actual line
@@ -64,14 +70,16 @@ Parse the review into discrete, falsifiable claims. Focus on:
 - **"Code at line N has bug Z"** — read surrounding context and evaluate
 - **"Test doesn't cover X"** — read the test
 - **"Pattern A should be pattern B"** — check if the code already uses pattern B
-- **"This is fragile / breaks when..."** — evaluate whether the failure scenario is actually possible given the math or data invariants
+- **"This is fragile / breaks when..."**
+  — evaluate whether the failure scenario is actually possible given the math or data invariants
 - **"Variable/dict is indexed by position N"** — check actual data structure (list vs dict, positional vs keyed)
 
 Skip subjective style preferences that have no factual component.
 
 ### Step 4: Verify each claim against the code
 
-For each claim, **read the relevant source files**. Use dedicated tools:
+For each claim, **read the relevant source files**.
+Use dedicated tools:
 
 - `Read` to examine specific files and line numbers
 - `Grep` to find patterns across the codebase
@@ -110,7 +118,8 @@ For each claim, assign a verdict:
 
 Apply `PROSE-DISCIPLINE.md` (bipartite repo root) when writing the verdict.
 
-Present findings as a numbered list matching the original review's numbering. For each claim:
+Present findings as a numbered list matching the original review's numbering.
+For each claim:
 
 1. **State the verdict** (bold)
 2. **Quote the key assertion** from the review
@@ -136,13 +145,20 @@ this is intentional. A comment explaining the mathematical reason would help.
 
 ## Guidelines
 
-- **Err on the side of reading more code**, not less. A 30-second file read prevents a false verdict.
-- **Check the actual branch**, not main. Reviews are about PR code.
-- **Don't assume the reviewer is right** just because they sound confident. Detailed, specific-sounding claims are often the most wrong.
-- **Don't assume the reviewer is wrong** either. Verify, don't assume.
-- **When claims involve data structures**, check the actual type (dict vs list, keyed vs positional). Reviewers frequently misremember these.
-- **When claims involve math**, read the documentation. Mathematical code often looks wrong to someone unfamiliar with the domain.
-- **Run the tests.** A claim that "all tests fail" is trivially verifiable.
+- **Err on the side of reading more code**, not less.
+  A 30-second file read prevents a false verdict.
+- **Check the actual branch**, not main.
+  Reviews are about PR code.
+- **Don't assume the reviewer is right** just because they sound confident.
+  Detailed, specific-sounding claims are often the most wrong.
+- **Don't assume the reviewer is wrong** either.
+  Verify, don't assume.
+- **When claims involve data structures**, check the actual type (dict vs list, keyed vs positional).
+  Reviewers frequently misremember these.
+- **When claims involve math**, read the documentation.
+  Mathematical code often looks wrong to someone unfamiliar with the domain.
+- **Run the tests.**
+  A claim that "all tests fail" is trivially verifiable.
 - **Restore the original branch** when done:
   ```bash
   git checkout <original-branch>

--- a/skills/bip-conductor-handoff/SKILL.md
+++ b/skills/bip-conductor-handoff/SKILL.md
@@ -5,24 +5,21 @@ description: Worker self-spawns a follow-up issue and hands off to a new slot
 
 # /bip-conductor-handoff
 
-Hand off work from a finishing worker session to a new slot. Run this
-from a **worker** (not the conductor) when your current issue is done
-and you know what should happen next.
+Hand off work from a finishing worker session to a new slot.
+Run this from a **worker** (not the conductor) when your current issue is done and you know what should happen next.
 
 ## Prerequisites — direction must be decided FIRST
 
 **Do not run this skill until you have a clear next direction.**
 
 If you have just finished an issue and are unsure what comes next:
-1. Think through what you learned, what's unresolved, and what the
-   logical next step is
-2. Write a **prose proposal** (2-4 sentences) describing the direction
-   and why it's the right next move
+1. Think through what you learned, what's unresolved, and what the logical next step is
+2. Write a **prose proposal** (2-4 sentences) describing the direction and why it's the right next move
 3. Present it to the user and **wait for confirmation**
 4. Only after the user agrees, proceed with the handoff
 
-This skill is for execution, not ideation. The thinking happens before
-you invoke it.
+This skill is for execution, not ideation.
+The thinking happens before you invoke it.
 
 ## Usage
 
@@ -51,8 +48,8 @@ If no issue number was provided:
 /bip-issue-next
 ```
 
-This drafts and creates the follow-up issue. Record the new issue
-number as `<N>`.
+This drafts and creates the follow-up issue.
+Record the new issue number as `<N>`.
 
 ### Step 3: Update the EPIC body
 
@@ -64,16 +61,15 @@ Follow the **EPIC body update pattern** from `/bip-epic`:
 3. If the current issue's PR is ready, check its box
 4. Conflict-check and push
 
-If the conflict check fails, report it and continue — the conductor
-will reconcile on next poll.
+If the conflict check fails, report it and continue — the conductor will reconcile on next poll.
 
 ### Step 4: Select or create a slot
 
 Read `.epic-config.json` from the repo root.
 
-**Finding the config**: In clone mode, `.epic-config.json` is in each
-clone's repo root. In worktree mode, it's in the **main checkout**
-(the conductor's working directory, not the worktree). To find it:
+**Finding the config**: In clone mode, `.epic-config.json` is in each clone's repo root.
+In worktree mode, it's in the **main checkout** (the conductor's working directory, not the worktree).
+To find it:
 ```bash
 # Worktree mode: find the main checkout
 MAIN_CHECKOUT=$(git worktree list | head -1 | awk '{print $1}')
@@ -93,18 +89,12 @@ for name in $(jq -r '.clone_names[]' .epic-config.json); do
 done
 ```
 
-`<this-skill's-base-directory>` is this skill's base directory as given
-at invocation (e.g. `/home/user/.claude/skills/bip-conductor-handoff`);
-the shared helper lives at `lib/spawn-intent.sh`, a sibling of every
-skill directory (see `skills/lib/spawn-intent.sh` in the `bipartite`
-repo).
+`<this-skill's-base-directory>` is this skill's base directory as given at invocation (e.g. `/home/user/.claude/skills/bip-conductor-handoff`); the shared helper lives at `lib/spawn-intent.sh`, a sibling of every skill directory (see `skills/lib/spawn-intent.sh` in the `bipartite` repo).
 
-Pick the first idle clone **that is not the current clone**. The
-handoff should move work to a different slot so the current session
-can wind down cleanly. If all other clones are busy, use the current
-clone as a last resort (after confirming with the user). If all clones
-including current are busy, offer to create a new clone using a name
-from `new_clone_names` in the config.
+Pick the first idle clone **that is not the current clone**.
+The handoff should move work to a different slot so the current session can wind down cleanly.
+If all other clones are busy, use the current clone as a last resort (after confirming with the user).
+If all clones including current are busy, offer to create a new clone using a name from `new_clone_names` in the config.
 
 **Worktree mode** (`local_worktrees: true`):
 ```bash
@@ -134,8 +124,8 @@ git checkout -b "<N>-$SLUG"
 rm -f .epic-status.json .epic-worklog.md
 ```
 
-The branch **must** be created before spawning. If the spawn starts
-on `main`, any uncommitted work lands on `main` and is hard to rescue.
+The branch **must** be created before spawning.
+If the spawn starts on `main`, any uncommitted work lands on `main` and is hard to rescue.
 
 **Worktree mode** — just clear stale status files:
 ```bash
@@ -152,9 +142,7 @@ Follow `/bip-conductor-spawn` Steps 3-4 to compose the prompt:
    - Ralph-loop invocation block
    - EPIC status protocol (`.epic-status.json` fields, worklog format)
    - Any phasing or gate criteria from the issue
-3. Use the **Write tool** to create `/tmp/spawn-<N>.txt` with the
-   full prompt (do NOT use shell redirection — complex prompts break
-   zsh expansion)
+3. Use the **Write tool** to create `/tmp/spawn-<N>.txt` with the full prompt (do NOT use shell redirection — complex prompts break zsh expansion)
 
 Then launch with the correct flags for your mode:
 
@@ -174,8 +162,7 @@ bip spawn --prompt-file /tmp/spawn-<N>.txt \
 ```
 
 **IMPORTANT**: Always use `--prompt-file`, never `--prompt "$(cat ...)"`.
-Always use `--dir` and `--name` — without them the tmux window gets
-a wrong name and the session runs in the wrong directory.
+Always use `--dir` and `--name` — without them the tmux window gets a wrong name and the session runs in the wrong directory.
 
 **Do NOT** use raw `tmux new-window` / `tmux send-keys` / `claude`.
 Always go through `bip spawn`.
@@ -186,8 +173,7 @@ If the current issue's PR is merged:
 - **Worktree mode**: the conductor will clean up on next poll
 - **Clone mode**: `git checkout main && git pull --ff-only`
 
-Don't force-remove your own worktree while you're in it — just let
-the conductor handle cleanup.
+Don't force-remove your own worktree while you're in it — just let the conductor handle cleanup.
 
 ### Step 8: Report
 
@@ -202,11 +188,9 @@ the conductor handle cleanup.
 ## Conventions
 
 Same as `/bip-epic`: `iN`/`pN` prefixes, full URLs on first mention.
-Tmux windows named `NNN-YYY` where NNN is the issue number and YYY is the
-clone/slot name (e.g. `281-cedar` in clone mode, `281-issue-281` in worktree mode).
+Tmux windows named `NNN-YYY` where NNN is the issue number and YYY is the clone/slot name (e.g. `281-cedar` in clone mode, `281-issue-281` in worktree mode).
 
 ## Layout config (issue #149)
 
-`.epic-config.json` keeps working. The newer global `layout:` block in
-`~/.config/bip/config.yml` configures worktree mode for non-EPIC `bip
-spawn`; see `docs/guides/layout.md`.
+`.epic-config.json` keeps working.
+The newer global `layout:` block in `~/.config/bip/config.yml` configures worktree mode for non-EPIC `bip spawn`; see `docs/guides/layout.md`.

--- a/skills/bip-conductor-poll/SKILL.md
+++ b/skills/bip-conductor-poll/SKILL.md
@@ -5,23 +5,17 @@ description: Quick poll of GitHub activity and clone status since last check
 
 # /bip-conductor-poll
 
-Lightweight mid-session update for the fleet conductor. Checks what
-changed on GitHub (as it bears on slots/clones) and in active clones
-since last check. Use this instead of `/bip-conductor` when you already
-have context established.
+Lightweight mid-session update for the fleet conductor.
+Checks what changed on GitHub (as it bears on slots/clones) and in active clones since last check.
+Use this instead of `/bip-conductor` when you already have context established.
 
-Fleet-scoped, not topic-scoped: this skill reconciles slots against
-GitHub state and does housekeeping. It does not update EPIC bodies —
-that's `/bip-epic`'s job, on its own cadence, driven by findings and
-completions rather than a poll timer.
+Fleet-scoped, not topic-scoped: this skill reconciles slots against GitHub state and does housekeeping.
+It does not update EPIC bodies — that's `/bip-epic`'s job, on its own cadence, driven by findings and completions rather than a poll timer.
 
-For continuous monitoring, prefer `bip epic watch` (started by
-`/bip-conductor` Step 7). It writes phase transitions to
-`.epic-notifications.log` in the conductor cwd; this poll skill reads
-new entries from that log to catch transitions the conductor may have
-missed. Use `/bip-conductor-poll` for:
-- Full GitHub reconciliation (merged PRs, new issues, comments) as it
-  bears on slot/clone state
+For continuous monitoring, prefer `bip epic watch` (started by `/bip-conductor` Step 7).
+It writes phase transitions to `.epic-notifications.log` in the conductor cwd; this poll skill reads new entries from that log to catch transitions the conductor may have missed.
+Use `/bip-conductor-poll` for:
+- Full GitHub reconciliation (merged PRs, new issues, comments) as it bears on slot/clone state
 - Slot cleanup
 - Catching up on log entries written while the conductor was idle
 
@@ -31,11 +25,8 @@ For periodic auto-polling: `/loop 10m /bip-conductor-poll`
 
 Two things stay in the primary because they're cheap and structured:
 
-**Notifications log tail** — if `bip epic watch` is running, it
-appends one JSONL line per phase transition to
-`.epic-notifications.log` in the conductor cwd. The state file
-`/tmp/.epic-poll-last-read` records the previous poll time as Unix
-seconds; pass the elapsed window to `--since`:
+**Notifications log tail** — if `bip epic watch` is running, it appends one JSONL line per phase transition to `.epic-notifications.log` in the conductor cwd.
+The state file `/tmp/.epic-poll-last-read` records the previous poll time as Unix seconds; pass the elapsed window to `--since`:
 
 ```bash
 LAST=$(cat /tmp/.epic-poll-last-read 2>/dev/null || echo $(($(date +%s) - 3600)))
@@ -44,159 +35,100 @@ bip epic watch --since "$((NOW - LAST))s" 2>/dev/null
 echo "$NOW" > /tmp/.epic-poll-last-read
 ```
 
-Surface any `needs-human` / `completed` transitions prominently per
-the section below.
+Surface any `needs-human` / `completed` transitions prominently per the section below.
 
-**Tmux window list** — `tmux list-windows -F "#W"` is one line of
-output and tells the subagent which slots to inspect.
+**Tmux window list** — `tmux list-windows -F "#W"` is one line of output and tells the subagent which slots to inspect.
 
-Everything else is delegated. Dispatch one `general-purpose` subagent
-for the combined poll (the poll is lighter than the cold start, so a
-single combined scan keeps round-trips down). Follow the dispatch
-pattern in `SUBAGENT-SCAN.md` (bipartite repo root). Brief:
+Everything else is delegated.
+Dispatch one `general-purpose` subagent for the combined poll (the poll is lighter than the cold start, so a single combined scan keeps round-trips down).
+Follow the dispatch pattern in `SUBAGENT-SCAN.md` (bipartite repo root).
+Brief:
 
-> Delta poll for the EPIC conductor since the previous poll. Tmux
-> windows currently open: `<list from tmux list-windows>`. Tasks:
+> Delta poll for the EPIC conductor since the previous poll.
+> Tmux windows currently open: `<list from tmux list-windows>`.
+> Tasks:
 >
-> 1. `gh pr list --search "is:pr is:merged sort:updated-desc"
->    --limit 5 --json number,title,mergedAt,body`. For each new
->    merge: note key results and whether it closes an issue.
-> 2. `gh pr list --json number,title,headRefName,state`. Note new
->    PRs or CI status changes.
-> 3. `gh issue list --search "sort:created-desc" --limit 5 --json
->    number,title,state,createdAt`.
-> 4. For each active slot (per the tmux list and any
->    `.epic-status.json` in `<clone_root>`), check the latest
->    issue-lead comment: `gh api
->    repos/<owner>/<repo>/issues/<N>/comments --jq '.[-1].body'`.
+> 1. `gh pr list --search "is:pr is:merged sort:updated-desc" --limit 5 --json number,title,mergedAt,body`.
+>    For each new merge: note key results and whether it closes an issue.
+> 2. `gh pr list --json number,title,headRefName,state`.
+>    Note new PRs or CI status changes.
+> 3. `gh issue list --search "sort:created-desc" --limit 5 --json number,title,state,createdAt`.
+> 4. For each active slot (per the tmux list and any `.epic-status.json` in `<clone_root>`), check the latest issue-lead comment: `gh api repos/<owner>/<repo>/issues/<N>/comments --jq '.[-1].body'`.
 >    Look for the `🤖 **Issue Lead**` prefix.
-> 5. Inventory slots from `.epic-config.json`. Clone mode: iterate
->    `clone_names`. Worktree mode: `find <clone_root> -maxdepth 1
->    -name 'issue-*' -type d`. For each slot, read
->    `.epic-status.json` and surface: phase, summary, scope,
->    stop_reason, lead_guidance. Migrate legacy phases:
->    `blocked → needs-human`, `pr-review → quality-gate`.
-> 6. For active slots, `git -C <slot> log --oneline main..HEAD |
->    head -5` to see recent commits.
-> 7. For slots that look finished or blocked, capture the last 20
->    lines of tmux: `tmux capture-pane -t <window> -p | tail -20`.
-> 8. Verify state with `gh pr view --json state` / `gh issue view
->    --json state` for anything you plan to flag — never claim
->    "open" or "merged" without a live confirmation.
+> 5. Inventory slots from `.epic-config.json`.
+>    Clone mode: iterate `clone_names`.
+>    Worktree mode: `find <clone_root> -maxdepth 1 -name 'issue-*' -type d`.
+>    For each slot, read `.epic-status.json` and surface: phase, summary, scope, stop_reason, lead_guidance.
+>    Migrate legacy phases: `blocked → needs-human`, `pr-review → quality-gate`.
+> 6. For active slots, `git -C <slot> log --oneline main..HEAD | head -5` to see recent commits.
+> 7. For slots that look finished or blocked, capture the last 20 lines of tmux: `tmux capture-pane -t <window> -p | tail -20`.
+> 8. Verify state with `gh pr view --json state` / `gh issue view --json state` for anything you plan to flag — never claim "open" or "merged" without a live confirmation.
 >
 > Return under 400 words, structured per `SUBAGENT-SCAN.md`:
-> - `changes_since_baseline`: merged PRs, new issues, new
->   issue-lead comments, slot phase changes
-> - `active_items`: per active slot — clone, issue, phase,
->   stop_reason, lead assessment (one line each)
-> - `action_candidates`: pending spawn intent directly in
->   `$CLONE_ROOT/.spawn-prompts/` (either `<N>.md` or `spawn-<N>.txt` —
->   check both) waiting to be executed — ignore anything under
->   `.spawn-prompts/consumed/`, that's already-launched intent, not
->   pending; merged PRs that should trigger slot cleanup. (Deciding
->   *which* open issues are ready to spawn is `/bip-epic`'s call, not
->   this poll's — report raw signal, not a readiness verdict.)
-> - `surprises`: `needs-human`/`completed` slots, stale status
->   files, contradictions, `RECOMMEND DEEPER LOOK` flags
+> - `changes_since_baseline`: merged PRs, new issues, new issue-lead comments, slot phase changes
+> - `active_items`: per active slot — clone, issue, phase, stop_reason, lead assessment (one line each)
+> - `action_candidates`: pending spawn intent directly in `$CLONE_ROOT/.spawn-prompts/` (either `<N>.md` or `spawn-<N>.txt` — check both) waiting to be executed — ignore anything under `.spawn-prompts/consumed/`, that's already-launched intent, not pending; merged PRs that should trigger slot cleanup.
+>   (Deciding *which* open issues are ready to spawn is `/bip-epic`'s call, not this poll's — report raw signal, not a readiness verdict.)
+> - `surprises`: `needs-human`/`completed` slots, stale status files, contradictions, `RECOMMEND DEEPER LOOK` flags
 
-If the report has zero `changes_since_baseline` and zero `surprises`,
-the poll output is one line: "All quiet."
+If the report has zero `changes_since_baseline` and zero `surprises`, the poll output is one line: "All quiet."
 
 ## After polling
 
 ### Focus on what matters
 
-**Lead with pending spawn intent** — `.spawn-prompts/` files (either naming pattern) the
-epic has already written and is waiting on the conductor to execute.
-This is the most actionable information at this level; deciding which
-*other* open issues should be spawned next is `/bip-epic`'s call.
+**Lead with pending spawn intent** — `.spawn-prompts/` files (either naming pattern) the epic has already written and is waiting on the conductor to execute.
+This is the most actionable information at this level; deciding which *other* open issues should be spawned next is `/bip-epic`'s call.
 
-**Surface lead evaluations** — if a clone's status shows a recent lead
-evaluation (stop_reason set, lead_guidance present), mention the lead's
-assessment briefly. This tells the conductor what the workers are doing
-without having to read full issue comments.
+**Surface lead evaluations** — if a clone's status shows a recent lead evaluation (stop_reason set, lead_guidance present), mention the lead's assessment briefly.
+This tells the conductor what the workers are doing without having to read full issue comments.
 
-**Flag needs-human and completed** — if any clone has `phase: "needs-human"`
-(or legacy `blocked`) or `phase: "completed"`, highlight it prominently.
-These require conductor attention. **Ring the terminal bell and send a
-phone notification** so the user notices even if away:
+**Flag needs-human and completed** — if any clone has `phase: "needs-human"` (or legacy `blocked`) or `phase: "completed"`, highlight it prominently.
+These require conductor attention.
+**Ring the terminal bell and send a phone notification** so the user notices even if away:
 ```bash
 printf '\a'
 NTFY_TOPIC=$(grep ntfy_topic ~/.config/bip/config.yml | awk '{print $2}')
 [ -n "$NTFY_TOPIC" ] && curl -s -H "Title: bip epic" -d "<clone> <phase> (<issue>)" "ntfy.sh/$NTFY_TOPIC" > /dev/null
 ```
 
-**Only report active clones** — clones with a tmux window that are
-actually doing something. Don't list completed or idle clones; that's
-noise. Completed clones can be mentioned briefly ("fir completed i374")
-but don't need a table row.
+**Only report active clones** — clones with a tmux window that are actually doing something.
+Don't list completed or idle clones; that's noise.
+Completed clones can be mentioned briefly ("fir completed i374") but don't need a table row.
 
-**Mention recent merges** only if they unblock something or change
-the plan.
+**Mention recent merges** only if they unblock something or change the plan.
 
-**Correcting a live worker mid-flight**: `ListAgents`/`SendMessage`
-reach other local Claude tmux sessions and can push an immediate
-correction without waiting for the worker's next lead evaluation or
-killing its tmux window.
-Send the correction directly — stating what changed in at least one
-line — rather than a bare pointer, which is a no-op for a worker that
-already reads the status file every step and strips the priority
-signal.
-If a correction is long enough that pointing at a file seems
-preferable, its home is the spawn prompt or the issue body, not a
-nudge.
-The durable/transient test is the deliverable: any nudge that changes
-what the worker will produce (scope, target, artifact, gate criterion)
-MUST also get a durable record, written by the **conductor** appending
-a timestamped, attributed entry to `.epic-worklog.md` in the same
-step — not `.epic-status.json`, since that file is the worker's own
-continuously-rewritten object and a second writer there is
-unsynchronized and gives no tiebreak against `lead_guidance`.
-Facts that leave the deliverable unchanged (host load, a peer's
-timing, a dependency that just landed) may be message-only.
-Delivery lands at the worker's next tool call, not instantly, and
-`SendMessage` only reaches addressable Claude sessions — run
-`ListAgents` first to confirm (the address is the session name it
-reports, not the tmux window name assigned at spawn — sending to the
-window name can fail with `No agent named '<window>' is reachable.`),
-and fall back to the file-only correction (a `conductor_guidance`
-field or a `lead_notes` entry tagged `source: conductor` — never
-`lead_guidance`, wait for the worker's own loop) when it isn't
-addressable.
-Skip the nudge entirely for a worker in `awaiting-results` with a live
-`check_cmd`; use `notify_when_idle: true` instead of "tell me when
-this worker finishes" — main-conversation only, this-machine only,
-one-shot.
+**Correcting a live worker mid-flight**: `ListAgents`/`SendMessage` reach other local Claude tmux sessions and can push an immediate correction without waiting for the worker's next lead evaluation or killing its tmux window.
+Send the correction directly — stating what changed in at least one line — rather than a bare pointer, which is a no-op for a worker that already reads the status file every step and strips the priority signal.
+If a correction is long enough that pointing at a file seems preferable, its home is the spawn prompt or the issue body, not a nudge.
+The durable/transient test is the deliverable: any nudge that changes what the worker will produce (scope, target, artifact, gate criterion) MUST also get a durable record, written by the **conductor** appending a timestamped, attributed entry to `.epic-worklog.md` in the same step — not `.epic-status.json`, since that file is the worker's own continuously-rewritten object and a second writer there is unsynchronized and gives no tiebreak against `lead_guidance`.
+Facts that leave the deliverable unchanged (host load, a peer's timing, a dependency that just landed) may be message-only.
+Delivery lands at the worker's next tool call, not instantly, and `SendMessage` only reaches addressable Claude sessions — run `ListAgents` first to confirm (the address is the session name it reports, not the tmux window name assigned at spawn — sending to the window name can fail with `No agent named '<window>' is reachable.`), and fall back to the file-only correction (a `conductor_guidance` field or a `lead_notes` entry tagged `source: conductor` — never `lead_guidance`, wait for the worker's own loop) when it isn't addressable.
+Skip the nudge entirely for a worker in `awaiting-results` with a live `check_cmd`; use `notify_when_idle: true` instead of "tell me when this worker finishes" — main-conversation only, this-machine only, one-shot.
 
 ### Output structure
 
-1. **Pending spawn intent**: `.spawn-prompts/` files (either naming pattern) waiting on
-   execution, plus idle clones available to run them.
+1. **Pending spawn intent**: `.spawn-prompts/` files (either naming pattern) waiting on execution, plus idle clones available to run them.
 
-2. **Active work**: Clones with tmux windows that are mid-task. One line
-   each: clone, issue, phase, stop_reason (if set), lead assessment.
+2. **Active work**: Clones with tmux windows that are mid-task.
+   One line each: clone, issue, phase, stop_reason (if set), lead assessment.
 
-3. **Needs human**: Clones in `needs-human` phase — show the lead's
-   assessment and what decision is needed.
+3. **Needs human**: Clones in `needs-human` phase — show the lead's assessment and what decision is needed.
 
-4. **Recently landed** (brief): PRs merged since last poll, only if
-   noteworthy.
+4. **Recently landed** (brief): PRs merged since last poll, only if noteworthy.
 
-5. **Execute pending spawns**: If spawn intent files and idle clones
-   both exist, propose running `/bip-conductor-spawn` for them. Wait
-   for confirmation.
+5. **Execute pending spawns**: If spawn intent files and idle clones both exist, propose running `/bip-conductor-spawn` for them.
+   Wait for confirmation.
 
 ### Housekeeping (do silently, don't report unless problems)
 
-This is the ongoing cleanup that keeps slots current between cold
-starts. Do it every poll cycle — don't wait for `/bip-conductor`. EPIC
-body content is not this skill's concern; `/bip-epic` keeps bodies
-current on its own cadence.
+This is the ongoing cleanup that keeps slots current between cold starts.
+Do it every poll cycle — don't wait for `/bip-conductor`.
+EPIC body content is not this skill's concern; `/bip-epic` keeps bodies current on its own cadence.
 
 #### Slot cleanup for merged PRs
 
-For each slot whose PR has merged (cross-reference merged PRs from
-check 1 with slot branches):
+For each slot whose PR has merged (cross-reference merged PRs from check 1 with slot branches):
 
 **Worktree mode**:
 ```bash
@@ -209,10 +141,7 @@ git worktree remove "$CLONE_ROOT/issue-<N>"
 git branch -d <branch>
 ```
 
-`<this-skill's-base-directory>` is this skill's base directory as given
-at invocation (e.g. `/home/user/.claude/skills/bip-conductor-poll`); the
-shared helper lives at `lib/spawn-intent.sh`, a sibling of every skill
-directory (see `skills/lib/spawn-intent.sh` in the `bipartite` repo).
+`<this-skill's-base-directory>` is this skill's base directory as given at invocation (e.g. `/home/user/.claude/skills/bip-conductor-poll`); the shared helper lives at `lib/spawn-intent.sh`, a sibling of every skill directory (see `skills/lib/spawn-intent.sh` in the `bipartite` repo).
 
 **Clone mode**:
 ```bash
@@ -223,38 +152,30 @@ git -C "$CLONE_ROOT/<clone>" pull --ff-only origin main
 rm -f "$CLONE_ROOT/<clone>/.epic-status.json" "$CLONE_ROOT/<clone>/.epic-worklog.md"
 ```
 
-Also clean up stale slots: no tmux window AND `.epic-status.json`
-older than 30 minutes. Same cleanup as above.
+Also clean up stale slots: no tmux window AND `.epic-status.json` older than 30 minutes.
+Same cleanup as above.
 
-If a merge closes an issue tracked in an EPIC, that's signal `/bip-epic`
-needs, not something to act on here — surface it under
-`changes_since_baseline` and move on.
+If a merge closes an issue tracked in an EPIC, that's signal `/bip-epic` needs, not something to act on here — surface it under `changes_since_baseline` and move on.
 
 #### Filter and route fleet-level findings
 
-Before recording anything anywhere, run each candidate fleet-level
-finding through this filter (same as `/bip-conductor-tuckin` Step 3):
+Before recording anything anywhere, run each candidate fleet-level finding through this filter (same as `/bip-conductor-tuckin` Step 3):
 
-1. **Is it derived?** Recomputable from `git`, `tmux`, `gh`, or the
-   filesystem — record nothing. Host quirks (which host had a warm
-   cache, which was mid-build) are derived and go stale within hours;
-   don't write them down anywhere, including MEMORY.md.
-2. **Is it already recorded?** A finding that produced an issue, PR,
-   test, or doc needs no second copy.
+1. **Is it derived?**
+   Recomputable from `git`, `tmux`, `gh`, or the filesystem — record nothing.
+   Host quirks (which host had a warm cache, which was mid-build) are derived and go stale within hours; don't write them down anywhere, including MEMORY.md.
+2. **Is it already recorded?**
+   A finding that produced an issue, PR, test, or doc needs no second copy.
 
-Only what survives both gates gets a destination: a durable clone-pool
-layout decision → a `CLAUDE.md`; a workflow rule → a skill; a
-topic-level decision → `/bip-epic`'s own memory, not here. Nothing
-else fits → the poll report itself.
+Only what survives both gates gets a destination: a durable clone-pool layout decision → a `CLAUDE.md`; a workflow rule → a skill; a topic-level decision → `/bip-epic`'s own memory, not here.
+Nothing else fits → the poll report itself.
 
 ## Conventions
 
 Same as `/bip-epic`: `iN`/`pN` prefixes, full URLs on first mention.
-Tmux windows named `NNN-YYY` where NNN is the issue number and YYY is the
-clone/slot name (e.g. `281-cedar` in clone mode, `281-issue-281` in worktree mode).
+Tmux windows named `NNN-YYY` where NNN is the issue number and YYY is the clone/slot name (e.g. `281-cedar` in clone mode, `281-issue-281` in worktree mode).
 
 ## Layout config (issue #149)
 
-`.epic-config.json` keeps working. The newer global `layout:` block in
-`~/.config/bip/config.yml` configures worktree mode for non-EPIC `bip
-spawn`; see `docs/guides/layout.md`.
+`.epic-config.json` keeps working.
+The newer global `layout:` block in `~/.config/bip/config.yml` configures worktree mode for non-EPIC `bip spawn`; see `docs/guides/layout.md`.

--- a/skills/bip-conductor-prepare-reboot/SKILL.md
+++ b/skills/bip-conductor-prepare-reboot/SKILL.md
@@ -6,11 +6,15 @@ allowed-tools: Bash, Read
 
 # /bip-conductor-prepare-reboot
 
-`/bip-conductor-recover` reconstructs a *killed* fleet after an unplanned reboot by scanning `~/.claude/projects/*/<id>.jsonl` and inferring which sessions were live from file mtimes. That inference is lossy: mtime is last *activity*, not "window was open", and it cannot tell which of several concurrent sessions in one cwd were on screen.
+`/bip-conductor-recover` reconstructs a *killed* fleet after an unplanned reboot by scanning `~/.claude/projects/*/<id>.jsonl` and inferring which sessions were live from file mtimes.
+That inference is lossy: mtime is last *activity*, not "window was open", and it cannot tell which of several concurrent sessions in one cwd were on screen.
 
-When the reboot is **planned**, we can do better: capture ground truth *while tmux is still alive*. This skill walks every pane on the host in one run, resolves each Claude window's exact `session_id` from the live process (its `--resume` cmdline, or start-time correlation for fresh sessions), optionally checkpoints epic workers, and writes a host-wide manifest. `bip-conductor-recover` then replays that manifest after the reboot — rebuilding every session by its real name, windows in order, each Claude window resumed to the right id — instead of guessing.
+When the reboot is **planned**, we can do better: capture ground truth *while tmux is still alive*.
+This skill walks every pane on the host in one run, resolves each Claude window's exact `session_id` from the live process (its `--resume` cmdline, or start-time correlation for fresh sessions), optionally checkpoints epic workers, and writes a host-wide manifest.
+`bip-conductor-recover` then replays that manifest after the reboot — rebuilding every session by its real name, windows in order, each Claude window resumed to the right id — instead of guessing.
 
-The deterministic engine is the bundled `epic-prepare-reboot` shell helper; this skill is the brain that runs it, sanity-checks the resolved table with the user, and triggers the manifest write / shutdown. Run it **on the box about to reboot** — that is where tmux, the jsonl files, and the clones live.
+The deterministic engine is the bundled `epic-prepare-reboot` shell helper; this skill is the brain that runs it, sanity-checks the resolved table with the user, and triggers the manifest write / shutdown.
+Run it **on the box about to reboot** — that is where tmux, the jsonl files, and the clones live.
 
 ## Usage
 
@@ -18,42 +22,53 @@ The deterministic engine is the bundled `epic-prepare-reboot` shell helper; this
 /bip-conductor-prepare-reboot [--no-checkpoint] [--shutdown]
 ```
 
-Run it once, host-wide, *before* the reboot. There is no project argument — the manifest spans the entire tmux host, not one epic project.
+Run it once, host-wide, *before* the reboot.
+There is no project argument — the manifest spans the entire tmux host, not one epic project.
 
 ## The bundled helper
 
-This skill ships the `epic-prepare-reboot` helper next to `SKILL.md` — no separate install. At the start of the run, set `HELPER` to its absolute path (this skill's base directory, given at invocation, + `/epic-prepare-reboot`) and use `"$HELPER"` in every command below:
+This skill ships the `epic-prepare-reboot` helper next to `SKILL.md` — no separate install.
+At the start of the run, set `HELPER` to its absolute path (this skill's base directory, given at invocation, + `/epic-prepare-reboot`) and use `"$HELPER"` in every command below:
 
 ```bash
 HELPER="<this-skill-dir>/epic-prepare-reboot"
 ```
 
-It needs `tmux`, `jq`, bash ≥ 4, and a GNU `date` (or `gdate`): it runs on Linux out of the box, and on macOS with `brew install coreutils bash`. Session-id resolution reads Linux `/proc` first and falls back to `ps` (so it is fully functional on macOS too, just second-resolution start times). It exits 2 with guidance if a prerequisite is missing.
+It needs `tmux`, `jq`, bash ≥ 4, and a GNU `date` (or `gdate`): it runs on Linux out of the box, and on macOS with `brew install coreutils bash`.
+Session-id resolution reads Linux `/proc` first and falls back to `ps` (so it is fully functional on macOS too, just second-resolution start times).
+It exits 2 with guidance if a prerequisite is missing.
 
 ## Workflow
 
 ### Step 1: Dry-run and review the resolved table
 
-Always look before you write. `--dry-run` walks every pane, resolves each window, and prints the table **without** checkpointing, writing, or shutting anything down:
+Always look before you write.
+`--dry-run` walks every pane, resolves each window, and prints the table **without** checkpointing, writing, or shutting anything down:
 
 ```bash
 "$HELPER" --dry-run
 ```
 
-Each row shows `SESSION  IDX  WINDOW  METHOD  CONF  SESSION_ID/CWD`. The resolution `method` per Claude window, in priority order:
+Each row shows `SESSION  IDX  WINDOW  METHOD  CONF  SESSION_ID/CWD`.
+The resolution `method` per Claude window, in priority order:
 
-- **cmdline** (`high`) — `--resume <id>` was in the Claude process args. Exact; covers any resumed session in any cwd.
-- **starttime** (`medium`) — a *fresh* session (launched without `--resume`) carries no id in its cmdline, so the helper correlates the Claude process start time with the cwd's jsonl that *began* closest. Handles fresh windows, including two fresh windows in one cwd.
+- **cmdline** (`high`) — `--resume <id>` was in the Claude process args.
+  Exact; covers any resumed session in any cwd.
+- **starttime** (`medium`) — a *fresh* session (launched without `--resume`) carries no id in its cmdline, so the helper correlates the Claude process start time with the cwd's jsonl that *began* closest.
+  Handles fresh windows, including two fresh windows in one cwd.
 - **newest** (`low`) — last resort: the newest jsonl for the cwd.
-- **shell** (`none`) — no Claude descendant; a bare shell or editor. Recorded with its cwd so the layout returns, recreated as a plain window.
+- **shell** (`none`) — no Claude descendant; a bare shell or editor.
+  Recorded with its cwd so the layout returns, recreated as a plain window.
 
 When start-time correlation finds two jsonls that fit a fresh process nearly equally (within a few seconds), the window is flagged **`ambiguous`** and both candidate ids are recorded — recover will ask rather than guess.
 
-Present a short summary to the user: how many sessions/windows, how many Claude windows resolved by each method, and call out any `ambiguous` rows by name. This is the moment to catch a misresolved window before it goes in the manifest.
+Present a short summary to the user: how many sessions/windows, how many Claude windows resolved by each method, and call out any `ambiguous` rows by name.
+This is the moment to catch a misresolved window before it goes in the manifest.
 
 ### Step 2: Decide on checkpointing
 
-By default the helper sends every epic **worker** (a Claude window whose cwd has `.epic-status.json`) a one-line checkpoint instruction — commit WIP, flush `.epic-status.json` + `.epic-worklog.md` — and waits briefly (`EPIC_PREPARE_CHECKPOINT_WAIT`, default 20s) for the flush. This **persists state; it does not wait for tasks to finish.**
+By default the helper sends every epic **worker** (a Claude window whose cwd has `.epic-status.json`) a one-line checkpoint instruction — commit WIP, flush `.epic-status.json` + `.epic-worklog.md` — and waits briefly (`EPIC_PREPARE_CHECKPOINT_WAIT`, default 20s) for the flush.
+This **persists state; it does not wait for tasks to finish.**
 
 - Default (checkpoint): use when workers are mid-task and you want their latest state captured.
 - `--no-checkpoint`: skip it when the fleet is already quiet, or when interrupting in-flight tool calls would do more harm than good.
@@ -62,14 +77,16 @@ Confirm the choice with the user before the real run.
 
 ### Step 3: Write the manifest
 
-Run the helper for real. Without `--shutdown` it stops after writing the manifest, leaving tmux running so you can verify:
+Run the helper for real.
+Without `--shutdown` it stops after writing the manifest, leaving tmux running so you can verify:
 
 ```bash
 "$HELPER"                 # checkpoint workers, then write the manifest
 "$HELPER" --no-checkpoint # write the manifest without quiescing workers
 ```
 
-The manifest lands at `~/.epic-recover/manifest.json` (override the dir with `EPIC_RECOVER_DIR`). It preserves your real session names, window names, order, and cwds, with a `session_id`, `method`, and `confidence` per Claude window — a **host-level** file so recover finds it without knowing the project list.
+The manifest lands at `~/.epic-recover/manifest.json` (override the dir with `EPIC_RECOVER_DIR`).
+It preserves your real session names, window names, order, and cwds, with a `session_id`, `method`, and `confidence` per Claude window — a **host-level** file so recover finds it without knowing the project list.
 
 ### Step 4: Shut down (optional)
 
@@ -83,7 +100,9 @@ When you are ready to reboot, either reboot the box yourself, or let the helper 
 
 ### Step 5: After the reboot
 
-On the rebooted box, run `/bip-conductor-recover`. It detects the manifest (parked before the current boot, not yet consumed), rebuilds **every** session by its real name with windows in order — Claude windows `--resume`'d to their exact ids, plain windows as bare shells — reports "(from manifest)", and asks about any `ambiguous` windows. After a successful replay it stamps the manifest consumed so a later *unplanned* reboot falls back to the jsonl scan instead of replaying a stale park.
+On the rebooted box, run `/bip-conductor-recover`.
+It detects the manifest (parked before the current boot, not yet consumed), rebuilds **every** session by its real name with windows in order — Claude windows `--resume`'d to their exact ids, plain windows as bare shells — reports "(from manifest)", and asks about any `ambiguous` windows.
+After a successful replay it stamps the manifest consumed so a later *unplanned* reboot falls back to the jsonl scan instead of replaying a stale park.
 
 ## The manifest (what recover consumes)
 
@@ -100,20 +119,26 @@ On the rebooted box, run `/bip-conductor-recover`. It detects the manifest (park
 }
 ```
 
-`confidence` ∈ `high` (cmdline) · `medium` (starttime) · `low` (newest) · `ambiguous` · `none` (shell). An `ambiguous` window also carries a `candidates: [id, id]` array. `session_id` is `null` for shell windows.
+`confidence` ∈ `high` (cmdline) · `medium` (starttime) · `low` (newest) · `ambiguous` · `none` (shell).
+An `ambiguous` window also carries a `candidates: [id, id]` array.
+`session_id` is `null` for shell windows.
 
 ## Manual verification
 
-These helpers introspect live tmux and the process tree, so they are verified by exercising them, not by a unit-test suite (the same convention as `epic-recover`). To check a change, against any host with a few tmux windows open:
+These helpers introspect live tmux and the process tree, so they are verified by exercising them, not by a unit-test suite (the same convention as `epic-recover`).
+To check a change, against any host with a few tmux windows open:
 
 1. **Fidelity** — `"$HELPER" --dry-run`; confirm the table's sessions/windows match `tmux list-panes -a` exactly (names, order, cwds), with a resolved `session_id` per Claude window.
 2. **Resolution** — a resumed window (started with `--resume`) shows `method=cmdline`; a fresh window shows `starttime`; two fresh windows in one cwd with near-identical start times show `ambiguous` (with two candidates in the manifest).
-3. **Roundtrip** — run for real, then on the same host `epic-recover --manifest-status` reports VALID and `--manifest-resume` rebuilds the sessions by real name with windows in order. (See `bip-conductor-recover`'s own verification notes for staleness/consumed/fallback.)
+3. **Roundtrip** — run for real, then on the same host `epic-recover --manifest-status` reports VALID and `--manifest-resume` rebuilds the sessions by real name with windows in order.
+   (See `bip-conductor-recover`'s own verification notes for staleness/consumed/fallback.)
 4. **Guards** — `--no-checkpoint` skips the worker nudges; `--shutdown` kills tmux only after the manifest exists.
 
 ## Notes
 
-- `--dry-run` mutates nothing. Only a real run writes the manifest, sends checkpoints, or (with `--shutdown`) kills tmux.
+- `--dry-run` mutates nothing.
+  Only a real run writes the manifest, sends checkpoints, or (with `--shutdown`) kills tmux.
 - The skill is **host-wide and project-agnostic** — it does *not* require `.epic-config.json` and records every session on the host, not just epic clones.
-- Naming pairs it with `bip-conductor-recover`, though it operates beyond epic clones. Related: `bip-conductor-tuckin` persists *fleet* state for a context reset — distinct from parking the *whole host* for a reboot.
+- Naming pairs it with `bip-conductor-recover`, though it operates beyond epic clones.
+  Related: `bip-conductor-tuckin` persists *fleet* state for a context reset — distinct from parking the *whole host* for a reboot.
 - Driving a remote box from elsewhere: prefix with `ssh <host> 'bash <skill-dir>/epic-prepare-reboot …'`, but it is cleanest run from a shell on the box itself.

--- a/skills/bip-conductor-recover/SKILL.md
+++ b/skills/bip-conductor-recover/SKILL.md
@@ -6,9 +6,12 @@ allowed-tools: Bash, Read
 
 # /bip-conductor-recover
 
-A reboot of a host running a bip-conductor fleet kills the tmux server and every `claude` process at once. The clones, their `.epic-status.json`/`.epic-worklog.md`, and the full per-session `~/.claude/projects/*/<id>.jsonl` conversations all survive on disk, so the sessions are resumable via `claude --dangerously-skip-permissions --resume <id>`. This skill finds those sessions, labels them in human terms, and resumes the ones you pick into tmux windows.
+A reboot of a host running a bip-conductor fleet kills the tmux server and every `claude` process at once.
+The clones, their `.epic-status.json`/`.epic-worklog.md`, and the full per-session `~/.claude/projects/*/<id>.jsonl` conversations all survive on disk, so the sessions are resumable via `claude --dangerously-skip-permissions --resume <id>`.
+This skill finds those sessions, labels them in human terms, and resumes the ones you pick into tmux windows.
 
-The deterministic engine is the bundled `epic-recover` shell helper; this skill is the brain that turns its raw output into labeled choices. Run it **on the box that rebooted** — that is where the tmux, jsonl, and clones live.
+The deterministic engine is the bundled `epic-recover` shell helper; this skill is the brain that turns its raw output into labeled choices.
+Run it **on the box that rebooted** — that is where the tmux, jsonl, and clones live.
 
 ## Usage
 
@@ -16,23 +19,28 @@ The deterministic engine is the bundled `epic-recover` shell helper; this skill 
 /bip-conductor-recover [project]
 ```
 
-`project` is a path to a bip-conductor project's **main clone** (the dir holding `.epic-config.json`), or its basename. Defaults to the current directory.
+`project` is a path to a bip-conductor project's **main clone** (the dir holding `.epic-config.json`), or its basename.
+Defaults to the current directory.
 
 ## The bundled helper
 
-This skill ships the `epic-recover` shell helper next to `SKILL.md` — no separate install. At the start of the run, set `HELPER` to its absolute path (this skill's base directory, given at invocation, + `/epic-recover`) and use `"$HELPER"` in every command below:
+This skill ships the `epic-recover` shell helper next to `SKILL.md` — no separate install.
+At the start of the run, set `HELPER` to its absolute path (this skill's base directory, given at invocation, + `/epic-recover`) and use `"$HELPER"` in every command below:
 
 ```bash
 HELPER="<this-skill-dir>/epic-recover"
 ```
 
-It needs GNU `date` (or `gdate`), `stat`, bash ≥ 4, and `jq`: it runs on Linux out of the box, and on macOS with `brew install coreutils bash`. It exits 2 with guidance if a prerequisite is missing.
+It needs GNU `date` (or `gdate`), `stat`, bash ≥ 4, and `jq`: it runs on Linux out of the box, and on macOS with `brew install coreutils bash`.
+It exits 2 with guidance if a prerequisite is missing.
 
 Start tmux the usual way first (e.g. `eval $(keychain --eval id_rsa) && tmux`) so the server holds your ssh-agent; windows the helper creates inherit that env.
 
 ## Two recovery paths
 
-If the reboot was **planned** and `/bip-conductor-prepare-reboot` parked the host first, a host-wide manifest at `~/.epic-recover/manifest.json` records every session/window with its exact `session_id`. Replaying it is deterministic and lossless — prefer it. Otherwise fall back to the jsonl **scan** below, which infers the live-at-reboot set from file mtimes.
+If the reboot was **planned** and `/bip-conductor-prepare-reboot` parked the host first, a host-wide manifest at `~/.epic-recover/manifest.json` records every session/window with its exact `session_id`.
+Replaying it is deterministic and lossless — prefer it.
+Otherwise fall back to the jsonl **scan** below, which infers the live-at-reboot set from file mtimes.
 
 ### Step 0: Check for a planned-reboot manifest
 
@@ -40,8 +48,11 @@ If the reboot was **planned** and `/bip-conductor-prepare-reboot` parked the hos
 "$HELPER" --manifest-status
 ```
 
-- **Exit 0 (`VALID …`)** — a manifest exists, was parked *before* the current boot, and is not yet consumed. Use the **manifest path** (Step M) and skip the scan entirely.
-- **Exit 1 (`none` / `stale` / `invalid`)** — no usable manifest (none written, parked *after* this boot, already consumed, or unparseable). Fall through to the **scan path** (Step 1). This is project-specific, so `cd` to the project's main clone first.
+- **Exit 0 (`VALID …`)** — a manifest exists, was parked *before* the current boot, and is not yet consumed.
+  Use the **manifest path** (Step M) and skip the scan entirely.
+- **Exit 1 (`none` / `stale` / `invalid`)** — no usable manifest (none written, parked *after* this boot, already consumed, or unparseable).
+  Fall through to the **scan path** (Step 1).
+  This is project-specific, so `cd` to the project's main clone first.
 
 ### Step M: Replay the manifest
 
@@ -49,7 +60,10 @@ If the reboot was **planned** and `/bip-conductor-prepare-reboot` parked the hos
 "$HELPER" --manifest-list      # TSV: session, index, window, cwd, session_id, method, confidence, issue, candidates
 ```
 
-Present the plan grouped by session (real names, windows in order). Most windows resume straight to their recorded id. For any window with `confidence=ambiguous`, show its `candidates` and **ask the user which id to resume** (or to leave it a plain shell) — do not guess. Then replay:
+Present the plan grouped by session (real names, windows in order).
+Most windows resume straight to their recorded id.
+For any window with `confidence=ambiguous`, show its `candidates` and **ask the user which id to resume** (or to leave it a plain shell) — do not guess.
+Then replay:
 
 ```bash
 "$HELPER" --manifest-resume \
@@ -57,7 +71,10 @@ Present the plan grouped by session (real names, windows in order). Most windows
   ["<session>:<index>=skip" ...]             # leave that window a plain shell
 ```
 
-This rebuilds **every** session by its real name with windows in order — Claude windows `--resume`'d to their ids, shell windows as bare shells — and reports "(from manifest)". Ambiguous windows not given an explicit pick are left as plain shells. On success it stamps the manifest consumed (renames it `manifest.<boot>.done`) so a later *unplanned* reboot does not replay a stale park. Then nudge resumed workers per **Step 5**.
+This rebuilds **every** session by its real name with windows in order — Claude windows `--resume`'d to their ids, shell windows as bare shells — and reports "(from manifest)".
+Ambiguous windows not given an explicit pick are left as plain shells.
+On success it stamps the manifest consumed (renames it `manifest.<boot>.done`) so a later *unplanned* reboot does not replay a stale park.
+Then nudge resumed workers per **Step 5**.
 
 ## Scan path (no usable manifest)
 
@@ -70,11 +87,14 @@ cd <project-main-clone>
 "$HELPER" --list
 ```
 
-This emits one TSV row per Claude session whose cwd is the main clone **or any worker clone** and whose jsonl was active in the window before the last reboot (default 36h; `EPIC_RECOVER_SINCE_HOURS` to widen). Columns: `last_active  clone  branch  issue  phase  session  first_prompt`. There is intentionally **no git-branch filter** — a worker clone often returns to `main` while its conversation continues, and the main clone hosts several concurrent sessions (conductor, planning, topic coordination).
+This emits one TSV row per Claude session whose cwd is the main clone **or any worker clone** and whose jsonl was active in the window before the last reboot (default 36h; `EPIC_RECOVER_SINCE_HOURS` to widen).
+Columns: `last_active  clone  branch  issue  phase  session  first_prompt`.
+There is intentionally **no git-branch filter** — a worker clone often returns to `main` while its conversation continues, and the main clone hosts several concurrent sessions (conductor, planning, topic coordination).
 
 ### Step 2: Label each session
 
-`first_prompt` is often spawn-prompt boilerplate ("IMPORTANT: Before doing any work…", "Caveat: The messages below…", a ralph-loop preamble) rather than the topic. When it is, peek deeper to name the session — read the first human-authored message past the preamble:
+`first_prompt` is often spawn-prompt boilerplate ("IMPORTANT: Before doing any work…", "Caveat: The messages below…", a ralph-loop preamble) rather than the topic.
+When it is, peek deeper to name the session — read the first human-authored message past the preamble:
 
 ```bash
 f=~/.claude/projects/$(printf '%s' "<clone-cwd>" | sed 's#/#-#g')/<session-id>*.jsonl
@@ -84,15 +104,20 @@ jq -rs '[.[]|select(.type=="user")|.message.content
         | .[0:3] | .[]' "$f" | head -c 600
 ```
 
-Turn each row into a short human label, e.g. `#1481 → clade-matched ASR parity`, `pcp-pipeline #52 follow-ups`, `coordinate-pca`, `DASM planning`. Note duplicates: a clone may have several sessions across the day; the newest is usually the one that was live at reboot.
+Turn each row into a short human label, e.g. `#1481 → clade-matched ASR parity`, `pcp-pipeline #52 follow-ups`, `coordinate-pca`, `DASM planning`.
+Note duplicates: a clone may have several sessions across the day; the newest is usually the one that was live at reboot.
 
 ### Step 3: Present the choices and confirm
 
-Show a compact labeled table (last-active, clone, label, short session-id) sorted newest first. Recommend the live-at-reboot set (newest per clone, plus the distinct main-clone sessions) but let the user choose. Always offer an explicit **Recover all** option alongside the per-session picks (and "Recommended set" / "Cancel"); when the user picks **Recover all**, pass *every* listed session-id to `--resume` in one call. **Do not spawn anything before the user confirms which sessions to resume.**
+Show a compact labeled table (last-active, clone, label, short session-id) sorted newest first.
+Recommend the live-at-reboot set (newest per clone, plus the distinct main-clone sessions) but let the user choose.
+Always offer an explicit **Recover all** option alongside the per-session picks (and "Recommended set" / "Cancel"); when the user picks **Recover all**, pass *every* listed session-id to `--resume` in one call.
+**Do not spawn anything before the user confirms which sessions to resume.**
 
 ### Step 4: Resume the chosen sessions
 
-Pass the selected session-ids to the helper. Run this from inside the project's tmux session so windows are added to it (the helper detects `$TMUX`):
+Pass the selected session-ids to the helper.
+Run this from inside the project's tmux session so windows are added to it (the helper detects `$TMUX`):
 
 ```bash
 "$HELPER" --resume <id1> <id2> ...
@@ -102,23 +127,30 @@ Each becomes a window named `<issue>-<clone>` (workers) or the clone basename (m
 
 ### Step 5: Nudge resumed workers
 
-A resumed worker reloads its context but sits idle — the ralph-loop wakeup that would have driven the next iteration died with the process. After each worker window finishes loading, send a one-line nudge so it resumes forward motion:
+A resumed worker reloads its context but sits idle — the ralph-loop wakeup that would have driven the next iteration died with the process.
+After each worker window finishes loading, send a one-line nudge so it resumes forward motion:
 
-> Host rebooted and this session was interrupted. Re-read `.epic-status.json` and `.epic-worklog.md`, then continue from where you left off.
+> Host rebooted and this session was interrupted.
+> Re-read `.epic-status.json` and `.epic-worklog.md`, then continue from where you left off.
 
-Auto-`send-keys` timing against claude's resume-load is unreliable, so prompt the user to paste it (or do it interactively once the window is ready). Conductor/planning/discussion sessions usually need no nudge.
+Auto-`send-keys` timing against claude's resume-load is unreliable, so prompt the user to paste it (or do it interactively once the window is ready).
+Conductor/planning/discussion sessions usually need no nudge.
 
 ## Notes
 
-- `--list`, `--manifest-status`, and `--manifest-list` mutate nothing; only `--resume`, `--manifest-resume`, and the bare interactive mode create tmux windows. Re-running the read-only modes is safe.
-- The manifest modes are **host-wide and project-agnostic** — they do not need `.epic-config.json` and rebuild every session in the manifest, not just one project's clones. The scan modes (`--list`, `--resume`, interactive) still require `.epic-config.json` in the cwd.
+- `--list`, `--manifest-status`, and `--manifest-list` mutate nothing; only `--resume`, `--manifest-resume`, and the bare interactive mode create tmux windows.
+  Re-running the read-only modes is safe.
+- The manifest modes are **host-wide and project-agnostic** — they do not need `.epic-config.json` and rebuild every session in the manifest, not just one project's clones.
+  The scan modes (`--list`, `--resume`, interactive) still require `.epic-config.json` in the cwd.
 - For a planned reboot, write that manifest first with `/bip-conductor-prepare-reboot` — it captures exact session ids from live processes, which is lossless where the mtime scan only infers.
 - Driving a remote rebooted box from elsewhere: prefix the helper calls with `ssh <host> 'cd <main-clone> && bash <skill-dir>/epic-recover …'`, but resuming into tmux is cleanest run from a shell already inside that host's tmux.
-- For a no-Claude recovery, run the helper directly with no args (`bash <skill-dir>/epic-recover`) for an interactive numbered picker over the same data — less smart labeling, same engine. Symlink it onto your `PATH` if you want it as a bare command.
+- For a no-Claude recovery, run the helper directly with no args (`bash <skill-dir>/epic-recover`) for an interactive numbered picker over the same data — less smart labeling, same engine.
+  Symlink it onto your `PATH` if you want it as a bare command.
 
 ## Manual verification
 
-The manifest data paths are pure JSON logic and worth exercising after a change; the live-tmux/process parts of the partner skill are verified the same way (see `bip-conductor-prepare-reboot`). Both helpers ship without a unit-test suite, matching this repo's shell-helper convention.
+The manifest data paths are pure JSON logic and worth exercising after a change; the live-tmux/process parts of the partner skill are verified the same way (see `bip-conductor-prepare-reboot`).
+Both helpers ship without a unit-test suite, matching this repo's shell-helper convention.
 
 1. **Staleness** — a manifest whose `parked_at` is *after* the current boot → `--manifest-status` reports `stale` and exits 1 (recover falls back to the scan).
 2. **Consumed** — after `--manifest-resume`, the manifest is renamed `manifest.<boot>.done`; a fresh `--manifest-status` reports `none`.

--- a/skills/bip-conductor-spawn/SKILL.md
+++ b/skills/bip-conductor-spawn/SKILL.md
@@ -6,12 +6,10 @@ description: Spawn a Claude session in a clone for an EPIC issue
 # /bip-conductor-spawn
 
 Spawn a Claude Code session in a tmux window to work on a GitHub issue.
-The worker runs inside a **ralph-loop** with an **issue-lead subagent**
-that evaluates progress at stopping points.
+The worker runs inside a **ralph-loop** with an **issue-lead subagent** that evaluates progress at stopping points.
 
-This is fleet-conductor machinery: it executes a spawn, annotating it
-with live fleet facts the topic side (`/bip-epic`) cannot see. See
-"Where the prompt comes from" below for the epic/conductor split.
+This is fleet-conductor machinery: it executes a spawn, annotating it with live fleet facts the topic side (`/bip-epic`) cannot see.
+See "Where the prompt comes from" below for the epic/conductor split.
 
 ## Usage
 
@@ -23,18 +21,13 @@ If clone-name is omitted, pick the best idle clone automatically.
 
 ## Configuration
 
-Reads `.epic-config.json` from the repo root (see `/bip-conductor` for
-format). **If the file does not exist**, stop and ask the user to
-configure it via `/bip-conductor` first.
+Reads `.epic-config.json` from the repo root (see `/bip-conductor` for format).
+**If the file does not exist**, stop and ask the user to configure it via `/bip-conductor` first.
 
 ## Where the prompt comes from
 
-Most of the time `/bip-epic` has already decided an issue is ready and
-written the semantic brief — why it matters, scope, dependency/collision
-warnings from its issue-body analysis — to `$CLONE_ROOT/.spawn-prompts/`.
-Check there first, under **either** naming convention live in that
-directory — `<N>.md` (current) or `spawn-<N>.txt` (older, still
-written by some sessions):
+Most of the time `/bip-epic` has already decided an issue is ready and written the semantic brief — why it matters, scope, dependency/collision warnings from its issue-body analysis — to `$CLONE_ROOT/.spawn-prompts/`.
+Check there first, under **either** naming convention live in that directory — `<N>.md` (current) or `spawn-<N>.txt` (older, still written by some sessions):
 
 ```bash
 source "$(dirname "<this-skill's-base-directory>")/lib/spawn-intent.sh"
@@ -43,43 +36,26 @@ INTENT=$(find_spawn_intent "$CLONE_ROOT" <N>)
 [ -n "$INTENT" ] && cat "$INTENT"
 ```
 
-`<this-skill's-base-directory>` is this skill's base directory as given at
-invocation (e.g. `/home/user/.claude/skills/bip-conductor-spawn`); the
-shared helper lives at `lib/spawn-intent.sh`, a sibling of every skill
-directory (see `skills/lib/spawn-intent.sh` in the `bipartite` repo).
+`<this-skill's-base-directory>` is this skill's base directory as given at invocation (e.g. `/home/user/.claude/skills/bip-conductor-spawn`); the shared helper lives at `lib/spawn-intent.sh`, a sibling of every skill directory (see `skills/lib/spawn-intent.sh` in the `bipartite` repo).
 
-Checking only `<N>.md` silently misses a real, live `spawn-<N>.txt` and
-falls through to the escape hatch below with no warning — exactly the
-failure this split exists to prevent, reintroduced by a filename. Don't
-narrow this check to one pattern.
+Checking only `<N>.md` silently misses a real, live `spawn-<N>.txt` and falls through to the escape hatch below with no warning — exactly the failure this split exists to prevent, reintroduced by a filename.
+Don't narrow this check to one pattern.
 
-- **Intent file present**: it is the base for the `IMPORTANT CONTEXT`
-  section of Step 4's prompt below — don't re-derive what it already
-  says. Your job is to check it against live fleet state (Step 2b) and
-  append fleet facts it structurally couldn't know: which host/clone is
-  actually free, a concurrent worker editing an overlapping file, a
-  build running on a target remote host. Mark the intent file consumed
-  after a successful launch (Step 6) — it has done its job, but the
-  directory lives outside git, so this is a move to `consumed/`, not a
-  delete (see Step 6).
-- **No intent file** (conductor-initiated respawn, routine maintenance,
-  quick fix with no upstream epic session): compose the prompt from the
-  issue directly, same as before. This is the escape hatch, not the
-  default path.
+- **Intent file present**: it is the base for the `IMPORTANT CONTEXT` section of Step 4's prompt below — don't re-derive what it already says.
+  Your job is to check it against live fleet state (Step 2b) and append fleet facts it structurally couldn't know: which host/clone is actually free, a concurrent worker editing an overlapping file, a build running on a target remote host.
+  Mark the intent file consumed after a successful launch (Step 6) — it has done its job, but the directory lives outside git, so this is a move to `consumed/`, not a delete (see Step 6).
+- **No intent file** (conductor-initiated respawn, routine maintenance, quick fix with no upstream epic session): compose the prompt from the issue directly, same as before.
+  This is the escape hatch, not the default path.
 
-If the intent conflicts with current fleet state in a way that isn't a
-mechanical fix (e.g. it asks for a clone/host that's genuinely
-contended, not just occupied by a finished session) — don't resolve it
-yourself. State the conflict to the user and let them decide; this
-mirrors the user-confirmation gate every spawn already goes through.
+If the intent conflicts with current fleet state in a way that isn't a mechanical fix (e.g. it asks for a clone/host that's genuinely contended, not just occupied by a finished session) — don't resolve it yourself.
+State the conflict to the user and let them decide; this mirrors the user-confirmation gate every spawn already goes through.
 
 ## Workflow
 
 ### Prerequisite: Issue number required
 
-Every spawn MUST target an existing GitHub issue. If the conductor wants
-to spawn work that doesn't have an issue yet (reruns, follow-ups, quick
-experiments), file the issue first:
+Every spawn MUST target an existing GitHub issue.
+If the conductor wants to spawn work that doesn't have an issue yet (reruns, follow-ups, quick experiments), file the issue first:
 
 1. Write a minimal issue body (title + 3-sentence motivation + success criteria)
 2. `gh issue create --title "..." --body-file ISSUE-*.md`
@@ -94,11 +70,8 @@ Read `clone_root` and `local_worktrees` from `.epic-config.json`.
 
 **Clone mode** (`local_worktrees` absent or false):
 
-If clone-name not specified, find an idle clone. A good pick is on `main`,
-clean, and has no live tmux pane in its directory — the pool is shared
-across operators and finishing workers self-claim slots via
-`/bip-conductor-handoff`, so filter these out to avoid choosing one that's
-already taken:
+If clone-name not specified, find an idle clone.
+A good pick is on `main`, clean, and has no live tmux pane in its directory — the pool is shared across operators and finishing workers self-claim slots via `/bip-conductor-handoff`, so filter these out to avoid choosing one that's already taken:
 ```bash
 source "$(dirname "<this-skill's-base-directory>")/lib/spawn-intent.sh"
 CLONE_ROOT=$(resolve_clone_root .epic-config.json)
@@ -113,18 +86,15 @@ for name in $(jq -r '.clone_names[]' .epic-config.json); do
 done
 ```
 
-This selection is **best-effort** — it avoids clones that are obviously
-taken. The actual guarantee is `bip spawn` itself: it refuses to launch
-into a directory a live tmux pane already occupies (`--force` overrides), so
-even if the pool churns between selection and spawn you can never land a
-second agent in one checkout. Prefer clones with clean worktrees. If all
-busy, offer to create a new clone using a name from `new_clone_names` in
-the config.
+This selection is **best-effort** — it avoids clones that are obviously taken.
+The actual guarantee is `bip spawn` itself: it refuses to launch into a directory a live tmux pane already occupies (`--force` overrides), so even if the pool churns between selection and spawn you can never land a second agent in one checkout.
+Prefer clones with clean worktrees.
+If all busy, offer to create a new clone using a name from `new_clone_names` in the config.
 
 **Worktree mode** (`local_worktrees: true`):
 
-Slot name is always `issue-<N>`. Branch name is `<N>-<slug>` where `<slug>`
-is the first 4 words of the issue title, lowercased and hyphenated.
+Slot name is always `issue-<N>`.
+Branch name is `<N>-<slug>` where `<slug>` is the first 4 words of the issue title, lowercased and hyphenated.
 
 Check if slot already exists:
 ```bash
@@ -160,39 +130,30 @@ git checkout main && git pull --ff-only origin main
 rm -f .epic-status.json .epic-worklog.md
 ```
 
-**Fetch inside each clone, never once in the conductor.** Each clone has its
-own `origin/main`, so a conductor-level fetch followed by
-`git -C <clone> reset --hard origin/main` resets the clone to *its own stale*
-ref and silently bases the worker on an old commit. The `cd` above is what
-makes this correct — don't collapse it in a batch-spawn loop (bitten twice in
-2026-08). `.epic-status.json` and `.epic-worklog.md` are gitignored, so
-`reset --hard` preserves them.
+**Fetch inside each clone, never once in the conductor.**
+Each clone has its own `origin/main`, so a conductor-level fetch followed by `git -C <clone> reset --hard origin/main` resets the clone to *its own stale* ref and silently bases the worker on an old commit.
+The `cd` above is what makes this correct — don't collapse it in a batch-spawn loop (bitten twice in 2026-08).
+`.epic-status.json` and `.epic-worklog.md` are gitignored, so `reset --hard` preserves them.
 
-**Worktree mode**: worktree was just created fresh from main — just clear
-any stale status files from a previous run on this same issue:
+**Worktree mode**: worktree was just created fresh from main — just clear any stale status files from a previous run on this same issue:
 ```bash
 rm -f "$SLOT/.epic-status.json" "$SLOT/.epic-worklog.md"
 ```
 
-**State cleanup is mandatory** — stale files from a previous assignment
-will confuse the worker and lead.
+**State cleanup is mandatory** — stale files from a previous assignment will confuse the worker and lead.
 
 ### Step 2b: Pre-launch staleness check
 
 Mechanical, topic-agnostic, and easy to skip under pressure — don't.
-For every blocker/dependency the issue body names (an issue number, a
-PR number, "blocked on #N"), verify it's still true right now:
+For every blocker/dependency the issue body names (an issue number, a PR number, "blocked on #N"), verify it's still true right now:
 
 ```bash
 gh pr view <N> --json state,mergedAt   # merged already?
 gh issue view <N> --json state          # closed already?
 ```
 
-An issue that declares itself blocked on an already-merged PR is the
-single most common staleness bug measured in practice (multiple
-instances in three days). If a named blocker turns out to be resolved,
-correct the composed prompt's `IMPORTANT CONTEXT` — don't pass the
-stale claim through to the worker.
+An issue that declares itself blocked on an already-merged PR is the single most common staleness bug measured in practice (multiple instances in three days).
+If a named blocker turns out to be resolved, correct the composed prompt's `IMPORTANT CONTEXT` — don't pass the stale claim through to the worker.
 
 ### Step 3: Read the issue
 
@@ -200,29 +161,17 @@ stale claim through to the worker.
 gh issue view <number> --json title,body
 ```
 
-Extract key context: what the issue asks for, data locations, phasing,
-dependencies. If a `.spawn-prompts/` intent file exists (see "Where
-the prompt comes from" above, under either naming convention), this is
-a cross-check against the live issue body, not a replacement for
-reading it — the intent file may itself have gone stale since the
-epic wrote it.
+Extract key context: what the issue asks for, data locations, phasing, dependencies.
+If a `.spawn-prompts/` intent file exists (see "Where the prompt comes from" above, under either naming convention), this is a cross-check against the live issue body, not a replacement for reading it — the intent file may itself have gone stale since the epic wrote it.
 
 ### Step 4: Compose the prompt
 
-The prompt has two parts: (1) the work instructions passed as the
-initial message to `claude` via `--prompt-file`, and (2) a ralph-loop
-invocation that the worker runs as its first action. The ralph-loop
-prompt is kept SHORT (no special characters) — just a reminder to
-continue. The detailed instructions are already in the conversation
-from the initial message.
+The prompt has two parts: (1) the work instructions passed as the initial message to `claude` via `--prompt-file`, and (2) a ralph-loop invocation that the worker runs as its first action.
+The ralph-loop prompt is kept SHORT (no special characters) — just a reminder to continue.
+The detailed instructions are already in the conversation from the initial message.
 
-The `IMPORTANT CONTEXT` section at the bottom is where the two sources
-combine: start from the epic's intent file when one exists, correct it
-per Step 2b, then append fleet facts only the conductor can see —
-which host/clone is actually free right now, a concurrent worker
-editing a file this issue also touches, a build in progress on a
-target remote host. Without this annotation step those fleet warnings
-never make it into the prompt at all.
+The `IMPORTANT CONTEXT` section at the bottom is where the two sources combine: start from the epic's intent file when one exists, correct it per Step 2b, then append fleet facts only the conductor can see — which host/clone is actually free right now, a concurrent worker editing a file this issue also touches, a build in progress on a target remote host.
+Without this annotation step those fleet warnings never make it into the prompt at all.
 
 **Prompt file** (written by conductor to /tmp/spawn-N.txt):
 ````
@@ -557,13 +506,9 @@ Always go through `bip spawn` which handles the full lifecycle correctly.
 
 ### Step 6: Confirm
 
-If launch succeeded and a `.spawn-prompts/` intent file (`$INTENT` from
-Step 3) was used, mark it consumed now — don't delete it. The
-directory lives outside every clone's git, so deletion there is
-unrecoverable, and a still-open issue may have another live session
-referencing the same brief. Moving it aside is reversible and lets
-`/bip-conductor-tuckin` Step 2 report it as consumed rather than
-queued:
+If launch succeeded and a `.spawn-prompts/` intent file (`$INTENT` from Step 3) was used, mark it consumed now — don't delete it.
+The directory lives outside every clone's git, so deletion there is unrecoverable, and a still-open issue may have another live session referencing the same brief.
+Moving it aside is reversible and lets `/bip-conductor-tuckin` Step 2 report it as consumed rather than queued:
 
 ```bash
 source "$(dirname "<this-skill's-base-directory>")/lib/spawn-intent.sh"
@@ -575,12 +520,10 @@ Report to the user:
 - Which issue it's working on
 - Any phasing or gate criteria
 
-If a persistent slot monitor is running (started by `/bip-conductor`), the
-conductor will receive automatic notifications when this worker changes
-phase. No additional monitoring setup is needed.
+If a persistent slot monitor is running (started by `/bip-conductor`), the conductor will receive automatic notifications when this worker changes phase.
+No additional monitoring setup is needed.
 
-If no monitor is running, suggest starting one or using
-`/loop 10m /bip-conductor-poll` to track progress.
+If no monitor is running, suggest starting one or using `/loop 10m /bip-conductor-poll` to track progress.
 
 ## Creating new slots
 
@@ -594,8 +537,8 @@ git clone "git@github.com:$REPO.git" <new-name>
 ```
 After creating, add the new name to `clone_names` in `.epic-config.json`.
 
-**Worktree mode** — no registration needed; worktrees are created on demand
-in Step 1 and named `issue-<N>`. No config changes required.
+**Worktree mode** — no registration needed; worktrees are created on demand in Step 1 and named `issue-<N>`.
+No config changes required.
 
 ## Cleaning up slots after work
 
@@ -611,8 +554,8 @@ CLONE_ROOT=$(resolve_clone_root .epic-config.json)
 git worktree remove "$CLONE_ROOT/issue-<N>"
 git branch -d <N>-short-desc
 ```
-If the worktree has uncommitted changes, use `--force`. Check for an open
-PR first — don't remove a worktree with unmerged work.
+If the worktree has uncommitted changes, use `--force`.
+Check for an open PR first — don't remove a worktree with unmerged work.
 
 ## Gitignore reminder
 
@@ -624,17 +567,15 @@ Target project repos should gitignore these files (add to `.gitignore`):
 ```
 
 `.epic-status.json` and `.epic-worklog.md` live in each clone/worktree.
-`.epic-notifications.log` lives in the conductor cwd and is written by
-`bip epic watch`. None should be checked in.
+`.epic-notifications.log` lives in the conductor cwd and is written by `bip epic watch`.
+None should be checked in.
 
 ## Conventions
 
-Same as `/bip-epic`: `iN`/`pN` prefixes. Tmux windows named `NNN-YYY`
-where NNN is the issue number and YYY is the clone/slot name
-(e.g. `281-cedar` in clone mode, `281-issue-281` in worktree mode).
+Same as `/bip-epic`: `iN`/`pN` prefixes.
+Tmux windows named `NNN-YYY` where NNN is the issue number and YYY is the clone/slot name (e.g. `281-cedar` in clone mode, `281-issue-281` in worktree mode).
 
 ## Layout config (issue #149)
 
-`.epic-config.json` keeps working. The newer global `layout:` block in
-`~/.config/bip/config.yml` configures worktree mode for non-EPIC `bip
-spawn`; see `docs/guides/layout.md`.
+`.epic-config.json` keeps working.
+The newer global `layout:` block in `~/.config/bip/config.yml` configures worktree mode for non-EPIC `bip spawn`; see `docs/guides/layout.md`.

--- a/skills/bip-conductor-tuckin/SKILL.md
+++ b/skills/bip-conductor-tuckin/SKILL.md
@@ -5,13 +5,10 @@ description: Persist fleet-side clone/slot state before context reset
 
 # /bip-conductor-tuckin
 
-Flush fleet state — clone/slot status, pending spawn intent — to
-durable storage before a context reset or session end. Run this when
-context is getting long or before stopping.
+Flush fleet state — clone/slot status, pending spawn intent — to durable storage before a context reset or session end.
+Run this when context is getting long or before stopping.
 
-Topic-side state (EPIC bodies, findings, decisions) is
-`/bip-epic-tuckin`'s job, not this skill's — run that separately if the
-epic session is also resetting.
+Topic-side state (EPIC bodies, findings, decisions) is `/bip-epic-tuckin`'s job, not this skill's — run that separately if the epic session is also resetting.
 
 ## Usage
 
@@ -32,8 +29,7 @@ Slot paths:
 For each slot the conductor interacted with this session:
 
 1. Check if the slot's `.epic-status.json` is stale or missing
-2. If the conductor has newer information (e.g., a slot finished,
-   got blocked, or changed phase), update the file:
+2. If the conductor has newer information (e.g., a slot finished, got blocked, or changed phase), update the file:
    ```bash
    source "$(dirname "<this-skill's-base-directory>")/lib/spawn-intent.sh"
    CLONE_ROOT=$(resolve_clone_root .epic-config.json)
@@ -49,64 +45,45 @@ For each slot the conductor interacted with this session:
    EOF
    ```
 
-   `<this-skill's-base-directory>` is this skill's base directory as
-   given at invocation (e.g. `/home/user/.claude/skills/bip-conductor-tuckin`);
-   the shared helper lives at `lib/spawn-intent.sh`, a sibling of every
-   skill directory (see `skills/lib/spawn-intent.sh` in the `bipartite`
-   repo).
+`<this-skill's-base-directory>` is this skill's base directory as given at invocation (e.g. `/home/user/.claude/skills/bip-conductor-tuckin`); the shared helper lives at `lib/spawn-intent.sh`, a sibling of every skill directory (see `skills/lib/spawn-intent.sh` in the `bipartite` repo).
 
-Update slots the conductor has direct knowledge about. This includes:
-- Slots whose PRs were merged this session (even if the slot's own
-  session already exited)
+Update slots the conductor has direct knowledge about.
+This includes:
+- Slots whose PRs were merged this session (even if the slot's own session already exited)
 - Slots the conductor observed finishing via tmux or poll
 
-Do not guess status for slots with active sessions that may have
-progressed beyond what the conductor last observed.
+Do not guess status for slots with active sessions that may have progressed beyond what the conductor last observed.
 
 ### Step 2: Note queued and consumed spawn intent
 
-List `$CLONE_ROOT/.spawn-prompts/` and report two groups separately —
-these are the epic's authored intent, not conductor state, so don't
-touch their contents either way:
+List `$CLONE_ROOT/.spawn-prompts/` and report two groups separately — these are the epic's authored intent, not conductor state, so don't touch their contents either way:
 
-- **Queued** — regular files directly in `.spawn-prompts/`:
-  `find "$CLONE_ROOT/.spawn-prompts" -maxdepth 1 -type f \( -name
-  '*.md' -o -name 'spawn-*.txt' \)` (both naming conventions live
-  there). `-type f` matters: a plain `ls` also lists the `consumed/`
-  directory itself as an entry, which is not a queued intent file.
+- **Queued** — regular files directly in `.spawn-prompts/`: `find "$CLONE_ROOT/.spawn-prompts" -maxdepth 1 -type f \( -name '*.md' -o -name 'spawn-*.txt' \)` (both naming conventions live there).
+  `-type f` matters: a plain `ls` also lists the `consumed/` directory itself as an entry, which is not a queued intent file.
   Still waiting on execution.
-- **Consumed** — files under `.spawn-prompts/consumed/`. Already
-  launched by `/bip-conductor-spawn` Step 6.
+- **Consumed** — files under `.spawn-prompts/consumed/`.
+  Already launched by `/bip-conductor-spawn` Step 6.
 
-Reporting these separately matters: a consumed file left in the top
-level (or a queued one reported as consumed) invites either a
-re-spawn of work that's already running or merged, or a queued brief
-getting ignored as if it were stale. Report both groups so the next
-conductor session (or the user) knows what's actually queued vs
-already launched.
+Reporting these separately matters: a consumed file left in the top level (or a queued one reported as consumed) invites either a re-spawn of work that's already running or merged, or a queued brief getting ignored as if it were stale.
+Report both groups so the next conductor session (or the user) knows what's actually queued vs already launched.
 
 ### Step 3: Filter and route fleet-level findings
 
-Most state should already be in `.epic-status.json` per slot. Before
-recording anything anywhere, run each candidate fleet-level finding
-through this filter:
+Most state should already be in `.epic-status.json` per slot.
+Before recording anything anywhere, run each candidate fleet-level finding through this filter:
 
-1. **Is it derived?** Recomputable from `git`, `tmux`, `gh`, or the
-   filesystem — record nothing, whatever the destination would have
-   been. Which remote host had a warm cache, which host was mid-build,
-   local cache sizes, open-issue counts, which worker was blocked: all
-   of these are re-measurable on demand and go stale within hours, so
-   don't write them down anywhere, including MEMORY.md.
-2. **Is it already recorded?** A finding that produced an issue, PR,
-   test, or doc needs no second copy.
+1. **Is it derived?**
+   Recomputable from `git`, `tmux`, `gh`, or the filesystem — record nothing, whatever the destination would have been.
+   Which remote host had a warm cache, which host was mid-build, local cache sizes, open-issue counts, which worker was blocked: all of these are re-measurable on demand and go stale within hours, so don't write them down anywhere, including MEMORY.md.
+2. **Is it already recorded?**
+   A finding that produced an issue, PR, test, or doc needs no second copy.
 
 Only what survives both gates gets a destination:
 - A durable repo-level fact → a `CLAUDE.md`.
 - A workflow rule → a skill.
 - A finding → the test, doc, or issue it came from.
-- Nothing else fits → the Step 4 report below. This is where a user
-  who has opted out of auto-memory files will actually see it — don't
-  treat a MEMORY.md write as the only or required destination.
+- Nothing else fits → the Step 4 report below.
+  This is where a user who has opted out of auto-memory files will actually see it — don't treat a MEMORY.md write as the only or required destination.
 
 ### Step 4: Report
 

--- a/skills/bip-conductor/SKILL.md
+++ b/skills/bip-conductor/SKILL.md
@@ -5,55 +5,39 @@ description: Fleet conductor cold-start dashboard — full scan of clones, tmux,
 
 # /bip-conductor
 
-Full cold-start dashboard for the **fleet** side of EPIC-based
-multi-clone orchestration: clone/tmux/host inventory, pre-launch
-staleness checks, spawning, and pruning. Topic-agnostic by design — it
-does no feature work and no deep reasoning about what an issue means.
+Full cold-start dashboard for the **fleet** side of EPIC-based multi-clone orchestration: clone/tmux/host inventory, pre-launch staleness checks, spawning, and pruning.
+Topic-agnostic by design — it does no feature work and no deep reasoning about what an issue means.
 Run from the **conductor clone** inside tmux.
 
-Topic strategy (EPIC bodies, issue/PR triage, dependency-direction and
-collision analysis between issues) is `/bip-epic`'s job, not this
-skill's. The two coordinate over `SendMessage` and a shared
-`.spawn-prompts/` directory that `/bip-epic` writes to and
-`/bip-conductor-spawn` reads from — see that skill's "Where the prompt
-comes from" section for the mechanics.
+Topic strategy (EPIC bodies, issue/PR triage, dependency-direction and collision analysis between issues) is `/bip-epic`'s job, not this skill's.
+The two coordinate over `SendMessage` and a shared `.spawn-prompts/` directory that `/bip-epic` writes to and `/bip-conductor-spawn` reads from — see that skill's "Where the prompt comes from" section for the mechanics.
 
-Use this at **session start** to establish fleet context. For
-mid-session updates, use `/bip-conductor-poll`. To spawn work, use
-`/bip-conductor-spawn`.
+Use this at **session start** to establish fleet context.
+For mid-session updates, use `/bip-conductor-poll`.
+To spawn work, use `/bip-conductor-spawn`.
 
 ## Role
 
 The conductor session owns the clone pool, tmux, and host state:
-- Scans clones/worktrees, tmux windows, and (via `/bip-scout`) remote
-  hosts
-- Runs the pre-launch staleness check before every spawn (is the named
-  blocker actually still open?)
-- Executes spawns — composing the fleet-fact annotation on top of
-  intent the epic already drafted, or from scratch for
-  conductor-initiated work
-- Cleans up finished slots and sweeps unfiled draft issues, with a
-  filed-vs-unfiled guard that never deletes authored-but-unfiled work
-- Never adjudicates a genuine resource conflict itself — states it and
-  asks the user (see "Arbitration" below)
-- Never does topic reasoning, and does not write code or create
-  branches for numbered issues (light triage — reading files, checking
-  CI output, running `gh` commands — is fine)
+- Scans clones/worktrees, tmux windows, and (via `/bip-scout`) remote hosts
+- Runs the pre-launch staleness check before every spawn (is the named blocker actually still open?)
+- Executes spawns — composing the fleet-fact annotation on top of intent the epic already drafted, or from scratch for conductor-initiated work
+- Cleans up finished slots and sweeps unfiled draft issues, with a filed-vs-unfiled guard that never deletes authored-but-unfiled work
+- Never adjudicates a genuine resource conflict itself — states it and asks the user (see "Arbitration" below)
+- Never does topic reasoning, and does not write code or create branches for numbered issues (light triage — reading files, checking CI output, running `gh` commands — is fine)
 
 ## Arbitration
 
-When two things want the same clone, cache, or host, or when the
-epic's spawn intent conflicts with what the conductor observes live,
-this skill does not run a heuristic to pick a winner. State the
-conflict plainly and ask the user. The user-confirmation gate every
-spawn already goes through is the same gate that resolves this — no
-separate arbitration rule is needed on top of it.
+When two things want the same clone, cache, or host, or when the epic's spawn intent conflicts with what the conductor observes live, this skill does not run a heuristic to pick a winner.
+State the conflict plainly and ask the user.
+The user-confirmation gate every spawn already goes through is the same gate that resolves this — no separate arbitration rule is needed on top of it.
 
 ## Conventions
 
 ### Issue/PR naming
-Same as `/bip-epic`: `i281` = issue #281, `p275` = PR #275. Never bare
-`#N`. First mention in bullet lists: full URL inline.
+Same as `/bip-epic`: `i281` = issue #281, `p275` = PR #275.
+Never bare `#N`.
+First mention in bullet lists: full URL inline.
 
 ### Tmux windows
 - Named `NNN-YYY` where NNN is the issue number and YYY is the clone/slot name
@@ -62,90 +46,43 @@ Same as `/bip-epic`: `i281` = issue #281, `p275` = PR #275. Never bare
 
 ### Conductor role
 The conductor session stays on `main` and does NOT do feature work.
-It orchestrates: scans, spawns clones, cleans up. Topic content —
-what the work means, what's ready and why — belongs to `/bip-epic`.
+It orchestrates: scans, spawns clones, cleans up.
+Topic content — what the work means, what's ready and why — belongs to `/bip-epic`.
 
 ### Reboots: parking and recovery
-For a **planned** reboot, run `/bip-conductor-prepare-reboot` first
-(host-wide, while tmux is alive): it resolves each Claude window's
-exact session id, optionally checkpoints workers, and writes a
-manifest so the workspace returns deterministically. For an
-**unplanned** reboot (or if no manifest was written), use
-`/bip-conductor-recover` from a project's main clone to find the
-killed Claude sessions and resume each into a tmux window
-(`claude --resume`). Recover replays the manifest when one exists and
-otherwise reads each session's own jsonl, so workers that returned to
-`main` and concurrent main-clone sessions (including any `/bip-epic`
-session) are all recoverable.
+For a **planned** reboot, run `/bip-conductor-prepare-reboot` first (host-wide, while tmux is alive): it resolves each Claude window's exact session id, optionally checkpoints workers, and writes a manifest so the workspace returns deterministically.
+For an **unplanned** reboot (or if no manifest was written), use `/bip-conductor-recover` from a project's main clone to find the killed Claude sessions and resume each into a tmux window (`claude --resume`).
+Recover replays the manifest when one exists and otherwise reads each session's own jsonl, so workers that returned to `main` and concurrent main-clone sessions (including any `/bip-epic` session) are all recoverable.
 
-**Numbered issues → spawn**: If work is tied to a GitHub issue (`iN`),
-always use `/bip-conductor-spawn` to assign it to a clone — even if the
-fix seems trivial. Issueless spawns break EPIC tracking, PR linking,
-and conductor polling.
+**Numbered issues → spawn**: If work is tied to a GitHub issue (`iN`), always use `/bip-conductor-spawn` to assign it to a clone — even if the fix seems trivial.
+Issueless spawns break EPIC tracking, PR linking, and conductor polling.
 
 ### Correcting a live worker: SendMessage as a nudge channel — execution half
 
-`ListAgents`/`SendMessage` reach other local Claude tmux sessions and
-let the conductor push an immediate correction to a live worker
-without killing and respawning its tmux window. Whether a correction
-needs this channel at all, and whether it's durable or transient, is
-`/bip-epic`'s call (see that skill's "Correcting a live worker"
-section) — this section covers the mechanics once the epic has decided
-and drafted the line, plus the case where the conductor itself spots
-something worth flagging (a fleet fact, not a scope change — always
-message-only, since fleet facts never redefine the deliverable).
+`ListAgents`/`SendMessage` reach other local Claude tmux sessions and let the conductor push an immediate correction to a live worker without killing and respawning its tmux window.
+Whether a correction needs this channel at all, and whether it's durable or transient, is `/bip-epic`'s call (see that skill's "Correcting a live worker" section) — this section covers the mechanics once the epic has decided and drafted the line, plus the case where the conductor itself spots something worth flagging (a fleet fact, not a scope change — always message-only, since fleet facts never redefine the deliverable).
 
 - **Send the correction directly — that is the channel's purpose.**
-  No status-file write is a precondition for messaging. State the
-  change in at least one line; a bare pointer ("re-read
-  `lead_guidance`") is a no-op for a worker that already reads the
-  status file every step, and it strips the priority signal (drop
-  what you're doing vs. finish the current step). If a correction is
-  long enough that pointing at a file seems preferable, its home is
-  the spawn prompt or the issue body, not a nudge.
-- **The durable/transient test is the deliverable.** Any nudge that
-  changes what the worker will produce — scope, target, artifact, gate
-  criterion — is state that matters and MUST be recorded durably in
-  the same step as the message, by the conductor appending a
-  timestamped, attributed entry to `.epic-worklog.md`. Workers treat
-  that file as append-only and never edit previous entries, so a
-  conductor append cannot clobber worker history the way editing
-  `lead_guidance` can: it is a field every spawn prompt attributes to
-  the lead, so a second writer makes a conductor nudge
-  indistinguishable from a lead verdict, with no tiebreak when they
-  disagree. If the status file is written at all, use a field the
-  lead does not own (`conductor_guidance`, or a `lead_notes` entry
-  tagged `source: conductor`) — never merge into `lead_guidance`.
-- Delivery is not instant: the message drains at the worker's *next
-  tool call*, not mid-tool-call. It is not a substitute for `tmux
-  capture-pane` when the conductor needs to see current state right now.
-- `SendMessage` only reaches addressable Claude sessions (tmux Claude
-  windows on this machine, or connected cloud/Remote Control sessions)
-  — never a plain shell, a remote SSH job, or a non-Claude compute node.
-  Run `ListAgents` first to confirm the target session is actually
-  addressable; fall back to the file-only correction (a
-  `conductor_guidance` field or a `lead_notes` entry tagged `source:
-  conductor` — never `lead_guidance`) and wait for the worker's own
-  loop when it isn't. **The address is the session
-  name `ListAgents` reports, not the tmux window name the conductor
-  assigned at spawn** — `SendMessage` to a window name can fail with
-  `No agent named '<window>' is reachable.`
-- Do not use `SendMessage` to route around the conductor's own
-  restrictions (cross-session permission laundering) — the "should not
-  write code or create branches for numbered issues" rule above applies
-  equally to instructions phrased as a message to a worker.
-- **When not to nudge**: a worker in `awaiting-results` with a live
-  `check_cmd` needs no ping. Use `notify_when_idle: true` instead of
-  "tell me when this worker finishes" — it works only from the main
-  conversation, only for sessions on this machine, and it is one-shot
-  (omit `message` for a pure subscription that costs the target
-  nothing; a subscription that never fires reports as expired).
+  No status-file write is a precondition for messaging.
+  State the change in at least one line; a bare pointer ("re-read `lead_guidance`") is a no-op for a worker that already reads the status file every step, and it strips the priority signal (drop what you're doing vs. finish the current step).
+  If a correction is long enough that pointing at a file seems preferable, its home is the spawn prompt or the issue body, not a nudge.
+- **The durable/transient test is the deliverable.**
+  Any nudge that changes what the worker will produce — scope, target, artifact, gate criterion — is state that matters and MUST be recorded durably in the same step as the message, by the conductor appending a timestamped, attributed entry to `.epic-worklog.md`.
+  Workers treat that file as append-only and never edit previous entries, so a conductor append cannot clobber worker history the way editing `lead_guidance` can: it is a field every spawn prompt attributes to the lead, so a second writer makes a conductor nudge indistinguishable from a lead verdict, with no tiebreak when they disagree.
+  If the status file is written at all, use a field the lead does not own (`conductor_guidance`, or a `lead_notes` entry tagged `source: conductor`) — never merge into `lead_guidance`.
+- Delivery is not instant: the message drains at the worker's *next tool call*, not mid-tool-call.
+  It is not a substitute for `tmux capture-pane` when the conductor needs to see current state right now.
+- `SendMessage` only reaches addressable Claude sessions (tmux Claude windows on this machine, or connected cloud/Remote Control sessions) — never a plain shell, a remote SSH job, or a non-Claude compute node.
+  Run `ListAgents` first to confirm the target session is actually addressable; fall back to the file-only correction (a `conductor_guidance` field or a `lead_notes` entry tagged `source: conductor` — never `lead_guidance`) and wait for the worker's own loop when it isn't.
+  **The address is the session name `ListAgents` reports, not the tmux window name the conductor assigned at spawn** — `SendMessage` to a window name can fail with `No agent named '<window>' is reachable.`
+- Do not use `SendMessage` to route around the conductor's own restrictions (cross-session permission laundering) — the "should not write code or create branches for numbered issues" rule above applies equally to instructions phrased as a message to a worker.
+- **When not to nudge**: a worker in `awaiting-results` with a live `check_cmd` needs no ping.
+  Use `notify_when_idle: true` instead of "tell me when this worker finishes" — it works only from the main conversation, only for sessions on this machine, and it is one-shot (omit `message` for a pure subscription that costs the target nothing; a subscription that never fires reports as expired).
 
 ## Configuration
 
-The conductor skill reads `.epic-config.json` from the repo root — the
-same file `/bip-epic` reads. This file is gitignored and must exist
-before either skill can operate; the conductor owns creating it.
+The conductor skill reads `.epic-config.json` from the repo root — the same file `/bip-epic` reads.
+This file is gitignored and must exist before either skill can operate; the conductor owns creating it.
 
 **Clone mode** (remote compute or pre-existing clones):
 ```json
@@ -169,19 +106,20 @@ before either skill can operate; the conductor owns creating it.
 }
 ```
 
-**Validation**: If `local_worktrees: true` and `clone_names` are both present, **stop and report an error** — they are mutually exclusive. `clone_names` is meaningless in worktree mode because slots are created on demand and named after the issue.
+**Validation**: If `local_worktrees: true` and `clone_names` are both present, **stop and report an error** — they are mutually exclusive.
+`clone_names` is meaningless in worktree mode because slots are created on demand and named after the issue.
 
 Fields:
 - **clone_root**: Parent directory containing all clones or worktrees.
-  Also where the shared `.spawn-prompts/` intent directory and any
-  unfiled `ISSUE-*.md` drafts live.
+  Also where the shared `.spawn-prompts/` intent directory and any unfiled `ISSUE-*.md` drafts live.
 - **clone_names**: (clone mode only) Existing clone directory names
 - **new_clone_names**: (clone mode only) Names available for creating new clones
 - **local_worktrees**: (worktree mode) If `true`, use `git worktree` for local slots named `issue-N`
 - **github_repo**: `org/repo` for `gh` commands
 - **conductor**: (clone mode only) Which clone is the orchestrator (stays on main)
 - **max_lead_iterations**: Max issue-lead evaluations before escalating to `needs-human` (default: 8)
-- **shared_filesystem**: (optional, default `false`) Set to `true` when the conductor and all compute nodes share an NFS filesystem; the conductor composes direct SSH execution commands instead of `make remote-sync` calls, and experiment results are immediately visible on local NFS paths. Each machine sets this flag for itself — no central list of NFS nodes is needed.
+- **shared_filesystem**: (optional, default `false`) Set to `true` when the conductor and all compute nodes share an NFS filesystem; the conductor composes direct SSH execution commands instead of `make remote-sync` calls, and experiment results are immediately visible on local NFS paths.
+  Each machine sets this flag for itself — no central list of NFS nodes is needed.
 
 ## Workflow
 
@@ -193,19 +131,20 @@ cat .epic-config.json
 
 **If the file does not exist**, stop and ask the user:
 1. Are you using local git worktrees or separate clones for parallel work?
-2. Where should slots live? (e.g. `~/re/pz-workers` for worktrees, or `~/re/pz` for clones)
-3. (Clone mode only) What are the clone directory names? Which is the conductor?
+2. Where should slots live?
+   (e.g. `~/re/pz-workers` for worktrees, or `~/re/pz` for clones)
+3. (Clone mode only) What are the clone directory names?
+   Which is the conductor?
 4. What is the GitHub repo (`org/repo`)?
-5. Are compute nodes on a shared NFS filesystem? (sets `shared_filesystem`)
+5. Are compute nodes on a shared NFS filesystem?
+   (sets `shared_filesystem`)
 
-**Note (worktree mode)**: The skill is run from the main repo itself, which
-acts as the conductor. There is no separate conductor clone — `clone_root`
-is just where worktrees are placed, not the main checkout.
+**Note (worktree mode)**: The skill is run from the main repo itself, which acts as the conductor.
+There is no separate conductor clone — `clone_root` is just where worktrees are placed, not the main checkout.
 
 Then create `.epic-config.json` with their answers and proceed.
 
-All subsequent steps use values from this config — never hardcode
-paths or clone names.
+All subsequent steps use values from this config — never hardcode paths or clone names.
 
 ### Step 2: Pull main
 
@@ -217,14 +156,9 @@ If this fails, report the problem and continue with stale state.
 
 ### Step 3: One-time unfiled-draft sweep
 
-Do this only at cold start, not on every poll — it's a init-time check,
-not an ongoing one.
+Do this only at cold start, not on every poll — it's a init-time check, not an ongoing one.
 
-`/bip-issue-file` moves a draft to `_ignore/` the moment it successfully
-files it, so anything still sitting loose as `ISSUE-*.md` directly in a
-clone root **is** unfiled, by construction (an `update` operation
-reuses the file in place, so a draft that's mid-revision on an existing
-issue is expected here too — don't treat those as orphans).
+`/bip-issue-file` moves a draft to `_ignore/` the moment it successfully files it, so anything still sitting loose as `ISSUE-*.md` directly in a clone root **is** unfiled, by construction (an `update` operation reuses the file in place, so a draft that's mid-revision on an existing issue is expected here too — don't treat those as orphans).
 
 ```bash
 source "$(dirname "<this-skill's-base-directory>")/lib/spawn-intent.sh"
@@ -232,70 +166,43 @@ CLONE_ROOT=$(resolve_clone_root .epic-config.json)
 find "$CLONE_ROOT" -maxdepth 2 -name 'ISSUE-*.md' -not -path '*/_ignore/*'
 ```
 
-`<this-skill's-base-directory>` is this skill's base directory as given
-at invocation (e.g. `/home/user/.claude/skills/bip-conductor`); the
-shared helper lives at `lib/spawn-intent.sh`, a sibling of every skill
-directory (see `skills/lib/spawn-intent.sh` in the `bipartite` repo).
+`<this-skill's-base-directory>` is this skill's base directory as given at invocation (e.g. `/home/user/.claude/skills/bip-conductor`); the shared helper lives at `lib/spawn-intent.sh`, a sibling of every skill directory (see `skills/lib/spawn-intent.sh` in the `bipartite` repo).
 
-**Never auto-delete or auto-file these.** An unfiled draft is authored
-state — the only copy of someone's unfinished thinking — and at least
-one sampled case turned out to be the most valuable item in the batch
-after sitting unfiled for a day. Just flag what you found (path, clone,
-first line) so the user can decide.
+**Never auto-delete or auto-file these.**
+An unfiled draft is authored state — the only copy of someone's unfinished thinking — and at least one sampled case turned out to be the most valuable item in the batch after sitting unfiled for a day.
+Just flag what you found (path, clone, first line) so the user can decide.
 
 ### Step 4: Fan out the clone/tmux scanner
 
-Dispatch one `general-purpose` subagent — single call, following the
-dispatch pattern in `SUBAGENT-SCAN.md` (bipartite repo root). Brief:
+Dispatch one `general-purpose` subagent — single call, following the dispatch pattern in `SUBAGENT-SCAN.md` (bipartite repo root).
+Brief:
 
-> Inventory clones/worktrees. Read `clone_root` and `local_worktrees`
-> from `.epic-config.json`.
+> Inventory clones/worktrees.
+> Read `clone_root` and `local_worktrees` from `.epic-config.json`.
 >
-> Clone mode (`local_worktrees` absent or false): iterate
-> `clone_names`; for each, capture branch, last commit, dirty files
-> (max 5), and `.epic-status.json` contents.
+> Clone mode (`local_worktrees` absent or false): iterate `clone_names`; for each, capture branch, last commit, dirty files (max 5), and `.epic-status.json` contents.
 >
-> Worktree mode (`local_worktrees: true`): `find $CLONE_ROOT
-> -maxdepth 1 -name 'issue-*' -type d`; for each, capture last
-> commit, dirty files, and `.epic-status.json`.
+> Worktree mode (`local_worktrees: true`): `find $CLONE_ROOT -maxdepth 1 -name 'issue-*' -type d`; for each, capture last commit, dirty files, and `.epic-status.json`.
 >
-> Also: `tmux list-windows -F "#W"`. And, for pending spawn intent from
-> the epic: `find $CLONE_ROOT/.spawn-prompts -maxdepth 1 \( -name
-> '*.md' -o -name 'spawn-*.txt' \)` — **both patterns**, since
-> `<N>.md` and the older `spawn-<N>.txt` are both live conventions in
-> that directory; a `-name '*.md'`-only find silently misses a real,
-> current `spawn-<N>.txt` intent file. `-maxdepth 1` also matters here:
-> `/bip-conductor-spawn` moves a launched intent file into a
-> `.spawn-prompts/consumed/` subdirectory instead of deleting it, and
-> this find must not descend into `consumed/` and report an
-> already-launched file as still pending.
+> Also: `tmux list-windows -F "#W"`.
+> And, for pending spawn intent from the epic: `find $CLONE_ROOT/.spawn-prompts -maxdepth 1 \( -name '*.md' -o -name 'spawn-*.txt' \)` — **both patterns**, since `<N>.md` and the older `spawn-<N>.txt` are both live conventions in that directory; a `-name '*.md'`-only find silently misses a real, current `spawn-<N>.txt` intent file.
+> `-maxdepth 1` also matters here: `/bip-conductor-spawn` moves a launched intent file into a `.spawn-prompts/consumed/` subdirectory instead of deleting it, and this find must not descend into `consumed/` and report an already-launched file as still pending.
 >
 > Classify each slot:
-> - `occupied`: has tmux window (regardless of agent status — user
->   may be doing follow-up work)
-> - `stale`: no tmux window, but has `.epic-status.json` or is on
->   non-main branch
+> - `occupied`: has tmux window (regardless of agent status — user may be doing follow-up work)
+> - `stale`: no tmux window, but has `.epic-status.json` or is on non-main branch
 > - `available`: (clone mode) no tmux window, on `main`, clean
 >
 > Return under 400 words:
-> - `active_items`: per slot: name, phase, summary, scope, stop_reason,
->   lead_guidance (from `.epic-status.json`), classification
-> - `action_candidates`: stale slots ready for cleanup (clean up
->   ONLY if no tmux window — never kill tmux windows); pending
->   spawn-intent files (either naming pattern) with an idle clone to
->   run them
-> - `surprises`: phase migrations (`blocked`/`pr-review`), missing
->   status files, contradictions
+> - `active_items`: per slot: name, phase, summary, scope, stop_reason, lead_guidance (from `.epic-status.json`), classification
+> - `action_candidates`: stale slots ready for cleanup (clean up ONLY if no tmux window — never kill tmux windows); pending spawn-intent files (either naming pattern) with an idle clone to run them
+> - `surprises`: phase migrations (`blocked`/`pr-review`), missing status files, contradictions
 
-If work will run on remote hosts, also check `/bip-scout` for host
-occupancy (live builds, warm caches, other sessions' remote jobs) —
-this is exactly the kind of fleet fact `/bip-epic` cannot see and the
-annotation step in `/bip-conductor-spawn` depends on.
+If work will run on remote hosts, also check `/bip-scout` for host occupancy (live builds, warm caches, other sessions' remote jobs) — this is exactly the kind of fleet fact `/bip-epic` cannot see and the annotation step in `/bip-conductor-spawn` depends on.
 
 ### Step 5: Build status display
 
-The dashboard is **slot-centric** — the epic's dashboard is
-issue-centric; this one is about what's occupying the fleet.
+The dashboard is **slot-centric** — the epic's dashboard is issue-centric; this one is about what's occupying the fleet.
 
 | Slot | Classification | Issue | Phase | Notes |
 |------|-----------------|-------|-------|-------|
@@ -304,46 +211,35 @@ issue-centric; this one is about what's occupying the fleet.
 | fir | stale (4d) | i589 | needs-human | check if experiment finished |
 | hazel | available | — | — | — |
 
-**Pending spawn intent**: list any `.spawn-prompts/` files found in
-Step 3/4 (either naming pattern), with the available slots that could
-run them.
+**Pending spawn intent**: list any `.spawn-prompts/` files found in Step 3/4 (either naming pattern), with the available slots that could run them.
 
 ### Step 6: Propose next action
 
 First, do housekeeping automatically (no need to ask):
 - **Clean up clones whose tmux window the user has already closed**:
-  - An **open tmux window** means the user is still using that clone —
-    even if the agent completed and the PR merged. The user often does
-    follow-up work (filing next issues, inspecting results, ad-hoc
-    commands). **Never kill a tmux window. Never clean up a clone that
-    still has a tmux window open.**
+  - An **open tmux window** means the user is still using that clone — even if the agent completed and the PR merged.
+    The user often does follow-up work (filing next issues, inspecting results, ad-hoc commands).
+    **Never kill a tmux window.
+    Never clean up a clone that still has a tmux window open.**
   - Only clean up clones with **no tmux window** (the user closed it):
     - *Clone mode*: `git checkout main && git pull --ff-only`, clear `.epic-status.json`
     - *Worktree mode*: `git worktree remove --force $CLONE_ROOT/issue-N && git branch -d <branch>`
 
 Then propose executing pending spawn intent:
 
-> "Pending intent: `i302` (retry logic) and `i315` (scoring refactor), 2 clones available. Shall I run `/bip-conductor-spawn`?"
+> "Pending intent: `i302` (retry logic) and `i315` (scoring refactor), 2 clones available.
+> Shall I run `/bip-conductor-spawn`?"
 
-Wait for user confirmation, then run `/bip-conductor-spawn` (do NOT
-improvise tmux/claude commands). Deciding *which other* open issues
-should be spawned next isn't this skill's call — that's `/bip-epic`.
+Wait for user confirmation, then run `/bip-conductor-spawn` (do NOT improvise tmux/claude commands).
+Deciding *which other* open issues should be spawned next isn't this skill's call — that's `/bip-epic`.
 
-If a live worker's scope needs correcting *before* its next natural
-stopping point: the epic decides whether it's durable, drafts the
-line, and the conductor delivers it — see "Correcting a live worker"
-above for the mechanics and where the durable record goes.
+If a live worker's scope needs correcting *before* its next natural stopping point: the epic decides whether it's durable, drafts the line, and the conductor delivers it — see "Correcting a live worker" above for the mechanics and where the durable record goes.
 
 ### Step 7: Start slot monitor
 
-After the dashboard is built and any spawns are launched, offer to start
-the **persistent slot monitor** — `bip epic watch` — which observes
-every slot's `.epic-status.json` and writes phase-transition events to
-`.epic-notifications.log` (JSONL) in the conductor cwd. The log is the
-canonical record; transitions survive watcher restarts and conductor
-compaction. This replaces `/loop 10m /bip-conductor-poll` for the most
-time-sensitive signals (phase transitions), while `/bip-conductor-poll`
-remains available for full slot reconciliation sweeps.
+After the dashboard is built and any spawns are launched, offer to start the **persistent slot monitor** — `bip epic watch` — which observes every slot's `.epic-status.json` and writes phase-transition events to `.epic-notifications.log` (JSONL) in the conductor cwd.
+The log is the canonical record; transitions survive watcher restarts and conductor compaction.
+This replaces `/loop 10m /bip-conductor-poll` for the most time-sensitive signals (phase transitions), while `/bip-conductor-poll` remains available for full slot reconciliation sweeps.
 
 Start the watcher in the background:
 
@@ -351,24 +247,16 @@ Start the watcher in the background:
 nohup bip epic watch >/dev/null 2>&1 &
 ```
 
-The watcher runs forever, exits cleanly on SIGTERM, and emits one event
-per real phase transition (default filter: `needs-human`, `completed`,
-`awaiting-results`, `quality-gate`). To also receive events as Claude
-Code notifications when that pipeline is reliable, additionally start a
-Monitor with `command: tail -F .epic-notifications.log` and
-`persistent: true`. The notifications log is the contract; Monitor is a
-latency optimization, not a correctness requirement.
+The watcher runs forever, exits cleanly on SIGTERM, and emits one event per real phase transition (default filter: `needs-human`, `completed`, `awaiting-results`, `quality-gate`).
+To also receive events as Claude Code notifications when that pipeline is reliable, additionally start a Monitor with `command: tail -F .epic-notifications.log` and `persistent: true`.
+The notifications log is the contract; Monitor is a latency optimization, not a correctness requirement.
 
-When a transition arrives showing `needs-human` or `completed`, the
-conductor should react immediately — read the slot's status, check the
-lead guidance, and either propose the next action or flag it for the user.
+When a transition arrives showing `needs-human` or `completed`, the conductor should react immediately — read the slot's status, check the lead guidance, and either propose the next action or flag it for the user.
 
-> "Slot monitor started — phase transitions are streaming to
-> `.epic-notifications.log`. Use `/bip-conductor-poll` for a full
-> reconciliation sweep when needed."
+> "Slot monitor started — phase transitions are streaming to `.epic-notifications.log`.
+> Use `/bip-conductor-poll` for a full reconciliation sweep when needed."
 
-On NFS-mounted clone roots where inotify does not fire on remote writes,
-pass `--poll` (defaults to a 2 s stat-loop) instead of fsnotify:
+On NFS-mounted clone roots where inotify does not fire on remote writes, pass `--poll` (defaults to a 2 s stat-loop) instead of fsnotify:
 
 ```bash
 nohup bip epic watch --poll >/dev/null 2>&1 &
@@ -402,17 +290,14 @@ nohup bip epic watch --poll >/dev/null 2>&1 &
   ```json
   {"pr_check": "pass|fail", "pr_review": "pass|fail", "iterations": 2}
   ```
-  Workers loop `/bip-pr-check` and `/bip-pr-review` until both pass clean.
-  The conductor can monitor progress via this field during polling.
+Workers loop `/bip-pr-check` and `/bip-pr-review` until both pass clean.
+The conductor can monitor progress via this field during polling.
 - `scope` — set by the issue lead each iteration (one-line restatement of the issue goal)
 - `stop_reason` — categorized reason from the lead's decision framework
 - `lead_guidance` — actionable instruction for the worker's next iteration
 - `lead_notes` — append-only log of lead evaluations (max 8 before escalation)
-- `completed_at` — ISO 8601 timestamp set by the lead after it
-  finishes the terminal `completed` ceremony (files any legitimate
-  follow-ups, posts the final PR comment). Its presence is the
-  idempotency signal: subsequent lead invocations at `completed` skip
-  the ceremony.
+- `completed_at` — ISO 8601 timestamp set by the lead after it finishes the terminal `completed` ceremony (files any legitimate follow-ups, posts the final PR comment).
+  Its presence is the idempotency signal: subsequent lead invocations at `completed` skip the ceremony.
 - `awaiting` — set during `awaiting-results` phase:
   ```json
   {
@@ -437,8 +322,6 @@ Legacy phases from older `.epic-status.json` files:
 
 ## Layout config (issue #149)
 
-`.epic-config.json`'s `clone_root` / `clone_names` / `local_worktrees`
-keep working untouched. The newer way to configure worktree mode (for
-non-EPIC `bip spawn` use) is the `layout:` block in
-`~/.config/bip/config.yml` — see `docs/guides/layout.md`. EPIC
-orchestration still reads `.epic-config.json` for now.
+`.epic-config.json`'s `clone_root` / `clone_names` / `local_worktrees` keep working untouched.
+The newer way to configure worktree mode (for non-EPIC `bip spawn` use) is the `layout:` block in `~/.config/bip/config.yml` — see `docs/guides/layout.md`.
+EPIC orchestration still reads `.epic-config.json` for now.

--- a/skills/bip-decay-audit/SKILL.md
+++ b/skills/bip-decay-audit/SKILL.md
@@ -11,15 +11,25 @@ Periodic codebase-health sweep for an agent-written repository.
 
 Agent-written codebases decay monotonically along a small set of axes that Armin Ronacher describes in ["Agentic Coding Recommendations"](https://lucumr.pocoo.org/2025/6/12/agentic-coding/) (2025-06-12):
 
-- **Greppability.** Ronacher recommends "functions with clear, descriptive and longer than usual function names." Once a generic symbol (`run`, `compute`, `get`) is used in three files it will be used in thirty, and grep stops finding a specific definition.
-- **Component extraction.** Ronacher recommends extracting components "when code becomes scattered across numerous files." Once a pattern (CLI parsing, progress reporting, error formatting) is copy-pasted to a third file, agents will copy it to every new file until someone factors it.
-- **Monster files.** Algorithm cores grow; new helpers land in the same file rather than a sibling.
-- **Zombie code.** `TODO`/`FIXME`, disabled tests, and commented-out blocks accrete.
-- **Test asymmetry.** Some modules get heavy regression coverage; new small modules land without tests.
+- **Greppability.**
+  Ronacher recommends "functions with clear, descriptive and longer than usual function names."
+  Once a generic symbol (`run`, `compute`, `get`) is used in three files it will be used in thirty, and grep stops finding a specific definition.
+- **Component extraction.**
+  Ronacher recommends extracting components "when code becomes scattered across numerous files."
+  Once a pattern (CLI parsing, progress reporting, error formatting) is copy-pasted to a third file, agents will copy it to every new file until someone factors it.
+- **Monster files.**
+  Algorithm cores grow; new helpers land in the same file rather than a sibling.
+- **Zombie code.**
+  `TODO`/`FIXME`, disabled tests, and commented-out blocks accrete.
+- **Test asymmetry.**
+  Some modules get heavy regression coverage; new small modules land without tests.
 
-None of these are catastrophic on any single PR. Over months they compound. `/bip-decay-audit` is a cheap, reproducible sweep that makes the compounding visible.
+None of these are catastrophic on any single PR.
+Over months they compound.
+`/bip-decay-audit` is a cheap, reproducible sweep that makes the compounding visible.
 
-`/bip-decay-audit` is NOT a PR reviewer (use `/bip-pr-review`), NOT a code reviewer for a diff (use `@clean-code-reviewer`), and NOT an architectural verdict. It produces signals; humans decide what to act on.
+`/bip-decay-audit` is NOT a PR reviewer (use `/bip-pr-review`), NOT a code reviewer for a diff (use `@clean-code-reviewer`), and NOT an architectural verdict.
+It produces signals; humans decide what to act on.
 
 ## Usage
 
@@ -35,7 +45,8 @@ None of these are catastrophic on any single PR. Over months they compound. `/bi
 
 ### Step 1: Locate state
 
-Per-repo state lives at `.bipartite/audit/` (add to `.gitignore` if not already covered). Structure:
+Per-repo state lives at `.bipartite/audit/` (add to `.gitignore` if not already covered).
+Structure:
 
 ```
 .bipartite/audit/
@@ -47,11 +58,13 @@ Per-repo state lives at `.bipartite/audit/` (add to `.gitignore` if not already 
   config.yml          # repo-specific thresholds (optional)
 ```
 
-If `.bipartite/audit/baseline.json` does not exist, this is a first run — everything is a new metric, no deltas. Warn the user and suggest `--baseline`.
+If `.bipartite/audit/baseline.json` does not exist, this is a first run — everything is a new metric, no deltas.
+Warn the user and suggest `--baseline`.
 
 ### Step 2: Detect languages and pick metric adapters
 
-Run `file`/`find` over the source tree to decide which per-language metrics apply. Adapters this skill knows about:
+Run `file`/`find` over the source tree to decide which per-language metrics apply.
+Adapters this skill knows about:
 
 | Language | Detection | Generic-name set | "Public function" pattern |
 |---|---|---|---|
@@ -64,33 +77,54 @@ If the adapter set is empty, print the detected files and stop — don't guess.
 
 ### Step 3: Collect signals
 
-Each signal is a single `rg`/`wc`/`find` invocation. Nothing expensive; the whole sweep should finish in under five seconds on a 100kLOC repo. Do NOT read full files. Do NOT spawn LLM subagents for the data-collection phase.
+Each signal is a single `rg`/`wc`/`find` invocation.
+Nothing expensive; the whole sweep should finish in under five seconds on a 100kLOC repo.
+Do NOT read full files.
+Do NOT spawn LLM subagents for the data-collection phase.
 
 Required signals (compute all for the detected language(s)):
 
-1. **`pub fn <generic>` counts.** For each name in the generic-name set, `rg -c "^<pattern>" <src>` and sum across files. Report per-name count plus list of files.
+1. **`pub fn <generic>` counts.**
+   For each name in the generic-name set, `rg -c "^<pattern>" <src>` and sum across files.
+   Report per-name count plus list of files.
 
-2. **Top 20 duplicated public symbols.** `rg -oh "^<public-fn-pattern>" <src> | sort | uniq -c | sort -rn | head -20`. Report name, count, and 5-file sample.
+2. **Top 20 duplicated public symbols.**
+   `rg -oh "^<public-fn-pattern>" <src> | sort | uniq -c | sort -rn | head -20`.
+   Report name, count, and 5-file sample.
 
-3. **Monster files.** `find <src> -name '*.<ext>' -exec wc -l {} +` then threshold. Report files > 1500 LOC (language-configurable). Flag any new since baseline.
+3. **Monster files.**
+   `find <src> -name '*.<ext>' -exec wc -l {} +` then threshold.
+   Report files > 1500 LOC (language-configurable).
+   Flag any new since baseline.
 
-4. **TODO/FIXME/XXX/HACK/BUG.** `rg -c "TODO|FIXME|XXX|HACK|BUG"` per-file, sorted by density (markers per 100 LOC). Top 10 files plus total count.
+4. **TODO/FIXME/XXX/HACK/BUG.**
+   `rg -c "TODO|FIXME|XXX|HACK|BUG"` per-file, sorted by density (markers per 100 LOC).
+   Top 10 files plus total count.
 
-5. **Disabled/skipped tests.** `rg "if \(false\)|SkipZigTest|@pytest\.mark\.skip|t\.Skip\(|\.skip\("` per-file. Total count.
+5. **Disabled/skipped tests.**
+   `rg "if \(false\)|SkipZigTest|@pytest\.mark\.skip|t\.Skip\(|\.skip\("` per-file.
+   Total count.
 
-6. **Commented-out code heuristic.** Per file: count lines matching `^\s*//\s*(if|while|for|fn|return|try|const|var|pub|test|def|func)\b` (adjust comment token per language). Top 10 files by count.
+6. **Commented-out code heuristic.**
+   Per file: count lines matching `^\s*//\s*(if|while|for|fn|return|try|const|var|pub|test|def|func)\b` (adjust comment token per language).
+   Top 10 files by count.
 
-7. **CLI parser duplication.** Language-specific:
+7. **CLI parser duplication.**
+   Language-specific:
    - Zig: `rg -l "^pub const CliConfig"` ∪ `rg -l "^pub const CliError"` ∪ `rg -l "^pub fn parseArgs"`.
    - Go: `rg -l "cobra\.Command{"` and total `RunE:` function count.
    - Python: `rg -l "argparse.ArgumentParser|click.command"`.
-   Report count of distinct CLI sites.
+Report count of distinct CLI sites.
 
-8. **Files larger by > 30% since baseline.** `wc -l` compared to `baseline.json`.
+8. **Files larger by > 30% since baseline.**
+   `wc -l` compared to `baseline.json`.
 
-9. **New files since baseline without a sibling test.** Diff `find <src>` against baseline; for each new file, check for a corresponding `tests/test_<name>.*` or `<name>_test.<ext>` (per language). Flag any.
+9. **New files since baseline without a sibling test.**
+   Diff `find <src>` against baseline; for each new file, check for a corresponding `tests/test_<name>.*` or `<name>_test.<ext>` (per language).
+   Flag any.
 
-10. **Module coupling (optional, if supported by language).** For Zig: `rg "@import\(\"\.\./" <src> | awk -F/ '{print $1,$3}' | sort -u` → edges; flag any bidirectional edge.
+10. **Module coupling (optional, if supported by language).**
+    For Zig: `rg "@import\(\"\.\./" <src> | awk -F/ '{print $1,$3}' | sort -u` → edges; flag any bidirectional edge.
 
 Optional signals (add under `--full`; more expensive):
 
@@ -100,7 +134,8 @@ Optional signals (add under `--full`; more expensive):
 
 ### Step 4: Write the report
 
-Produce one markdown file at `.bipartite/audit/history/<ISO-date>.md`. Format:
+Produce one markdown file at `.bipartite/audit/history/<ISO-date>.md`.
+Format:
 
 ```markdown
 # <repo-name> audit — <ISO-date>
@@ -142,11 +177,14 @@ Skill: `/bip-decay-audit` (see skills/bip-decay-audit/SKILL.md).
 Principles: Ronacher 2025-06-12 (linked in SKILL.md).
 ```
 
-Open the report. In tmux: `tmux display-popup -w 90% -h 90% -E -- less <path>`. Otherwise, print the path and let the user open it.
+Open the report.
+In tmux: `tmux display-popup -w 90% -h 90% -E -- less <path>`.
+Otherwise, print the path and let the user open it.
 
 ### Step 5: Save state
 
-Write this run's signals as JSON to `.bipartite/audit/history/<ISO-date>.json`. If `--baseline`, also overwrite `.bipartite/audit/baseline.json`.
+Write this run's signals as JSON to `.bipartite/audit/history/<ISO-date>.json`.
+If `--baseline`, also overwrite `.bipartite/audit/baseline.json`.
 
 ### Step 6: Regressions get a nudge, not a fix
 
@@ -155,32 +193,60 @@ If any metric regressed, list the specific regressions and offer three options:
 2. Draft an issue with `/bip-issue-check` describing the refactor to bring the metric back down.
 3. Promote this run to baseline via `/bip-decay-audit --baseline` (accept the new state).
 
-Do not auto-fix. Do not auto-file. The skill's job ends at the report.
+Do not auto-fix.
+Do not auto-file.
+The skill's job ends at the report.
 
 ## Guidelines
 
-- **Keep the data-collection phase dumb.** `rg` + `wc` + `find`, nothing else. No LLM calls during step 3. Subagents are only useful in step 6 if the user asks for a kaizen pass on a specific regression.
-- **Thresholds are language- and repo-specific.** A monster-file cutoff of 1500 LOC is reasonable for Zig with dense DP kernels; a Python webapp might use 500. Store overrides in `.bipartite/audit/config.yml`.
-- **Don't sweep `_ignore/`, `zig-cache/`, `zig-out/`, `target/`, `build/`, `.pixi/`, `node_modules/`, `experiments/`, or `testdata/`.** These inflate every count without contributing signal.
-- **Signals, not verdicts.** The report never says "fix this." It says "this went up since baseline." A single-file 200-LOC growth may be a legitimate feature; three files that all grew 50% in one week is a pattern.
-- **Make every number reproducible.** The "Methodology" section must show the exact `rg`/`wc` command for every cell. Agents working on a regression then know exactly what metric to move.
-- **First run has no deltas.** Suggest `--baseline` and stop; don't pretend every metric is a regression.
-- **Run on demand, not automatically.** Weekly cadence is a suggestion. Use `/bip.schedule` to wire a cron if you want it recurring.
-- **Read the docstring before calling anything zombie.** Scaffolding can be load-bearing for a tracked future issue. A zero import count is a question, not a verdict.
-- **Apply the deletion test before recommending a split.** Many real importers means deletion would force inlining everywhere and the split earns its keep; zero or one means a shallow module.
-- **Present numbered candidates and let the user grill them before filing** — each with the smell, a proposed fix, and a rough size. Don't pre-design. One well-anchored issue beats several threshold-driven ones; a size threshold surfaces the architecture question, it isn't the question.
+- **Keep the data-collection phase dumb.**
+  `rg` + `wc` + `find`, nothing else.
+  No LLM calls during step 3.
+  Subagents are only useful in step 6 if the user asks for a kaizen pass on a specific regression.
+- **Thresholds are language- and repo-specific.**
+  A monster-file cutoff of 1500 LOC is reasonable for Zig with dense DP kernels; a Python webapp might use 500.
+  Store overrides in `.bipartite/audit/config.yml`.
+- **Don't sweep `_ignore/`, `zig-cache/`, `zig-out/`, `target/`, `build/`, `.pixi/`, `node_modules/`, `experiments/`, or `testdata/`.**
+  These inflate every count without contributing signal.
+- **Signals, not verdicts.**
+  The report never says "fix this."
+  It says "this went up since baseline."
+  A single-file 200-LOC growth may be a legitimate feature; three files that all grew 50% in one week is a pattern.
+- **Make every number reproducible.**
+  The "Methodology" section must show the exact `rg`/`wc` command for every cell.
+  Agents working on a regression then know exactly what metric to move.
+- **First run has no deltas.**
+  Suggest `--baseline` and stop; don't pretend every metric is a regression.
+- **Run on demand, not automatically.**
+  Weekly cadence is a suggestion.
+  Use `/bip.schedule` to wire a cron if you want it recurring.
+- **Read the docstring before calling anything zombie.**
+  Scaffolding can be load-bearing for a tracked future issue.
+  A zero import count is a question, not a verdict.
+- **Apply the deletion test before recommending a split.**
+  Many real importers means deletion would force inlining everywhere and the split earns its keep; zero or one means a shallow module.
+- **Present numbered candidates and let the user grill them before filing** — each with the smell, a proposed fix, and a rough size.
+  Don't pre-design.
+  One well-anchored issue beats several threshold-driven ones; a size threshold surfaces the architecture question, it isn't the question.
 
 ## Why this shape
 
-- **Not a PR reviewer**: `/bip-pr-review` and `@clean-code-reviewer` handle per-diff review. `/bip-decay-audit` looks at whole-repo state, which they cannot.
-- **Not an LLM-semantic pass**: tempting to run cosine similarity across function bodies to find near-duplicates. Expensive, noisy, and the useful signal ("three CLIs copy-pasted the same `while (i < args.len)` loop") is better caught by a cheap `rg -l "pub fn parseArgs"` count.
-- **State in-repo, not in a DB**: `.bipartite/audit/` is committable (or gitignorable) at the user's discretion. Baselines live in git if kept; deltas show up in `git log`. No bip-side storage required.
-- **Output is markdown, not a dashboard**: agents read markdown; `less` in a popup renders it; humans can paste it into Slack. No web UI to maintain.
+- **Not a PR reviewer**: `/bip-pr-review` and `@clean-code-reviewer` handle per-diff review.
+  `/bip-decay-audit` looks at whole-repo state, which they cannot.
+- **Not an LLM-semantic pass**: tempting to run cosine similarity across function bodies to find near-duplicates.
+  Expensive, noisy, and the useful signal ("three CLIs copy-pasted the same `while (i < args.len)` loop") is better caught by a cheap `rg -l "pub fn parseArgs"` count.
+- **State in-repo, not in a DB**: `.bipartite/audit/` is committable (or gitignorable) at the user's discretion.
+  Baselines live in git if kept; deltas show up in `git log`.
+  No bip-side storage required.
+- **Output is markdown, not a dashboard**: agents read markdown; `less` in a popup renders it; humans can paste it into Slack.
+  No web UI to maintain.
 
 ## References
 
-- Armin Ronacher, ["Agentic Coding Recommendations"](https://lucumr.pocoo.org/2025/6/12/agentic-coding/) (2025-06-12) — primary source for the greppability and extract-components principles this skill measures against. Key quote: "functions with clear, descriptive and longer than usual function names."
+- Armin Ronacher, ["Agentic Coding Recommendations"](https://lucumr.pocoo.org/2025/6/12/agentic-coding/) (2025-06-12) — primary source for the greppability and extract-components principles this skill measures against.
+  Key quote: "functions with clear, descriptive and longer than usual function names."
 - Armin Ronacher, ["Agent Design Is Still Hard"](https://lucumr.pocoo.org/2025/11/21/agents-are-hard/) (2025-11-21) — observability and failure-isolation framing that informs why regressions get reported but never auto-fixed.
 - Armin Ronacher, ["AI And The Ship of Theseus"](https://lucumr.pocoo.org/2026/3/5/theseus/) (2026-03-05) — context on how agent-authored rewrites drift.
-- Precipitating case: phyz repo audit 2026-04-21 found 38 `pub fn run` collisions and ~5000 LOC of CLI-parser duplication across 10 modules. The initial version of this skill's signal list is exactly what that audit ran by hand.
+- Precipitating case: phyz repo audit 2026-04-21 found 38 `pub fn run` collisions and ~5000 LOC of CLI-parser duplication across 10 modules.
+  The initial version of this skill's signal list is exactly what that audit ran by hand.
 - Sibling skills: `/bip-kaizen` (continuous improvement), `/bip-pr-review` (per-PR review), `/bip-issue-check` (issue drafting), `/bip-scout` (remote resource scan — similar name, orthogonal scope).

--- a/skills/bip-digest/SKILL.md
+++ b/skills/bip-digest/SKILL.md
@@ -19,7 +19,8 @@ bip digest --channel dasm2 --post-to scratch --post  # Post to scratch channel
 ## Options
 
 - `--channel CHANNEL` — Channel whose repos to scan (required)
-- `--since PERIOD` — Time period (e.g., 1w, 2d, 12h). Default: 1w
+- `--since PERIOD` — Time period (e.g., 1w, 2d, 12h).
+  Default: 1w
 - `--post` — Actually post to Slack (default: preview only)
 - `--post-to CHANNEL` — Override destination (e.g., scratch for testing)
 - `--repos REPOS` — Override repos (comma-separated)
@@ -33,5 +34,6 @@ bip digest --channel dasm2 --post-to scratch --post  # Post to scratch channel
 
 ## Safe by Default
 
-The digest command previews output by default. Use `--post` to actually send to Slack.
+The digest command previews output by default.
+Use `--post` to actually send to Slack.
 This prevents accidental posts to real channels.

--- a/skills/bip-epic-check/SKILL.md
+++ b/skills/bip-epic-check/SKILL.md
@@ -6,14 +6,11 @@ allowed-tools: Agent, Bash, Read, Edit
 
 # /bip-epic-check
 
-Review an EPIC issue markdown file for the qualities that matter at
-the strategic/research level. EPICs are roadmaps that guide months of
-work — they are NOT implementation tasks.
+Review an EPIC issue markdown file for the qualities that matter at the strategic/research level.
+EPICs are roadmaps that guide months of work — they are NOT implementation tasks.
 
-This skill complements `/bip-issue-check` (which reviews implementation-
-ready issues for data paths, column names, test configs). `/bip-epic-check`
-reviews research direction documents for the failure modes that waste
-months, not hours.
+This skill complements `/bip-issue-check` (which reviews implementation- ready issues for data paths, column names, test configs).
+`/bip-epic-check` reviews research direction documents for the failure modes that waste months, not hours.
 
 ## Usage
 
@@ -27,13 +24,13 @@ months, not hours.
 ### Step 1: Determine the file path
 
 - If `$ARGUMENTS` is provided, use that as the file path
-- Otherwise, check conversation context for the most recently discussed
-  EPIC issue file (ISSUE-*.md)
+- Otherwise, check conversation context for the most recently discussed EPIC issue file (ISSUE-*.md)
 - If unclear, ask the user which file to use
 
 ### Step 2: Load context
 
-Read the EPIC file. Also check for:
+Read the EPIC file.
+Also check for:
 - `CLAUDE.md` in the repo root (project conventions)
 - Any existing EPICs in the target repo (for style consistency):
   ```bash
@@ -43,102 +40,83 @@ Read the EPIC file. Also check for:
 
 ### Step 3: Spawn a review subagent
 
-Use the Agent tool to launch a general-purpose subagent that reads the
-EPIC file and checks the following. The subagent should verify claims
-by reading referenced files, running cost calculations, and checking
-existing repo structure.
+Use the Agent tool to launch a general-purpose subagent that reads the EPIC file and checks the following.
+The subagent should verify claims by reading referenced files, running cost calculations, and checking existing repo structure.
 
 Pass the full EPIC text and any context from Step 2 to the subagent.
 
 #### 1. Vision clarity
 
-- **Objective vs strategy**: Does the EPIC clearly distinguish the
-  optimization objective (what we're maximizing) from the search
-  strategy (how we navigate the space)? A common failure is claiming a
-  "new objective" when only the search strategy changed, or vice versa.
+- **Objective vs strategy**: Does the EPIC clearly distinguish the optimization objective (what we're maximizing) from the search strategy (how we navigate the space)?
+  A common failure is claiming a "new objective" when only the search strategy changed, or vice versa.
   Flag as **HIGH** if conflated.
 
-- **Novelty claim**: Is the "what's novel" claim precise? Can you tell
-  exactly which existing method does the closest thing and what the
-  delta is? Vague novelty ("combines X and Y") without explaining why
-  no one has done this is a red flag.
+- **Novelty claim**: Is the "what's novel" claim precise?
+  Can you tell exactly which existing method does the closest thing and what the delta is?
+  Vague novelty ("combines X and Y") without explaining why no one has done this is a red flag.
 
 - **Achievability**: Is there a plausible argument that this can work?
-  Not a proof, but at least a reason to believe the approach isn't
-  doomed (e.g., a related method works in a simpler setting, a
-  theoretical argument, or preliminary evidence).
+  Not a proof, but at least a reason to believe the approach isn't doomed (e.g., a related method works in a simpler setting, a theoretical argument, or preliminary evidence).
 
 #### 2. Scope discipline
 
-- **"What this is NOT" section**: Is there one? EPICs attract scope
-  creep because they're long-running. Explicitly listing out-of-scope
-  items prevents drift. Flag as **HIGH** if missing.
+- **"What this is NOT" section**: Is there one?
+  EPICs attract scope creep because they're long-running.
+  Explicitly listing out-of-scope items prevents drift.
+  Flag as **HIGH** if missing.
 
-- **Phase boundaries**: Could someone tell, for each phase, whether
-  it's done or not? Each phase needs a concrete gate (a test, a
-  metric threshold, a comparison). "Implement X" is not a gate;
-  "X produces identical output to reference on test case Y" is.
+- **Phase boundaries**: Could someone tell, for each phase, whether it's done or not?
+  Each phase needs a concrete gate (a test, a metric threshold, a comparison).
+  "Implement X" is not a gate; "X produces identical output to reference on test case Y" is.
 
-- **Phase dependencies**: Are co-dependencies between components
-  explicit? If Phase N requires something from Phase M that isn't
-  listed as a prerequisite, flag as **HIGH**.
+- **Phase dependencies**: Are co-dependencies between components explicit?
+  If Phase N requires something from Phase M that isn't listed as a prerequisite, flag as **HIGH**.
 
 #### 3. Cost and complexity claims
 
-This is the single highest-value check. EPICs routinely wave hands
-at computational cost with analogies ("same pattern as X") that don't
-survive arithmetic.
+This is the single highest-value check.
+EPICs routinely wave hands at computational cost with analogies ("same pattern as X") that don't survive arithmetic.
 
-- **Back-of-envelope verification**: For every complexity claim
-  (O(...) notation, "same as X", "< Nx slower"), work out the actual
-  cost on a concrete example. If the EPIC says "O(n * tree_pass)",
-  compute what that means for n=16, n=64, n=256. If it says "< 10x
-  wall time", check whether the stated complexity allows that.
+- **Back-of-envelope verification**: For every complexity claim (O(...)
+  notation, "same as X", "< Nx slower"), work out the actual cost on a concrete example.
+  If the EPIC says "O(n * tree_pass)", compute what that means for n=16, n=64, n=256.
+  If it says "< 10x wall time", check whether the stated complexity allows that.
   Flag as **CRITICAL** if a cost claim is wrong by > 2x.
 
-- **Scaling cliffs**: Are there operations whose cost changes
-  qualitatively at some scale? (e.g., fits in cache at n=32 but not
-  n=64; profile size grows polynomially but DP cost is multiplicative).
+- **Scaling cliffs**: Are there operations whose cost changes qualitatively at some scale?
+  (e.g., fits in cache at n=32 but not n=64; profile size grows polynomially but DP cost is multiplicative).
   Flag as **HIGH** if a scaling cliff exists but isn't discussed.
 
-- **Success criteria vs cost**: Do the success criteria (especially
-  wall-time criteria) survive the cost analysis? If criterion says
-  "< 10x" but the complexity analysis shows 32x, flag as **CRITICAL**.
+- **Success criteria vs cost**: Do the success criteria (especially wall-time criteria) survive the cost analysis?
+  If criterion says "< 10x" but the complexity analysis shows 32x, flag as **CRITICAL**.
 
 #### 4. Risk analysis
 
-- **Risks and mitigations**: Is there a section? At minimum, the EPIC
-  should identify the top 3 ways the approach could fail and name an
-  early signal for each. Flag as **HIGH** if missing.
+- **Risks and mitigations**: Is there a section?
+  At minimum, the EPIC should identify the top 3 ways the approach could fail and name an early signal for each.
+  Flag as **HIGH** if missing.
 
-- **Kill criterion**: Which success criterion catches fundamental
-  failure earliest? If the first real test is in the final phase, the
-  EPIC risks months of work before discovering the approach doesn't
-  work. Flag as **HIGH** if the earliest meaningful accuracy test is
-  in the last phase.
+- **Kill criterion**: Which success criterion catches fundamental failure earliest?
+  If the first real test is in the final phase, the EPIC risks months of work before discovering the approach doesn't work.
+  Flag as **HIGH** if the earliest meaningful accuracy test is in the last phase.
 
-- **Failure modes specific to this approach**: Generic risks ("might
-  be slow", "might not be accurate") don't count. The risks should
-  be specific to the approach — failure modes that wouldn't apply to
-  alternative approaches. (e.g., "profile blowup" is specific to
-  profile-based methods; "might not beat PRANK" is generic.)
+- **Failure modes specific to this approach**: Generic risks ("might be slow", "might not be accurate") don't count.
+  The risks should be specific to the approach — failure modes that wouldn't apply to alternative approaches.
+  (e.g., "profile blowup" is specific to profile-based methods; "might not beat PRANK" is generic.)
 
 #### 5. Reference and attribution accuracy
 
-- **Author attributions**: Are papers correctly attributed? Pay
-  special attention to the PI's own papers — don't use generic
-  "et al." for first-author work. Check that reference IDs (bip keys)
-  are correct if provided.
+- **Author attributions**: Are papers correctly attributed?
+  Pay special attention to the PI's own papers — don't use generic "et al." for first-author work.
+  Check that reference IDs (bip keys) are correct if provided.
 
-- **Characterization of related work**: For each method described in
-  "Connection to existing work", is the characterization accurate?
-  Check for common mischaracterizations: saying a method "doesn't do X"
-  when it does, or claiming a method uses technique Y when it uses Z.
+- **Characterization of related work**: For each method described in "Connection to existing work", is the characterization accurate?
+  Check for common mischaracterizations: saying a method "doesn't do X" when it does, or claiming a method uses technique Y when it uses Z.
 
 #### 6. Structural completeness
 
-Check for the following sections (based on established EPIC patterns
-in matsengrp repos). Flag missing sections as **MEDIUM**:
+Check for the following sections (based on established EPIC patterns in matsengrp repos).
+Flag missing sections as **MEDIUM**:
 
 - [ ] Vision
 - [ ] What this is NOT (scope boundaries)
@@ -156,21 +134,17 @@ in matsengrp repos). Flag missing sections as **MEDIUM**:
 
 #### 7. Insertion order / search order (domain-specific)
 
-If the EPIC proposes a greedy or incremental algorithm, check whether
-the ordering/scheduling of operations is discussed. Greedy algorithms
-are notoriously order-sensitive. Flag as **HIGH** if the EPIC proposes
-incremental construction but defers order discussion to the final phase.
+If the EPIC proposes a greedy or incremental algorithm, check whether the ordering/scheduling of operations is discussed.
+Greedy algorithms are notoriously order-sensitive.
+Flag as **HIGH** if the EPIC proposes incremental construction but defers order discussion to the final phase.
 
 ### Step 4: Report findings
 
 Present findings grouped by severity:
 
-- **CRITICAL**: Cost claims that don't survive arithmetic; success
-  criteria contradicted by the design; fundamental logical gaps
-- **HIGH**: Missing scope boundaries; missing risk analysis; phase
-  dependencies unclear; kill criterion too late
-- **MEDIUM**: Style/structure gaps; imprecise language; missing
-  placeholder sections
+- **CRITICAL**: Cost claims that don't survive arithmetic; success criteria contradicted by the design; fundamental logical gaps
+- **HIGH**: Missing scope boundaries; missing risk analysis; phase dependencies unclear; kill criterion too late
+- **MEDIUM**: Style/structure gaps; imprecise language; missing placeholder sections
 - **LOW**: Nitpicks, minor attribution issues
 
 For each finding, state:
@@ -180,14 +154,12 @@ For each finding, state:
 
 ### Step 5: Fix gaps (with approval)
 
-Present findings to the user. Do NOT edit the file without explicit
-approval — EPICs represent strategic decisions that require human
-judgment.
+Present findings to the user.
+Do NOT edit the file without explicit approval — EPICs represent strategic decisions that require human judgment.
 
 After the user approves specific fixes, apply them to the file.
 
 ### Step 6: Optionally submit
 
-If the user wants to submit the EPIC as a GitHub issue, invoke
-`/bip-issue-file` with the file path. EPICs are often kept as local
-markdown files and submitted later, so do not assume submission.
+If the user wants to submit the EPIC as a GitHub issue, invoke `/bip-issue-file` with the file path.
+EPICs are often kept as local markdown files and submitted later, so do not assume submission.

--- a/skills/bip-epic-tuckin/SKILL.md
+++ b/skills/bip-epic-tuckin/SKILL.md
@@ -5,13 +5,10 @@ description: Persist topic-side EPIC state before context reset
 
 # /bip-epic-tuckin
 
-Flush topic state — EPIC bodies, findings, decisions — to durable
-storage before a context reset or session end. Run this when context
-is getting long or before stopping.
+Flush topic state — EPIC bodies, findings, decisions — to durable storage before a context reset or session end.
+Run this when context is getting long or before stopping.
 
-Fleet-side state (clone/slot status, `.epic-status.json`, pending
-spawn intent) is `/bip-conductor-tuckin`'s job, not this skill's — run
-that separately if the conductor session is also resetting.
+Fleet-side state (clone/slot status, `.epic-status.json`, pending spawn intent) is `/bip-conductor-tuckin`'s job, not this skill's — run that separately if the conductor session is also resetting.
 
 ## Usage
 
@@ -23,37 +20,29 @@ that separately if the conductor session is also resetting.
 
 ### Step 1: Push EPIC body edits
 
-For each `ISSUE-EPIC-*.md` file in the repo root, follow the **EPIC body
-update pattern** from `/bip-epic` (pull with `updatedAt` tracking → edit →
-conflict-check → push). Extract the issue number from the filename
-(`ISSUE-EPIC-284.md` → 284). Prune completed sections while you're in
-there — this is the same discipline as `/bip-epic`'s regular update
-pattern, not a separate cleanup pass.
+For each `ISSUE-EPIC-*.md` file in the repo root, follow the **EPIC body update pattern** from `/bip-epic` (pull with `updatedAt` tracking → edit → conflict-check → push).
+Extract the issue number from the filename (`ISSUE-EPIC-284.md` → 284).
+Prune completed sections while you're in there — this is the same discipline as `/bip-epic`'s regular update pattern, not a separate cleanup pass.
 
 Report which EPICs were pushed (and which were skipped due to conflicts).
 
 ### Step 2: Filter and route topic-level findings
 
 Most state should already be in EPIC bodies (`ISSUE-EPIC-<N>.md`).
-Before recording anything anywhere, run each candidate topic-level
-finding through this filter:
+Before recording anything anywhere, run each candidate topic-level finding through this filter:
 
-1. **Is it derived?** Recomputable from `git`, `gh`, or the EPIC bodies
-   themselves — record nothing.
-2. **Does it already have a home?** Dependency-direction or collision
-   findings belong in the EPIC body they concern (Step 1), not as a
-   separate copy. A finding that already produced an issue, PR, or
-   EPIC body update needs no second copy either.
+1. **Is it derived?**
+   Recomputable from `git`, `gh`, or the EPIC bodies themselves — record nothing.
+2. **Does it already have a home?**
+   Dependency-direction or collision findings belong in the EPIC body they concern (Step 1), not as a separate copy.
+   A finding that already produced an issue, PR, or EPIC body update needs no second copy either.
 
 Only what survives both gates gets a destination:
 - A durable repo-level fact → a `CLAUDE.md`.
 - A workflow rule → a skill.
-- A cross-EPIC pattern or key decision not yet captured anywhere →
-  the EPIC body it's most relevant to, or the Step 3 report below if
-  none fits.
-- Nothing else fits → the Step 3 report. This is where a user who has
-  opted out of auto-memory files will actually see it — don't treat a
-  MEMORY.md write as the only or required destination.
+- A cross-EPIC pattern or key decision not yet captured anywhere → the EPIC body it's most relevant to, or the Step 3 report below if none fits.
+- Nothing else fits → the Step 3 report.
+  This is where a user who has opted out of auto-memory files will actually see it — don't treat a MEMORY.md write as the only or required destination.
 
 ### Step 3: Report
 

--- a/skills/bip-epic/SKILL.md
+++ b/skills/bip-epic/SKILL.md
@@ -5,58 +5,40 @@ description: EPIC topic strategy — GitHub issue/PR triage, EPIC body compositi
 
 # /bip-epic
 
-Topic-scoped strategy for EPIC-based multi-clone orchestration: program
-state, issue/PR triage, EPIC body composition, and the semantic
-judgment calls a topic-agnostic fleet scanner structurally cannot make
-(a model-semantics change landing mid-sweep, a deletion in one issue
-that a sibling issue's patch depends on). Fleet mechanics — clone/tmux
-inventory, staleness checks, spawning, pruning of clone-side artifacts
-— belong to `/bip-conductor`. The two roles coordinate over
-`SendMessage` and a shared `.spawn-prompts/` directory (see "Handing
-spawn intent to the conductor" below); they do not need to be the same
-session, though they may run side-by-side in one tmux host.
+Topic-scoped strategy for EPIC-based multi-clone orchestration: program state, issue/PR triage, EPIC body composition, and the semantic judgment calls a topic-agnostic fleet scanner structurally cannot make (a model-semantics change landing mid-sweep, a deletion in one issue that a sibling issue's patch depends on).
+Fleet mechanics — clone/tmux inventory, staleness checks, spawning, pruning of clone-side artifacts — belong to `/bip-conductor`.
+The two roles coordinate over `SendMessage` and a shared `.spawn-prompts/` directory (see "Handing spawn intent to the conductor" below); they do not need to be the same session, though they may run side-by-side in one tmux host.
 
-Use this at **session start** to establish topic context. For fleet
-state (which clones are free, what's running where, tmux/host
-occupancy), ask `/bip-conductor` instead — this skill does not scan
-clones or tmux, and has no visibility into them.
+Use this at **session start** to establish topic context.
+For fleet state (which clones are free, what's running where, tmux/host occupancy), ask `/bip-conductor` instead — this skill does not scan clones or tmux, and has no visibility into them.
 
 ## Role
 
 The epic session does strategy, not fleet ops:
 - Reads and interprets EPIC/issue/PR content on GitHub
 - Composes and prunes EPIC bodies
-- Flags dependency-direction conflicts and file-overlap collisions
-  between open issues, before either gets spawned — by the time
-  branches exist the cost of a collision is already sunk
-- Decides an issue is ready and drafts the spawn brief, but does not
-  spawn it — that goes to `/bip-conductor` as intent, not action
-- Never writes code, creates branches, or spawns tmux windows for
-  numbered issues itself
+- Flags dependency-direction conflicts and file-overlap collisions between open issues, before either gets spawned — by the time branches exist the cost of a collision is already sunk
+- Decides an issue is ready and drafts the spawn brief, but does not spawn it — that goes to `/bip-conductor` as intent, not action
+- Never writes code, creates branches, or spawns tmux windows for numbered issues itself
 
 ## Conventions
 
 ### Issue/PR naming
-- `i281` = issue #281, `p275` = PR #275. Never bare `#N`.
+- `i281` = issue #281, `p275` = PR #275.
+  Never bare `#N`.
 - First mention in bullet lists: full URL inline.
 
-Tmux window naming, reboot recovery, and the live-worker `SendMessage`
-mechanics are `/bip-conductor` concerns — see that skill's Conventions
-section.
+Tmux window naming, reboot recovery, and the live-worker `SendMessage` mechanics are `/bip-conductor` concerns — see that skill's Conventions section.
 
 ## Configuration
 
-Reads `.epic-config.json` from the repo root — the same file
-`/bip-conductor` uses, so the two roles never disagree about where
-things live. The epic role only needs two fields out of it:
+Reads `.epic-config.json` from the repo root — the same file `/bip-conductor` uses, so the two roles never disagree about where things live.
+The epic role only needs two fields out of it:
 - **github_repo**: `org/repo` for `gh` commands
-- **clone_root**: to locate the shared `$CLONE_ROOT/.spawn-prompts/`
-  directory (see below)
+- **clone_root**: to locate the shared `$CLONE_ROOT/.spawn-prompts/` directory (see below)
 
-**If the file does not exist**, don't create it here — run
-`/bip-conductor` first. It owns the clone/worktree layout questions
-(clone mode vs. worktree mode, clone names, shared filesystem) that
-the rest of the file's fields are about.
+**If the file does not exist**, don't create it here — run `/bip-conductor` first.
+It owns the clone/worktree layout questions (clone mode vs. worktree mode, clone names, shared filesystem) that the rest of the file's fields are about.
 
 ## Workflow
 
@@ -66,145 +48,93 @@ the rest of the file's fields are about.
 cat .epic-config.json
 ```
 
-If this project uses the auto-memory directory, also read its
-MEMORY.md for topic-level context from previous sessions (decisions,
-findings, what's next) — some setups deliberately don't use it (e.g.
-because the directory is keyed by working directory and invisible to
-other clones), in which case skip this and rely on EPIC bodies and
-issue history instead.
+If this project uses the auto-memory directory, also read its MEMORY.md for topic-level context from previous sessions (decisions, findings, what's next) — some setups deliberately don't use it (e.g. because the directory is keyed by working directory and invisible to other clones), in which case skip this and rely on EPIC bodies and issue history instead.
 
 ### Step 2: Fan out scanners
 
-Dispatch two groups of `general-purpose` subagents in parallel —
-single message, multiple `Agent` tool calls. Follow the dispatch
-pattern in `SUBAGENT-SCAN.md` (bipartite repo root). Start with the
-cheap structured listing the primary can do directly:
+Dispatch two groups of `general-purpose` subagents in parallel — single message, multiple `Agent` tool calls.
+Follow the dispatch pattern in `SUBAGENT-SCAN.md` (bipartite repo root).
+Start with the cheap structured listing the primary can do directly:
 
 ```bash
 gh issue list --search "EPIC in:title" --json number,title
 ```
 
-**Group A: one subagent per EPIC.** Brief:
+**Group A: one subagent per EPIC.**
+Brief:
 
-> Read EPIC `i<N>` and report its current state. Tasks:
+> Read EPIC `i<N>` and report its current state.
+> Tasks:
 > 1. `gh issue view <N> --json title,body,updatedAt`.
-> 2. Parse the Status dashboard and Key findings. (Older EPIC bodies
->    may still carry a legacy clone-assignment table from before the
->    fleet/topic split — that's fleet state that shouldn't have been
->    authored here; note it as a `surprise` for cleanup, don't treat
->    it as current truth.)
-> 3. For each open item the dashboard lists, run `gh issue view
->    <child-N> --json state,stateReason` to confirm it is still open.
+> 2. Parse the Status dashboard and Key findings.
+>    (Older EPIC bodies may still carry a legacy clone-assignment table from before the fleet/topic split — that's fleet state that shouldn't have been authored here; note it as a `surprise` for cleanup, don't treat it as current truth.)
+> 3. For each open item the dashboard lists, run `gh issue view <child-N> --json state,stateReason` to confirm it is still open.
 >
 > Return under 400 words:
-> - `changes_since_baseline`: completed items, new findings, items
->   newly opened
-> - `active_items`: open work with brief status (for which clone is
->   running it, if any, that's `/bip-conductor`'s dashboard, not this
->   report)
+> - `changes_since_baseline`: completed items, new findings, items newly opened
+> - `active_items`: open work with brief status (for which clone is running it, if any, that's `/bip-conductor`'s dashboard, not this report)
 > - `action_candidates`: items the EPIC marks ready but unassigned
-> - `surprises`: contradictions, legacy clone-assignment tables found
->   in the body, `RECOMMEND DEEPER LOOK` flags
+> - `surprises`: contradictions, legacy clone-assignment tables found in the body, `RECOMMEND DEEPER LOOK` flags
 
-**Group B: one PR/issue triage subagent.** Brief:
+**Group B: one PR/issue triage subagent.**
+Brief:
 
-> Triage the backlog for the epic. Tasks:
-> 1. `gh issue list --search "sort:updated-desc" --limit 20 --json
->    number,title,state,labels,body`.
+> Triage the backlog for the epic.
+> Tasks:
+> 1. `gh issue list --search "sort:updated-desc" --limit 20 --json number,title,state,labels,body`.
 > 2. `gh pr list --json number,title,headRefName,state`.
-> 3. `gh pr list --search "is:pr is:merged sort:updated-desc"
->    --limit 10 --json number,title,mergedAt`.
-> 4. For each open issue, check its `depends_on` field and any
->    blocking context. An issue that depends on an unmerged PR or
->    unfinished experiment is NOT ready — omit silently.
-> 5. Verify state with `gh issue view <N> --json state` for any
->    issue you plan to flag — never claim "open" without confirmation.
+> 3. `gh pr list --search "is:pr is:merged sort:updated-desc" --limit 10 --json number,title,mergedAt`.
+> 4. For each open issue, check its `depends_on` field and any blocking context.
+>    An issue that depends on an unmerged PR or unfinished experiment is NOT ready — omit silently.
+> 5. Verify state with `gh issue view <N> --json state` for any issue you plan to flag — never claim "open" without confirmation.
 >
 > Return under 400 words:
 > - `changes_since_baseline`: PRs merged since last session
 > - `active_items`: open PRs with state/CI status
-> - `action_candidates`: open issues ready to spawn (unblocked,
->   unassigned, dependencies satisfied), ordered by priority
-> - `surprises`: closed/merged items the EPICs don't reflect yet,
->   issues with unclear blocker state, `RECOMMEND DEEPER LOOK` flags
+> - `action_candidates`: open issues ready to spawn (unblocked, unassigned, dependencies satisfied), ordered by priority
+> - `surprises`: closed/merged items the EPICs don't reflect yet, issues with unclear blocker state, `RECOMMEND DEEPER LOOK` flags
 
-**Never ask the user a question about an issue/PR status that you
-could answer with a `gh` query** — verify first, then present facts.
+**Never ask the user a question about an issue/PR status that you could answer with a `gh` query** — verify first, then present facts.
 
 ### Step 3: Reconcile
 
-Compose the reconciliation from the two reports — do not paste
-subagent prose verbatim.
+Compose the reconciliation from the two reports — do not paste subagent prose verbatim.
 
-- Never present an issue as "ready to spawn" or "needs action" without
-  confirming it's still OPEN on GitHub
+- Never present an issue as "ready to spawn" or "needs action" without confirming it's still OPEN on GitHub
 - Flag anything merged/closed that an EPIC body doesn't reflect yet
-- If either group's report has zero `surprises` and zero
-  `changes_since_baseline`, send a follow-up to that subagent with a
-  narrower question before concluding "nothing changed there."
+- If either group's report has zero `surprises` and zero `changes_since_baseline`, send a follow-up to that subagent with a narrower question before concluding "nothing changed there."
 
-Clone/tmux occupancy is not part of this reconciliation — it's
-`/bip-conductor`'s dashboard, not this one.
+Clone/tmux occupancy is not part of this reconciliation — it's `/bip-conductor`'s dashboard, not this one.
 
 ### Step 4: Dependency-direction and collision detection
 
-Run this before proposing any issue as ready to spawn, not after —
-once a branch exists the cost of a collision is sunk. This automates
-what has so far been a manual capability: extracting file paths from
-issue bodies and building an overlap matrix.
+Run this before proposing any issue as ready to spawn, not after — once a branch exists the cost of a collision is sunk.
+This automates what has so far been a manual capability: extracting file paths from issue bodies and building an overlap matrix.
 
-1. From every currently open, unassigned (or about-to-be-spawned)
-   issue body, extract mentioned file/module paths — code blocks,
-   a "Files:" section, or explicit paths in prose.
-2. Build an overlap matrix: any two open issues naming the same file
-   or module are a candidate collision.
-3. For each overlap, read both issue bodies against each other and
-   ask the harder question, not just "who goes first": can both land
-   as currently written, in either order? Or does one delete,
-   rename, or restructure something the other's patch depends on —
-   a dependency-direction conflict that no ordering fixes, because one
-   issue has to change shape? (Concrete shape: one issue deletes a
-   function a sibling issue is patching; one issue's test assertion
-   contradicts a value a sibling issue is about to change.)
-4. Record findings where a future spawn will see them: a note in the
-   EPIC body's dashboard, and — if either issue is about to be handed
-   off as spawn intent (Step 6) — the warning goes directly into that
-   issue's brief.
+1. From every currently open, unassigned (or about-to-be-spawned) issue body, extract mentioned file/module paths — code blocks, a "Files:" section, or explicit paths in prose.
+2. Build an overlap matrix: any two open issues naming the same file or module are a candidate collision.
+3. For each overlap, read both issue bodies against each other and ask the harder question, not just "who goes first": can both land as currently written, in either order?
+   Or does one delete, rename, or restructure something the other's patch depends on — a dependency-direction conflict that no ordering fixes, because one issue has to change shape?
+   (Concrete shape: one issue deletes a function a sibling issue is patching; one issue's test assertion contradicts a value a sibling issue is about to change.)
+4. Record findings where a future spawn will see them: a note in the EPIC body's dashboard, and — if either issue is about to be handed off as spawn intent (Step 6) — the warning goes directly into that issue's brief.
 
 ### Step 5: Prune and update the EPIC body
 
-Follow the **EPIC body update pattern** below. Do this whenever
-findings come in, items complete, or new work starts — not on a fixed
-cadence.
+Follow the **EPIC body update pattern** below.
+Do this whenever findings come in, items complete, or new work starts — not on a fixed cadence.
 
-**Prune on every write, not on a separate sweep.** The observed
-failure mode is accretion, not staleness: a body cut from 524 to 146
-lines had almost nothing stale in what was removed — it was cut
-because the work had *finished* (checked-off phases, a fully-ticked
-table) and kept getting appended around instead of trimmed. Whenever
-you touch a body to add a finding or check a box, also look for
-sections whose work is now fully complete and cut them in the same
-edit, rather than letting them ride to the next dedicated cleanup.
+**Prune on every write, not on a separate sweep.**
+The observed failure mode is accretion, not staleness: a body cut from 524 to 146 lines had almost nothing stale in what was removed — it was cut because the work had *finished* (checked-off phases, a fully-ticked table) and kept getting appended around instead of trimmed.
+Whenever you touch a body to add a finding or check a box, also look for sections whose work is now fully complete and cut them in the same edit, rather than letting them ride to the next dedicated cleanup.
 
-**Fleet state is derived, never authored — don't let it back into the
-body.** Which clone holds which issue, which slots are free, which
-tmux windows are live: recompute this from `git`/`tmux`/`gh` (that's
-`/bip-conductor`'s Step 5 dashboard) whenever you need it. Never write
-it into an EPIC body or a continuation doc — it goes stale within a
-day and there is no mechanism to notice, which is exactly the failure
-a hand-maintained clone table caused when it went stale twice in one
-day. Handoff artifacts (spawn intent, unfiled drafts) are the opposite
-category: authored deliberately, to a durable path outside git,
-precisely so they survive clone churn — pruning them (Step 6, below)
-is about cleaning up finished authored state, not about avoiding
-writing derived state down in the first place.
+**Fleet state is derived, never authored — don't let it back into the body.**
+Which clone holds which issue, which slots are free, which tmux windows are live: recompute this from `git`/`tmux`/`gh` (that's `/bip-conductor`'s Step 5 dashboard) whenever you need it.
+Never write it into an EPIC body or a continuation doc — it goes stale within a day and there is no mechanism to notice, which is exactly the failure a hand-maintained clone table caused when it went stale twice in one day.
+Handoff artifacts (spawn intent, unfiled drafts) are the opposite category: authored deliberately, to a durable path outside git, precisely so they survive clone churn — pruning them (Step 6, below) is about cleaning up finished authored state, not about avoiding writing derived state down in the first place.
 
 ### Step 6: Hand spawn intent to the conductor
 
-For each issue judged ready (unblocked per Step 3, no unresolved
-collision or dependency-direction conflict per Step 4), draft the
-semantic brief — why it matters, scope, any dependency/collision
-warnings from Step 4 — and write it to:
+For each issue judged ready (unblocked per Step 3, no unresolved collision or dependency-direction conflict per Step 4), draft the semantic brief — why it matters, scope, any dependency/collision warnings from Step 4 — and write it to:
 
 ```bash
 source "$(dirname "<this-skill's-base-directory>")/lib/spawn-intent.sh"
@@ -213,93 +143,46 @@ mkdir -p "$CLONE_ROOT/.spawn-prompts"
 # Use the Write tool to create "$CLONE_ROOT/.spawn-prompts/<N>.md" with the brief
 ```
 
-`<this-skill's-base-directory>` is this skill's base directory as given
-at invocation (e.g. `/home/user/.claude/skills/bip-epic`); the shared
-helper lives at `lib/spawn-intent.sh`, a sibling of every skill
-directory (see `skills/lib/spawn-intent.sh` in the `bipartite` repo).
+`<this-skill's-base-directory>` is this skill's base directory as given at invocation (e.g. `/home/user/.claude/skills/bip-epic`); the shared helper lives at `lib/spawn-intent.sh`, a sibling of every skill directory (see `skills/lib/spawn-intent.sh` in the `bipartite` repo).
 
-`clone_root` in `.epic-config.json` is tilde-form — resolve it the same
-way every `/bip-conductor*` skill does, or the brief silently lands in
-a literal `~` directory in the cwd instead of the shared intent
-directory, and the conductor never sees it. `mkdir -p` because
-`.spawn-prompts/` won't exist yet on a fresh repo.
+`clone_root` in `.epic-config.json` is tilde-form — resolve it the same way every `/bip-conductor*` skill does, or the brief silently lands in a literal `~` directory in the cwd instead of the shared intent directory, and the conductor never sees it.
+`mkdir -p` because `.spawn-prompts/` won't exist yet on a fresh repo.
 
-**Naming note**: an older, already-live convention in this same
-directory names files `spawn-<N>.txt` instead. Both are valid intent —
-`/bip-conductor-spawn` checks for either (see that skill's "Where the
-prompt comes from"). Use `<N>.md` for new intent; don't rename existing
-`spawn-<N>.txt` files you find there, since one may be mid-flight.
+**Naming note**: an older, already-live convention in this same directory names files `spawn-<N>.txt` instead.
+Both are valid intent — `/bip-conductor-spawn` checks for either (see that skill's "Where the prompt comes from").
+Use `<N>.md` for new intent; don't rename existing `spawn-<N>.txt` files you find there, since one may be mid-flight.
 
-This directory lives outside every clone's git (deliberately — it
-must survive clone churn) and is the handoff point to
-`/bip-conductor-spawn`, which reads it, checks it against live fleet
-state, appends the fleet facts only it can see, and executes after
-user confirmation. **Do not spawn or touch tmux/clones yourself** —
-that's the conductor's job, and mixing the two roles back together is
-exactly the failure mode this split exists to avoid.
+This directory lives outside every clone's git (deliberately — it must survive clone churn) and is the handoff point to `/bip-conductor-spawn`, which reads it, checks it against live fleet state, appends the fleet facts only it can see, and executes after user confirmation.
+**Do not spawn or touch tmux/clones yourself** — that's the conductor's job, and mixing the two roles back together is exactly the failure mode this split exists to avoid.
 
-**Check whether a conductor session exists before announcing a handoff
-into a void** — `ListAgents` for one. Writing intent and telling the
-user "the conductor will pick these up" is only true if a conductor is
-or will be running; on a small job with no separate conductor session,
-that message describes nothing and the intent file just accretes,
-unpicked-up, forever.
+**Check whether a conductor session exists before announcing a handoff into a void** — `ListAgents` for one.
+Writing intent and telling the user "the conductor will pick these up" is only true if a conductor is or will be running; on a small job with no separate conductor session, that message describes nothing and the intent file just accretes, unpicked-up, forever.
 
-- **Conductor addressable**: tell the user which issues now have
-  pending intent —
-  > "Spawn intent written for `i302` (retry logic) and `i315` (scoring
-  > refactor) — the conductor will pick these up."
-  If it's urgent, `ListAgents`/`SendMessage` it directly rather than
-  waiting for its next poll cycle — see `/bip-conductor`'s Conventions
-  section for the mechanics and addressability caveats.
-- **No conductor addressable**: say so, and offer both real options —
-  start one now (`/bip-conductor` in a separate tmux window, the normal
-  setup for a multi-issue fleet), or, for a single small job where
-  standing up a second session is overhead, run `/bip-conductor-spawn`
-  yourself from this session for just this intent file. The second
-  option is a deliberate, user-confirmed exception to "don't spawn
-  yourself" above, not a silent default — say plainly that it mixes
-  the two roles for this one spawn, and let the user pick.
+- **Conductor addressable**: tell the user which issues now have pending intent —
+> "Spawn intent written for `i302` (retry logic) and `i315` (scoring refactor) — the conductor will pick these up."
+If it's urgent, `ListAgents`/`SendMessage` it directly rather than waiting for its next poll cycle — see `/bip-conductor`'s Conventions section for the mechanics and addressability caveats.
+- **No conductor addressable**: say so, and offer both real options — start one now (`/bip-conductor` in a separate tmux window, the normal setup for a multi-issue fleet), or, for a single small job where standing up a second session is overhead, run `/bip-conductor-spawn` yourself from this session for just this intent file.
+  The second option is a deliberate, user-confirmed exception to "don't spawn yourself" above, not a silent default — say plainly that it mixes the two roles for this one spawn, and let the user pick.
 
 ### Step 7: Correcting a live worker — the judgment half
 
-When a live worker's scope needs correcting *before* its next natural
-stopping point, the epic — not the conductor — makes the call: is this
-change durable (it changes what the worker will produce: scope,
-target, artifact, gate criterion) or transient (host load, a peer's
-timing, a dependency that just landed)?
+When a live worker's scope needs correcting *before* its next natural stopping point, the epic — not the conductor — makes the call: is this change durable (it changes what the worker will produce: scope, target, artifact, gate criterion) or transient (host load, a peer's timing, a dependency that just landed)?
 
-- **Durable**: draft the one-line correction and ask the conductor to
-  deliver it — the conductor `SendMessage`s the worker directly and
-  appends a timestamped, attributed entry to `.epic-worklog.md` in the
-  same step (never edits `lead_guidance` — see `/bip-conductor`'s
-  Conventions section for why the append-only path matters). The
-  epic's job stops at drafting the line — route it through the
-  conductor even though `SendMessage` would reach the worker directly
-  from here too. A single delivery path is what keeps the message and
-  the `.epic-worklog.md` append from diverging: two senders means a
-  correction can land in the worker's context with no durable record,
-  or a durable record with no delivery.
-- **Transient**: message-only is fine; still routes through the
-  conductor, for the same single-delivery-path reason.
+- **Durable**: draft the one-line correction and ask the conductor to deliver it — the conductor `SendMessage`s the worker directly and appends a timestamped, attributed entry to `.epic-worklog.md` in the same step (never edits `lead_guidance` — see `/bip-conductor`'s Conventions section for why the append-only path matters).
+  The epic's job stops at drafting the line — route it through the conductor even though `SendMessage` would reach the worker directly from here too.
+  A single delivery path is what keeps the message and the `.epic-worklog.md` append from diverging: two senders means a correction can land in the worker's context with no durable record, or a durable record with no delivery.
+- **Transient**: message-only is fine; still routes through the conductor, for the same single-delivery-path reason.
 
-A worker correction is often *more* time-sensitive than spawn intent —
-the worker is actively doing the wrong thing while it sits in a queue.
-If the conductor session is addressable right now, `SendMessage` it
-directly to request immediate delivery, rather than leaving the
-correction for its next poll cycle — same mechanics and addressability
-caveats as Step 6's escape hatch.
+A worker correction is often *more* time-sensitive than spawn intent — the worker is actively doing the wrong thing while it sits in a queue.
+If the conductor session is addressable right now, `SendMessage` it directly to request immediate delivery, rather than leaving the correction for its next poll cycle — same mechanics and addressability caveats as Step 6's escape hatch.
 
 ## EPIC body update pattern
 
-EPIC issue bodies are the source of truth for project status. Update
-them when findings come in, items complete, or new work starts — and
-prune completed sections in the same edit (Step 5 above).
+EPIC issue bodies are the source of truth for project status.
+Update them when findings come in, items complete, or new work starts — and prune completed sections in the same edit (Step 5 above).
 
-**Local file convention**: Keep a persistent local copy as
-`ISSUE-EPIC-<N>.md` in the repo root (e.g. `ISSUE-EPIC-281.md`,
-`ISSUE-EPIC-295.md`). These files are gitignored via the `ISSUE-*.md`
-pattern.
+**Local file convention**: Keep a persistent local copy as `ISSUE-EPIC-<N>.md` in the repo root (e.g. `ISSUE-EPIC-281.md`, `ISSUE-EPIC-295.md`).
+These files are gitignored via the `ISSUE-*.md` pattern.
 
 ```bash
 # Pull current body and record the timestamp
@@ -322,22 +205,18 @@ else
 fi
 ```
 
-**Conflict check**: Record `updatedAt` when pulling. Before pushing,
-re-fetch `updatedAt` — if it changed, someone else edited. Re-pull,
-merge their changes, and retry. When in doubt, ask the user.
+**Conflict check**: Record `updatedAt` when pulling.
+Before pushing, re-fetch `updatedAt` — if it changed, someone else edited.
+Re-pull, merge their changes, and retry.
+When in doubt, ask the user.
 
 Key sections to maintain:
-- **Status dashboard**: Check/uncheck boxes, add new items, cut
-  finished ones
+- **Status dashboard**: Check/uncheck boxes, add new items, cut finished ones
 - **Key findings**: Numbered list, append new findings
 - **Related experiments**: Add new experiment rows
 
-**Do not maintain a clone/slot assignment table in the body** — which
-clone is working which issue is fleet state, derived from `git`/`tmux`,
-not authored here (see the "Fleet state is derived" note above). If an
-item's status dashboard entry needs a pointer to who's on it, name the
-issue, not the clone — `/bip-conductor`'s dashboard is the place to
-ask "which clone."
+**Do not maintain a clone/slot assignment table in the body** — which clone is working which issue is fleet state, derived from `git`/`tmux`, not authored here (see the "Fleet state is derived" note above).
+If an item's status dashboard entry needs a pointer to who's on it, name the issue, not the clone — `/bip-conductor`'s dashboard is the place to ask "which clone."
 
 ## Error handling
 
@@ -347,8 +226,6 @@ ask "which clone."
 
 ## Layout config (issue #149)
 
-`.epic-config.json`'s `clone_root` / `clone_names` / `local_worktrees`
-keep working untouched. The newer way to configure worktree mode (for
-non-EPIC `bip spawn` use) is the `layout:` block in
-`~/.config/bip/config.yml` — see `docs/guides/layout.md`. EPIC
-orchestration still reads `.epic-config.json` for now.
+`.epic-config.json`'s `clone_root` / `clone_names` / `local_worktrees` keep working untouched.
+The newer way to configure worktree mode (for non-EPIC `bip spawn` use) is the `layout:` block in `~/.config/bip/config.yml` — see `docs/guides/layout.md`.
+EPIC orchestration still reads `.epic-config.json` for now.

--- a/skills/bip-issue-check/SKILL.md
+++ b/skills/bip-issue-check/SKILL.md
@@ -6,8 +6,7 @@ allowed-tools: Agent, Bash, Read, Edit, Skill
 
 # /bip-issue-check
 
-Review a GitHub issue markdown file for implementation-readiness, fix
-gaps, then submit via `/bip-issue-file`.
+Review a GitHub issue markdown file for implementation-readiness, fix gaps, then submit via `/bip-issue-file`.
 
 ## Usage
 
@@ -20,84 +19,67 @@ gaps, then submit via `/bip-issue-file`.
 ### Step 1: Determine the file path
 
 - If `$ARGUMENTS` is provided, use that as the file path
-- Otherwise, check conversation context for the most recently discussed
-  issue file (ISSUE-*.md)
+- Otherwise, check conversation context for the most recently discussed issue file (ISSUE-*.md)
 - If unclear, ask the user which file to use
 
 ### Step 2: Load project constitution and design docs
 
 Search for `CONSTITUTION.md` and `DESIGN.md` in the repository root.
-If found, load them. The constitution contains process/workflow
-principles (MUST/SHOULD rules). The design doc contains technical
-architecture decisions. Both will be checked against the issue in
-Step 3.
+If found, load them.
+The constitution contains process/workflow principles (MUST/SHOULD rules).
+The design doc contains technical architecture decisions.
+Both will be checked against the issue in Step 3.
 
 ### Step 3: Spawn a review subagent
 
-Use the Agent tool to launch a general-purpose subagent that reads the
-issue file and checks for the following. The subagent should also read
-any referenced files (data files, config files, source code) to verify
-claims. Pass the contents of `CONSTITUTION.md` and `DESIGN.md` to the
-subagent if they exist.
+Use the Agent tool to launch a general-purpose subagent that reads the issue file and checks for the following.
+The subagent should also read any referenced files (data files, config files, source code) to verify claims.
+Pass the contents of `CONSTITUTION.md` and `DESIGN.md` to the subagent if they exist.
 
 #### Constitution alignment
 
-If a `CONSTITUTION.md` exists, check every MUST/SHOULD principle against
-the issue. Flag violations as **CRITICAL**. Common things to catch:
+If a `CONSTITUTION.md` exists, check every MUST/SHOULD principle against the issue.
+Flag violations as **CRITICAL**.
+Common things to catch:
 
 - Issue proposes an approach that contradicts a stated principle
-- Issue omits something the constitution requires (e.g., file-based
-  state for agent workflows, scope tied to a GitHub issue, quality
-  gate expectations)
-- Issue describes manual steps where the constitution calls for
-  automation (or vice versa — automation where human judgment is needed)
+- Issue omits something the constitution requires (e.g., file-based state for agent workflows, scope tied to a GitHub issue, quality gate expectations)
+- Issue describes manual steps where the constitution calls for automation (or vice versa — automation where human judgment is needed)
 
 #### Design alignment
 
-If a `DESIGN.md` exists, check technical proposals against architecture
-decisions. Flag conflicts as **HIGH**. Common things to catch:
+If a `DESIGN.md` exists, check technical proposals against architecture decisions.
+Flag conflicts as **HIGH**.
+Common things to catch:
 
-- Issue proposes a storage approach that contradicts the data model
-  (e.g., database migrations instead of rebuild-from-JSONL)
-- Issue introduces dependencies that violate constraints (e.g., CGO,
-  cloud-only services without offline fallback)
+- Issue proposes a storage approach that contradicts the data model (e.g., database migrations instead of rebuild-from-JSONL)
+- Issue introduces dependencies that violate constraints (e.g., CGO, cloud-only services without offline fallback)
 - Issue writes data outside the nexus pattern
 
 #### Completeness checks
 
-1. **Data paths**: Are all file paths concrete and verifiable? Can
-   someone find every referenced file without asking questions? Check
-   that paths exist on disk or that remote paths have copy instructions.
+1. **Data paths**: Are all file paths concrete and verifiable?
+   Can someone find every referenced file without asking questions?
+   Check that paths exist on disk or that remote paths have copy instructions.
 
-   **Git-tracked status** (reproducibility): For every in-repo path the
-   issue references — notes files, scripts, configs, notebooks — check
-   that the path is tracked in the remote branch that readers will have.
-   Flag as **HIGH** if a path is untracked, uncommitted, or committed
-   only to a local branch that hasn't been pushed. Other contributors
-   cannot open a file that lives only on the author's machine, and
-   ad-hoc shell snippets "not committed anywhere" are the same problem.
-   Checks (run against the branch the issue lives on, or `main`):
+**Git-tracked status** (reproducibility): For every in-repo path the issue references — notes files, scripts, configs, notebooks — check that the path is tracked in the remote branch that readers will have.
+Flag as **HIGH** if a path is untracked, uncommitted, or committed only to a local branch that hasn't been pushed.
+Other contributors cannot open a file that lives only on the author's machine, and ad-hoc shell snippets "not committed anywhere" are the same problem.
+Checks (run against the branch the issue lives on, or `main`):
    ```bash
    git ls-files --error-unmatch <path>     # tracked?
    git log -1 --oneline -- <path>          # has a commit?
    git status --porcelain <path>           # uncommitted changes?
    ```
-   **Fix:** default to inlining the needed content directly into the
-   issue body — reproducer snippets, tables of numbers, key paragraphs
-   from a notes file. Do this as part of the normal fix pass; read the
-   uncommitted file and lift the load-bearing parts. "Ad-hoc shell
-   snippets" cited as the source of quoted numbers are a red flag —
-   inline the actual commands. Only if inlining would be unreasonable
-   (many pages of content, binary artifacts, or relevance is ambiguous)
-   surface to the user and ask whether to inline a subset or drop the
-   reference.
+**Fix:** default to inlining the needed content directly into the issue body — reproducer snippets, tables of numbers, key paragraphs from a notes file.
+Do this as part of the normal fix pass; read the uncommitted file and lift the load-bearing parts.
+"Ad-hoc shell snippets" cited as the source of quoted numbers are a red flag — inline the actual commands.
+Only if inlining would be unreasonable (many pages of content, binary artifacts, or relevance is ambiguous) surface to the user and ask whether to inline a subset or drop the reference.
 
-2. **Column names / API contracts**: If the issue references specific
-   data formats (CSV columns, API fields, config keys), verify them
-   against the actual source (read the relevant code or data files).
+2. **Column names / API contracts**: If the issue references specific data formats (CSV columns, API fields, config keys), verify them against the actual source (read the relevant code or data files).
 
-3. **Algorithm specification**: Is the core algorithm described with
-   enough detail to implement? Check for:
+3. **Algorithm specification**: Is the core algorithm described with enough detail to implement?
+   Check for:
    - Mathematical formulas written out explicitly
    - Clear input/output types
    - Edge cases addressed (what to skip, what to include)
@@ -106,146 +88,89 @@ decisions. Flag conflicts as **HIGH**. Common things to catch:
 4. **Prerequisites**: Are all needed packages, tools, and data listed?
    Are version constraints noted where they matter?
 
-5. **Directory structure**: Does the proposed structure follow project
-   conventions? (Check CLAUDE.md or experiments/CLAUDE.md for patterns.)
+5. **Directory structure**: Does the proposed structure follow project conventions?
+   (Check CLAUDE.md or experiments/CLAUDE.md for patterns.)
 
-6. **Code organization — library vs scripts**: If the repo has a Python
-   package (look for `__init__.py` under a top-level directory, or
-   `pyproject.toml` with `[project]`), and the issue proposes new `.py`
-   files in `scripts/`, `workflow/scripts/`, or `bin/`, check whether
-   the core logic should instead live in the library package as a
-   reusable module, with only a thin CLI wrapper in the scripts
-   directory. Flag as **HIGH** if:
-   - The proposed script contains non-trivial logic (algorithms, data
-     transformations, model fitting) rather than just CLI argument
-     parsing and a `main()` call
-   - Similar modules already exist in the library package (check for
-     a pattern of library + wrapper)
+6. **Code organization — library vs scripts**: If the repo has a Python package (look for `__init__.py` under a top-level directory, or `pyproject.toml` with `[project]`), and the issue proposes new `.py` files in `scripts/`, `workflow/scripts/`, or `bin/`, check whether the core logic should instead live in the library package as a reusable module, with only a thin CLI wrapper in the scripts directory.
+   Flag as **HIGH** if:
+   - The proposed script contains non-trivial logic (algorithms, data transformations, model fitting) rather than just CLI argument parsing and a `main()` call
+   - Similar modules already exist in the library package (check for a pattern of library + wrapper)
    - The logic would benefit from unit testing independent of the CLI
-   Suggest a concrete module path following the existing package naming
-   conventions (check sibling modules for style).
+Suggest a concrete module path following the existing package naming conventions (check sibling modules for style).
 
-7. **Test config**: If the project requires fast test configs (e.g.,
-   < 1 minute), is one specified with concrete parameters?
+7. **Test config**: If the project requires fast test configs (e.g., < 1 minute), is one specified with concrete parameters?
 
 #### Infrastructure reuse
 
-8. **Existing infrastructure reuse**: Before accepting that the issue
-   should build new infrastructure (Snakefiles, pipelines, experiment
-   directories, scripts, configs), search for existing work that could
-   be extended. This is one of the most common and costly mistakes in
-   issue design — building from scratch when 80% of the pipeline
-   already exists.
+8. **Existing infrastructure reuse**: Before accepting that the issue should build new infrastructure (Snakefiles, pipelines, experiment directories, scripts, configs), search for existing work that could be extended.
+   This is one of the most common and costly mistakes in issue design — building from scratch when 80% of the pipeline already exists.
 
-   **How to check:**
-   - Search merged PRs for related keywords (dataset names, method
-     names, tool names):
+**How to check:**
+   - Search merged PRs for related keywords (dataset names, method names, tool names):
      ```bash
      gh pr list --repo <org/repo> --state merged --search "<keywords>" --limit 20
      ```
-   - Search the repo for existing Snakefiles, experiment directories,
-     or pipeline configs that overlap with the proposed work:
+   - Search the repo for existing Snakefiles, experiment directories, or pipeline configs that overlap with the proposed work:
      ```bash
      find <repo_path> -name "Snakefile" -o -name "*.smk" -o -name "config.yml" | head -20
      ```
    - Read the most promising matches to assess overlap.
 
-   **Flag as HIGH if:**
-   - An existing Snakefile/pipeline already implements >50% of the
-     proposed workflow steps (e.g., same data ingestion, same tool
-     invocations, same output structure)
-   - The issue proposes a new experiment directory when an existing
-     one uses the same datasets and tools
-   - The issue creates new wrapper scripts for tools that already
-     have wrappers in the repo
+**Flag as HIGH if:**
+   - An existing Snakefile/pipeline already implements >50% of the proposed workflow steps (e.g., same data ingestion, same tool invocations, same output structure)
+   - The issue proposes a new experiment directory when an existing one uses the same datasets and tools
+   - The issue creates new wrapper scripts for tools that already have wrappers in the repo
 
-   **Recommend:** Extend the existing infrastructure (add rules to the
-   existing Snakefile, add config entries, add new targets) rather
-   than duplicating it. Name the specific existing file/directory and
-   explain what can be reused.
+**Recommend:** Extend the existing infrastructure (add rules to the existing Snakefile, add config entries, add new targets) rather than duplicating it.
+Name the specific existing file/directory and explain what can be reused.
 
 #### Codebase style and structure alignment
 
-8b. **Existing code pattern conformance**: Read the source files most
-   relevant to the proposed work (the directory where new code would
-   land, plus 2-3 sibling modules) and check that the issue's design
-   fits the patterns already established in the codebase. This catches
-   drift that DESIGN.md and CONSTITUTION.md cannot — emergent
-   conventions that live only in the code.
+8b.
+**Existing code pattern conformance**: Read the source files most relevant to the proposed work (the directory where new code would land, plus 2-3 sibling modules) and check that the issue's design fits the patterns already established in the codebase.
+This catches drift that DESIGN.md and CONSTITUTION.md cannot — emergent conventions that live only in the code.
 
-   **How to check:**
-   - Identify where the proposed code would live (package, directory,
-     module).
-   - Read 2-3 existing files in that area to extract patterns: naming
-     conventions (functions, types, files), error handling idiom,
-     constructor/factory style, test file layout, and public API shape.
-   - Compare the issue's proposed interfaces, type names, function
-     signatures, and file organization against those patterns.
+**How to check:**
+   - Identify where the proposed code would live (package, directory, module).
+   - Read 2-3 existing files in that area to extract patterns: naming conventions (functions, types, files), error handling idiom, constructor/factory style, test file layout, and public API shape.
+   - Compare the issue's proposed interfaces, type names, function signatures, and file organization against those patterns.
 
-   **Flag as HIGH if:**
-   - The issue proposes a naming convention that conflicts with
-     neighbors (e.g., `NewFooClient()` when siblings use `OpenFoo()`)
-   - The issue introduces a structural pattern not used elsewhere
-     (e.g., a global registry when the codebase uses dependency
-     injection, or callbacks when the codebase uses interfaces)
-   - The issue puts files in a location that breaks the existing
-     package layout (e.g., a new top-level package when similar
-     functionality lives under `internal/`)
-   - The issue proposes a public API surface that is inconsistent
-     with sibling modules (e.g., exposing struct fields when neighbors
-     use getter methods, or vice versa)
+**Flag as HIGH if:**
+   - The issue proposes a naming convention that conflicts with neighbors (e.g., `NewFooClient()` when siblings use `OpenFoo()`)
+   - The issue introduces a structural pattern not used elsewhere (e.g., a global registry when the codebase uses dependency injection, or callbacks when the codebase uses interfaces)
+   - The issue puts files in a location that breaks the existing package layout (e.g., a new top-level package when similar functionality lives under `internal/`)
+   - The issue proposes a public API surface that is inconsistent with sibling modules (e.g., exposing struct fields when neighbors use getter methods, or vice versa)
 
-   **Recommend:** Name the specific existing files that set the
-   pattern and show what the issue should match.
+**Recommend:** Name the specific existing files that set the pattern and show what the issue should match.
 
 #### Deep reuse audit (code-reuse-reviewer)
 
-8c. **Fan-out reuse audit via `code-reuse-reviewer`**: When the issue
-   proposes extending or modifying existing modules (not pure greenfield
-   work), spawn the `code-reuse-reviewer` agent as a deeper pass beyond
-   8b's lightweight sibling-file check. This agent fans out per-file
-   sub-agents to actively hunt for duplicated helpers/constants and
-   missed reuse opportunities — worth the extra cost when there's a
-   concrete integration point to check the proposal against.
+8c.
+**Fan-out reuse audit via `code-reuse-reviewer`**: When the issue proposes extending or modifying existing modules (not pure greenfield work), spawn the `code-reuse-reviewer` agent as a deeper pass beyond 8b's lightweight sibling-file check.
+This agent fans out per-file sub-agents to actively hunt for duplicated helpers/constants and missed reuse opportunities — worth the extra cost when there's a concrete integration point to check the proposal against.
 
-   **Gate — does this apply?** Check whether the issue names specific
-   existing files, functions, or packages it will extend, modify, or
-   call into.
-   - **Opportunity present** (run it): the issue names existing
-     files/functions/packages as integration points, even loosely
-     ("add a method to X", "extend the Y pipeline", "hook into Z's
-     config loading"). In this codebase, this is the common case —
-     very little proposed work is pure greenfield.
-   - **No opportunity** (skip it): the issue describes a genuinely new
-     package/directory with no stated integration point into existing
-     code. Note explicitly in the report "skipped — no integration
-     point found" rather than silently omitting it, so the gate call
-     itself is reviewable.
+**Gate — does this apply?**
+Check whether the issue names specific existing files, functions, or packages it will extend, modify, or call into.
+   - **Opportunity present** (run it): the issue names existing files/functions/packages as integration points, even loosely ("add a method to X", "extend the Y pipeline", "hook into Z's config loading").
+     In this codebase, this is the common case — very little proposed work is pure greenfield.
+   - **No opportunity** (skip it): the issue describes a genuinely new package/directory with no stated integration point into existing code.
+     Note explicitly in the report "skipped — no integration point found" rather than silently omitting it, so the gate call itself is reviewable.
 
-   **How to run:** Use the Agent tool with
-   `subagent_type: code-reuse-reviewer`. Pass it the issue's proposed
-   interfaces/design and the specific existing files it names as
-   integration points, and ask it to check for: helpers or constants
-   that already exist and would be duplicated, structural patterns it
-   should follow but doesn't, and any existing function it could call
-   instead of reimplementing.
+**How to run:** Use the Agent tool with `subagent_type: code-reuse-reviewer`.
+Pass it the issue's proposed interfaces/design and the specific existing files it names as integration points, and ask it to check for: helpers or constants that already exist and would be duplicated, structural patterns it should follow but doesn't, and any existing function it could call instead of reimplementing.
 
-   **Flag as HIGH if** the agent finds an existing helper, constant, or
-   pattern that the issue's proposed design would duplicate or bypass.
+**Flag as HIGH if** the agent finds an existing helper, constant, or pattern that the issue's proposed design would duplicate or bypass.
 
-   **Recommend:** Name the specific existing symbol or file and show
-   how the issue's design should call it instead.
+**Recommend:** Name the specific existing symbol or file and show how the issue's design should call it instead.
 
 #### Redundancy with existing issues
 
-8d. **Duplicate or overlapping issues**: Search open GitHub issues to
-   check whether the proposed work duplicates or substantially overlaps
-   with an existing issue. This prevents wasted effort and conflicting
-   implementations.
+8d.
+**Duplicate or overlapping issues**: Search open GitHub issues to check whether the proposed work duplicates or substantially overlaps with an existing issue.
+This prevents wasted effort and conflicting implementations.
 
-   **How to check:**
-   - Extract 3-5 key terms from the issue title and body (feature
-     names, tool names, data types, package names).
+**How to check:**
+   - Extract 3-5 key terms from the issue title and body (feature names, tool names, data types, package names).
    - Search open issues:
      ```bash
      gh issue list --repo <org/repo> --state open --search "<keywords>" --limit 15
@@ -254,206 +179,141 @@ decisions. Flag conflicts as **HIGH**. Common things to catch:
      ```bash
      gh issue view <number> --repo <org/repo>
      ```
-   - Assess whether the scope overlaps meaningfully (>30% of tasks
-     or the same core deliverable).
+   - Assess whether the scope overlaps meaningfully (>30% of tasks or the same core deliverable).
 
-   **Flag as HIGH if:**
-   - An open issue targets the same feature, dataset, or pipeline
-     with substantial overlap in deliverables
-   - An open issue is a superset that already includes this work
-     as a subtask
+**Flag as HIGH if:**
+   - An open issue targets the same feature, dataset, or pipeline with substantial overlap in deliverables
+   - An open issue is a superset that already includes this work as a subtask
 
-   **Flag as MEDIUM if:**
-   - An open issue touches related code or data but with a clearly
-     different goal (mention it for awareness, not as a blocker)
+**Flag as MEDIUM if:**
+   - An open issue touches related code or data but with a clearly different goal (mention it for awareness, not as a blocker)
 
-   **Recommend:** Link to the overlapping issue and suggest one of:
-   consolidate into the existing issue, explicitly scope-split with
-   cross-references, or close the duplicate.
+**Recommend:** Link to the overlapping issue and suggest one of: consolidate into the existing issue, explicitly scope-split with cross-references, or close the duplicate.
 
 #### Ambiguity and placeholder checks
 
-9. **Vague language**: Scan the entire issue for adjectives and adverbs
-   that lack measurable criteria. Flag instances of words like "fast",
-   "scalable", "robust", "intuitive", "efficient", "significant",
-   "reasonable", "appropriate", "properly", "should improve". Each
-   flagged term must be replaced with a concrete, quantified criterion.
+9. **Vague language**: Scan the entire issue for adjectives and adverbs that lack measurable criteria.
+   Flag instances of words like "fast", "scalable", "robust", "intuitive", "efficient", "significant", "reasonable", "appropriate", "properly", "should improve".
+   Each flagged term must be replaced with a concrete, quantified criterion.
 
-9b. **Defined terms for computed quantities**: Every named metric, rate,
-   ratio, slope, statistic, or other computed quantity must be anchored
-   to an explicit formula or to code that computes it. Interpretive or
-   evaluative names ("quality", "fit", "accuracy", "performance",
-   "signal") are worse than neutral ones — they carry connotations the
-   computation may not support, and reviewers can't check claims built
-   on a term they can't pin down.
+9b.
+**Defined terms for computed quantities**: Every named metric, rate, ratio, slope, statistic, or other computed quantity must be anchored to an explicit formula or to code that computes it.
+Interpretive or evaluative names ("quality", "fit", "accuracy", "performance", "signal") are worse than neutral ones — they carry connotations the computation may not support, and reviewers can't check claims built on a term they can't pin down.
 
-   **Common failure modes:**
-   - Rate, ratio, or fraction without a specified denominator (the
-     same numerator over different denominators gives different
-     answers).
-   - Average, mean, or median without naming the population, subset,
-     or weighting it's taken over.
-   - Correlation, slope, or regression without naming both variables,
-     the sample, and any weighting.
-   - Domain-loaded nouns ("quality", "fitness", "affinity",
-     "performance") attached to what is actually a mechanical count,
-     ratio, or model output.
-   - Comparison claim ("X is better than baseline") without naming
-     the baseline, the test, or the threshold for "better".
-   - Statistical test reported with name or software but not the
-     settings that matter (alpha, alternative, one- vs two-sided,
-     weighting).
+**Common failure modes:**
+   - Rate, ratio, or fraction without a specified denominator (the same numerator over different denominators gives different answers).
+   - Average, mean, or median without naming the population, subset, or weighting it's taken over.
+   - Correlation, slope, or regression without naming both variables, the sample, and any weighting.
+   - Domain-loaded nouns ("quality", "fitness", "affinity", "performance") attached to what is actually a mechanical count, ratio, or model output.
+   - Comparison claim ("X is better than baseline") without naming the baseline, the test, or the threshold for "better".
+   - Statistical test reported with name or software but not the settings that matter (alpha, alternative, one- vs two-sided, weighting).
 
-   **How to check:** For every named quantity, find a formula, code
-   snippet, or pointer to the exact function. If a pointer is given,
-   read the code and confirm the name matches what the code computes
-   — denominators, filters, and weightings are where names most often
-   drift from reality.
+**How to check:** For every named quantity, find a formula, code snippet, or pointer to the exact function.
+If a pointer is given, read the code and confirm the name matches what the code computes — denominators, filters, and weightings are where names most often drift from reality.
 
-   **Flag as HIGH** when the quantity drives a conclusion (prediction,
-   success criterion, hypothesis). Flag as **MEDIUM** when it only
-   appears in motivating context and the surrounding discussion
-   doesn't depend on its exact value.
+**Flag as HIGH** when the quantity drives a conclusion (prediction, success criterion, hypothesis).
+Flag as **MEDIUM** when it only appears in motivating context and the surrounding discussion doesn't depend on its exact value.
 
-   **Recommend:** replace evaluative labels with mechanical ones, and
-   give the formula or code inline the first time a quantity appears.
-   Spell out denominator, population, and weighting explicitly — these
-   are the details reviewers most often have to reconstruct on their
-   own.
+**Recommend:** replace evaluative labels with mechanical ones, and give the formula or code inline the first time a quantity appears.
+Spell out denominator, population, and weighting explicitly — these are the details reviewers most often have to reconstruct on their own.
 
 10. **Unresolved placeholders**: Scan for `TODO`, `TKTK`, `TBD`, `???`,
-   `<placeholder>`, `[NEEDS CLARIFICATION]`, `XXX`, or similar markers
-   that indicate unfinished thinking. Every placeholder must be resolved
-   with concrete content before the issue is submitted.
+`<placeholder>`, `[NEEDS CLARIFICATION]`, `XXX`, or similar markers that indicate unfinished thinking.
+Every placeholder must be resolved with concrete content before the issue is submitted.
 
 #### Prose discipline
 
-10c. **Apply `PROSE-DISCIPLINE.md`** (bipartite repo root). Read the file and check the issue against its rules and reviewer flags. Flag violations as **MEDIUM**, or **HIGH** when they materially obscure the deliverable. Name the offending location and propose the trimmed version; for paragraph-form enumerations, write the bullet-list rewrite.
+10c.
+**Apply `PROSE-DISCIPLINE.md`** (bipartite repo root).
+Read the file and check the issue against its rules and reviewer flags.
+Flag violations as **MEDIUM**, or **HIGH** when they materially obscure the deliverable.
+Name the offending location and propose the trimmed version; for paragraph-form enumerations, write the bullet-list rewrite.
 
 #### Internal consistency
 
-10b. **Cross-section agreement**: An issue is a specification. When two
-   sections disagree, the worker has to guess which is authoritative,
-   and whichever they pick will be wrong for someone.
+10b.
+**Cross-section agreement**: An issue is a specification.
+When two sections disagree, the worker has to guess which is authoritative, and whichever they pick will be wrong for someone.
 
-   **Common failure modes:**
-   - Numbers stated in one section don't match another (counts, sums,
-     line deltas).
-   - Two rules or constraints, each satisfiable alone, can't both hold
-     on some inputs.
-   - Named entities (file paths, identifiers, issue numbers) appear
-     in multiple sections with different forms.
+**Common failure modes:**
+   - Numbers stated in one section don't match another (counts, sums, line deltas).
+   - Two rules or constraints, each satisfiable alone, can't both hold on some inputs.
+   - Named entities (file paths, identifiers, issue numbers) appear in multiple sections with different forms.
 
-   **How to check:** For each prescriptive section (tables, rules,
-   lists, counts), find the other sections that reference or verify
-   it and confirm they agree. Count things that state a count. Run
-   each verification command mentally against the prescribed content.
+**How to check:** For each prescriptive section (tables, rules, lists, counts), find the other sections that reference or verify it and confirm they agree.
+Count things that state a count.
+Run each verification command mentally against the prescribed content.
 
-   **Flag as HIGH if** the worker would have to choose between two
-   sections of the issue to proceed.
+**Flag as HIGH if** the worker would have to choose between two sections of the issue to proceed.
 
-   **Recommend:** Name the conflicting locations and propose which
-   side should change — usually the prescriptive section reflects
-   author intent and the verification should match it, but the
-   author confirms.
+**Recommend:** Name the conflicting locations and propose which side should change — usually the prescriptive section reflects author intent and the verification should match it, but the author confirms.
 
 #### Validation and benchmarking checks
 
 11. **Success criteria**: Are there concrete, measurable success criteria?
-   Not vague ("should improve") but specific ("held-out lnL improves by
-   >1 nat per lineage on average").
+Not vague ("should improve") but specific ("held-out lnL improves by >1 nat per lineage on average").
 
-12. **Null model / baseline**: Is there a clearly specified baseline for
-    comparison? Is the baseline computation described in enough detail
-    to reproduce (formula, software, parameters)?
+12. **Null model / baseline**: Is there a clearly specified baseline for comparison?
+    Is the baseline computation described in enough detail to reproduce (formula, software, parameters)?
 
-13. **Evaluation metric**: Is the primary metric well-defined? Is it
-    clear how to compute it (what software, what formula, what data)?
+13. **Evaluation metric**: Is the primary metric well-defined?
+    Is it clear how to compute it (what software, what formula, what data)?
 
-14. **Cross-validation / held-out evaluation**: If the issue involves
-    model fitting, is the train/test split strategy specified? Are
-    leakage risks addressed?
+14. **Cross-validation / held-out evaluation**: If the issue involves model fitting, is the train/test split strategy specified?
+    Are leakage risks addressed?
 
-15. **Benchmarks**: Are runtime expectations stated? Are absolute
-    numbers reported (not just relative improvements) so future work
-    can compare?
+15. **Benchmarks**: Are runtime expectations stated?
+    Are absolute numbers reported (not just relative improvements) so future work can compare?
 
-16. **Diagnostics**: Are there diagnostic outputs that help debug
-    problems (e.g., coverage histograms, convergence plots, sanity
-    checks)?
+16. **Diagnostics**: Are there diagnostic outputs that help debug problems (e.g., coverage histograms, convergence plots, sanity checks)?
 
 #### Correctness validation brainstorm (REQUIRED)
 
-This is one of the most important parts of the review. Scientific code
-must be validated beyond basic smoke tests. The subagent MUST actively
-brainstorm additional validations that would be convincing evidence the
-math and implementation are correct, then check whether the issue
-already includes them. If not, flag as **HIGH**.
+This is one of the most important parts of the review.
+Scientific code must be validated beyond basic smoke tests.
+The subagent MUST actively brainstorm additional validations that would be convincing evidence the math and implementation are correct, then check whether the issue already includes them.
+If not, flag as **HIGH**.
 
-Think creatively about what tests would actually catch bugs in the
-mathematical or algorithmic core. Common categories:
+Think creatively about what tests would actually catch bugs in the mathematical or algorithmic core.
+Common categories:
 
-17. **Known-answer tests**: Are there cases where the correct answer
-    is known analytically or from a trusted reference implementation?
-    For example: degenerate inputs where the formula simplifies,
-    textbook examples with published answers, or toy cases small
-    enough to verify by hand. Every non-trivial algorithm should have
-    at least one known-answer test specified in the issue.
+17. **Known-answer tests**: Are there cases where the correct answer is known analytically or from a trusted reference implementation?
+    For example: degenerate inputs where the formula simplifies, textbook examples with published answers, or toy cases small enough to verify by hand.
+    Every non-trivial algorithm should have at least one known-answer test specified in the issue.
 
-18. **Symmetry and invariance checks**: Does the algorithm have
-    mathematical properties that can be tested? Examples: commutativity
-    (swapping inputs gives the same result), idempotency (applying
-    twice gives the same result as once), conservation laws (quantities
-    that should sum to a constant), invariance under permutation or
-    relabeling. Each such property is a free correctness check.
+18. **Symmetry and invariance checks**: Does the algorithm have mathematical properties that can be tested?
+    Examples: commutativity (swapping inputs gives the same result), idempotency (applying twice gives the same result as once), conservation laws (quantities that should sum to a constant), invariance under permutation or relabeling.
+    Each such property is a free correctness check.
 
-19. **Limit and boundary behavior**: What happens at extremes? Does the
-    algorithm degrade gracefully or produce known results at boundaries?
-    Examples: uniform input, all-zeros, single-element input, very
-    large/small values, identity transformations. These often expose
-    off-by-one errors and numerical issues.
+19. **Limit and boundary behavior**: What happens at extremes?
+    Does the algorithm degrade gracefully or produce known results at boundaries?
+    Examples: uniform input, all-zeros, single-element input, very large/small values, identity transformations.
+    These often expose off-by-one errors and numerical issues.
 
-20. **Comparison to reference implementation**: If a reference
-    implementation exists (in R, Python, another language, or a
-    published software package), is there a test that runs both and
-    compares outputs on realistic data? Matching a trusted
-    implementation on non-trivial inputs is strong evidence of
-    correctness.
+20. **Comparison to reference implementation**: If a reference implementation exists (in R, Python, another language, or a published software package), is there a test that runs both and compares outputs on realistic data?
+    Matching a trusted implementation on non-trivial inputs is strong evidence of correctness.
 
-21. **Stochastic / statistical tests**: For randomized algorithms, are
-    there distribution-level tests? Examples: checking that samples
-    have the correct mean/variance, that a sampler passes a
-    goodness-of-fit test, that Monte Carlo estimates converge to known
-    values as sample size increases.
+21. **Stochastic / statistical tests**: For randomized algorithms, are there distribution-level tests?
+    Examples: checking that samples have the correct mean/variance, that a sampler passes a goodness-of-fit test, that Monte Carlo estimates converge to known values as sample size increases.
 
-22. **Gradient / sensitivity checks**: For optimization or
-    differentiable code, are there finite-difference gradient checks?
-    For any continuous function, is the output tested for reasonable
-    sensitivity to input perturbations?
+22. **Gradient / sensitivity checks**: For optimization or differentiable code, are there finite-difference gradient checks?
+    For any continuous function, is the output tested for reasonable sensitivity to input perturbations?
 
-23. **Round-trip and self-consistency**: Can the computation be checked
-    by inverting it or by verifying an internal consistency relation?
-    Examples: encode then decode should recover the original,
-    likelihood of the MAP estimate should be >= likelihood of
-    perturbed values, forward and reverse computations should agree.
+23. **Round-trip and self-consistency**: Can the computation be checked by inverting it or by verifying an internal consistency relation?
+    Examples: encode then decode should recover the original, likelihood of the MAP estimate should be >= likelihood of perturbed values, forward and reverse computations should agree.
 
-The subagent should propose at least 2-3 concrete, specific
-validations tailored to the particular algorithm or method in the
-issue. Generic suggestions like "add more tests" are not acceptable —
-each suggestion must name the specific test, what inputs to use, and
-what the expected output or property is.
+The subagent should propose at least 2-3 concrete, specific validations tailored to the particular algorithm or method in the issue.
+Generic suggestions like "add more tests" are not acceptable — each suggestion must name the specific test, what inputs to use, and what the expected output or property is.
 
 ### Step 4: Fix gaps (with approval gate)
 
-Determine whether the agent authored this issue file in the current
-session. This controls whether edits require approval:
+Determine whether the agent authored this issue file in the current session.
+This controls whether edits require approval:
 
-- **Agent-authored** (the agent wrote the issue earlier in this same
-  session): Edit the file directly to fix all gaps. No approval
-  needed — the agent owns the content.
-- **User-authored or external** (the file was provided by the user,
-  loaded from GitHub, or written in a previous session): **Do not
-  edit without explicit user approval.** Present findings first.
+- **Agent-authored** (the agent wrote the issue earlier in this same session): Edit the file directly to fix all gaps.
+  No approval needed — the agent owns the content.
+- **User-authored or external** (the file was provided by the user, loaded from GitHub, or written in a previous session): **Do not edit without explicit user approval.**
+  Present findings first.
 
 #### When approval is required
 
@@ -462,8 +322,7 @@ Present the subagent's findings as a concise summary:
 - For each gap, state what the problem is and what the proposed fix would be
 - Note any hard-wrapping issues (paragraphs broken at ~70-80 chars that should be single lines)
 
-If the findings are substantial (more than 3-4 items, or any
-CRITICAL/HIGH), write them to a temporary file and open for review:
+If the findings are substantial (more than 3-4 items, or any CRITICAL/HIGH), write them to a temporary file and open for review:
 
 ```bash
 cat > /tmp/bip-issue-check-findings.md <<'EOF'
@@ -482,16 +341,17 @@ Do not proceed until the user says to go ahead.
 
 #### Applying edits
 
-Whether auto-applying (agent-authored) or after approval
-(user-authored), fix gaps by adding concrete details (exact column
-names, formulas, file paths) over vague placeholders.
+Whether auto-applying (agent-authored) or after approval (user-authored), fix gaps by adding concrete details (exact column names, formulas, file paths) over vague placeholders.
 
-**Fix hard-wrapping.** If the file contains hard-wrapped paragraphs (newlines inserted mid-sentence at ~70-80 characters), unwrap them so each paragraph is a single long line. Only newlines for actual structural breaks (between paragraphs, list items, headings). GitHub renders markdown with soft wrapping.
+**Fix hard-wrapping.**
+If the file contains hard-wrapped paragraphs (newlines inserted mid-sentence at ~70-80 characters), unwrap them so each paragraph is a single long line.
+Only newlines for actual structural breaks (between paragraphs, list items, headings).
+GitHub renders markdown with soft wrapping.
 
 ### Step 6: Submit via /bip-issue-file
 
-Invoke the `/bip-issue-file` skill with the same file path. It will open
-the file for the user to review after submitting:
+Invoke the `/bip-issue-file` skill with the same file path.
+It will open the file for the user to review after submitting:
 
 ```
 /bip-issue-file <file_path>
@@ -500,7 +360,6 @@ the file for the user to review after submitting:
 ### Step 7: Report
 
 Summarize:
-- Number of gaps found and fixed (grouped by severity if constitution
-  checks were run: CRITICAL / HIGH / MEDIUM / LOW)
+- Number of gaps found and fixed (grouped by severity if constitution checks were run: CRITICAL / HIGH / MEDIUM / LOW)
 - The GitHub issue URL
 - Any remaining open questions that need user input

--- a/skills/bip-issue-file/SKILL.md
+++ b/skills/bip-issue-file/SKILL.md
@@ -31,7 +31,8 @@ Search the recent conversation history for:
 - Issue numbers referenced in discussion (e.g., "#123", "issue 123")
 - Any clear indication we're discussing a specific issue
 
-If found, this is an UPDATE operation. Otherwise, CREATE.
+If found, this is an UPDATE operation.
+Otherwise, CREATE.
 
 ### Step 3: Check for assignee context
 
@@ -73,17 +74,13 @@ gh issue create --title "<extracted title>" --body-file <file> --assignee <usern
 
 ### Step 6: Move the draft out of the way (CREATE only)
 
-On a successful **create**, the source file has done its job — move it
-so it stops being mistaken for unfiled work by any fleet-side sweep
-(e.g. `/bip-conductor`'s cold-start draft check) or confusing a future
-agent poking around the clone:
+On a successful **create**, the source file has done its job — move it so it stops being mistaken for unfiled work by any fleet-side sweep (e.g. `/bip-conductor`'s cold-start draft check) or confusing a future agent poking around the clone:
 
 ```bash
 mkdir -p _ignore && mv <file> _ignore/
 ```
 
-Skip this for **update** operations — the file is still the live
-source for future edits to that issue, so it stays in place.
+Skip this for **update** operations — the file is still the live source for future edits to that issue, so it stays in place.
 
 ### Step 7: Report results
 

--- a/skills/bip-issue-iterate/SKILL.md
+++ b/skills/bip-issue-iterate/SKILL.md
@@ -6,9 +6,9 @@ allowed-tools: Agent, Bash, Read, Edit, Write, Glob, Grep, Skill
 
 # /bip-issue-iterate
 
-Refine an issue draft that already exists. The draft gets **smaller and more
-correct** each round. It may spawn sibling drafts, and it may end in "this
-isn't worth filing."
+Refine an issue draft that already exists.
+The draft gets **smaller and more correct** each round.
+It may spawn sibling drafts, and it may end in "this isn't worth filing."
 
 ## Usage
 
@@ -30,22 +30,21 @@ Use `/bip-issue-check` as the terminal gate here, not as a substitute.
 
 ## The core loop: paragraph by paragraph
 
-The default mode is a walk through the document, one paragraph or section per
-turn. It is the pleasant mode and the productive one — small scope, one
-decision at a time, easy for the user to steer. Offer it at the start and
-return to it whenever the user has no specific objection.
+The default mode is a walk through the document, one paragraph or section per turn.
+It is the pleasant mode and the productive one — small scope, one decision at a time, easy for the user to steer.
+Offer it at the start and return to it whenever the user has no specific objection.
 
 For each paragraph, in order:
 
-1. **Load-bearing test.** What action does this paragraph change — a
-   parameter, a gate, a decision rule, a file someone edits? If nothing, cut
-   it. Content that only reassures the reader is not load-bearing. Expect to
-   cut half: a paragraph supporting one instruction has usually grown to ten
-   lines.
-2. **Verify what survives.** Every line number, default value, and
-   behavioral claim gets checked against the code *before* you write the
-   replacement.
-3. **Rewrite tighter.** State the mechanism once, then the consequence.
+1. **Load-bearing test.**
+   What action does this paragraph change — a parameter, a gate, a decision rule, a file someone edits?
+   If nothing, cut it.
+   Content that only reassures the reader is not load-bearing.
+   Expect to cut half: a paragraph supporting one instruction has usually grown to ten lines.
+2. **Verify what survives.**
+   Every line number, default value, and behavioral claim gets checked against the code *before* you write the replacement.
+3. **Rewrite tighter.**
+   State the mechanism once, then the consequence.
 4. **Propagate** (see below).
 5. **Report**: what was cut, what was kept and why, what you had to correct.
 
@@ -53,74 +52,59 @@ Do not run ahead to the next paragraph unless asked.
 
 ## When the user raises an objection
 
-Treat it as technical, not editorial. A challenge to a premise is not a
-request to reword.
+Treat it as technical, not editorial.
+A challenge to a premise is not a request to reword.
 
 - **Verify before responding**, not after.
-- **Let the conclusion move.** A premise-level correction can dissolve a
-  section, shrink the issue to near-nothing, or invalidate the fix you
-  proposed. Follow it. Do not preserve a wrong claim by softening it.
-- **Correct prior turns plainly** where the error changes the work, in one
-  sentence, then continue.
+- **Let the conclusion move.**
+  A premise-level correction can dissolve a section, shrink the issue to near-nothing, or invalidate the fix you proposed.
+  Follow it.
+  Do not preserve a wrong claim by softening it.
+- **Correct prior turns plainly** where the error changes the work, in one sentence, then continue.
 
 ## Standing rules
 
-**Verify, then write.** Assertions about defaults, dispatch, line numbers,
-and what a function does are wrong often enough that writing them unchecked
-is the main source of rework — and a plausible-sounding claim about a
-function's behaviour is the thing a worker will implement against.
+**Verify, then write.**
+Assertions about defaults, dispatch, line numbers, and what a function does are wrong often enough that writing them unchecked is the main source of rework — and a plausible-sounding claim about a function's behaviour is the thing a worker will implement against.
 
-**Search for prior art before proposing a fix.** Before designing anything,
-grep for an existing helper, an existing convention in sibling experiments,
-and a closed issue that already diagnosed it. Proposing a mechanism the repo
-already has — or contradicting a convention it already follows — is a
-Constitution VI violation, the most common failure here, and one that
-usually inverts the proposed fix rather than merely its framing.
+**Search for prior art before proposing a fix.**
+Before designing anything, grep for an existing helper, an existing convention in sibling experiments, and a closed issue that already diagnosed it.
+Proposing a mechanism the repo already has — or contradicting a convention it already follows — is a Constitution VI violation, the most common failure here, and one that usually inverts the proposed fix rather than merely its framing.
 
 **Simulate for magnitude, then check the simulation matches the code path.**
 Right arithmetic against the wrong function is a silent, confident error.
-Any number that reaches the issue is either reproducible from an inlined
-seeded snippet — which you have run in the form it appears — or delegated to
-a measurement the issue schedules. Never cite an ad-hoc script: a number
-nobody can regenerate is one nobody can correct.
+Any number that reaches the issue is either reproducible from an inlined seeded snippet — which you have run in the form it appears — or delegated to a measurement the issue schedules.
+Never cite an ad-hoc script: a number nobody can regenerate is one nobody can correct.
 
-**Cut self-argument.** Drafts refined across rounds accumulate the residue
-`/bip-remove-metaspeak` targets: passages arguing with a position the draft
-no longer holds, retractions of proposals never filed, and narration of its
-own revision. Squash to the final position. Keep a rejected approach only as
-a short "what not to do" when someone would otherwise retry it; drop the
-history of how it was rejected.
+**Cut self-argument.**
+Drafts refined across rounds accumulate the residue `/bip-remove-metaspeak` targets: passages arguing with a position the draft no longer holds, retractions of proposals never filed, and narration of its own revision.
+Squash to the final position.
+Keep a rejected approach only as a short "what not to do" when someone would otherwise retry it; drop the history of how it was rejected.
 
-**Propagate before reporting.** Every change chases through: run counts and
-arithmetic, cross-references and quoted section names, validation item
-numbering, success criteria, decision rules, sibling draft files, and the
-body of anything already filed. Subtractive edits leave dangling references
-and stale totals, and those are what make a reader stop trusting the rest.
+**Propagate before reporting.**
+Every change chases through: run counts and arithmetic, cross-references and quoted section names, validation item numbering, success criteria, decision rules, sibling draft files, and the body of anything already filed.
+Subtractive edits leave dangling references and stale totals, and those are what make a reader stop trusting the rest.
 
 ## Sibling issues
 
-Scope regularly reveals that part of the draft belongs elsewhere — a shared
-library change riding inside an experiment issue, or a bug found while
-verifying a claim.
+Scope regularly reveals that part of the draft belongs elsewhere — a shared library change riding inside an experiment issue, or a bug found while verifying a claim.
 
-**Write the sibling as its own `ISSUE-*.md` file and tell the user.** Do not
-file it. Do not fold it back in. Then cross-reference both drafts, and state
-in each whether either blocks the other.
+**Write the sibling as its own `ISSUE-*.md` file and tell the user.**
+Do not file it.
+Do not fold it back in.
+Then cross-reference both drafts, and state in each whether either blocks the other.
 
 ## Before filing
 
-1. **Fresh adversarial read — only after a premise-level change.** If a
-   round changed what the issue *claims*, not just how it reads, spawn a
-   subagent to read the whole document cold. Brief it explicitly on what was
-   reframed and tell it to hunt for surviving old framing, asks that
-   contradict the new premise, and validations that no longer test anything.
+1. **Fresh adversarial read — only after a premise-level change.**
+   If a round changed what the issue *claims*, not just how it reads, spawn a subagent to read the whole document cold.
+   Brief it explicitly on what was reframed and tell it to hunt for surviving old framing, asks that contradict the new premise, and validations that no longer test anything.
    Skip this for rounds that only tightened wording.
 2. **`/bip-issue-check`** for constitution and completeness.
-3. **Ask before filing.** Then write the assigned number back into every
-   draft that referred to the file by name.
+3. **Ask before filing.**
+   Then write the assigned number back into every draft that referred to the file by name.
 
 ## Ending without filing
 
-A legitimate outcome. If the load-bearing test empties the issue, or prior
-art shows the work is done, say so and recommend closing the draft rather
-than filing a thin issue.
+A legitimate outcome.
+If the load-bearing test empties the issue, or prior art shows the work is done, say so and recommend closing the draft rather than filing a thin issue.

--- a/skills/bip-issue-next/SKILL.md
+++ b/skills/bip-issue-next/SKILL.md
@@ -6,10 +6,9 @@ allowed-tools: Agent, Bash, Read, Edit, Write, Glob, Grep, Skill
 
 # /bip-issue-next
 
-Draft an issue, quality-check it, and submit — all in one command. The
-"next" issue may come from any source: a PR decision, a deferral filed
-by the issue-lead, an idea raised in conversation, or a topic given
-inline. There is no requirement that a PR exist.
+Draft an issue, quality-check it, and submit — all in one command.
+The "next" issue may come from any source: a PR decision, a deferral filed by the issue-lead, an idea raised in conversation, or a topic given inline.
+There is no requirement that a PR exist.
 
 ## Usage
 
@@ -20,73 +19,53 @@ inline. There is no requirement that a PR exist.
 /bip-issue-next                       # infer from current conversation
 ```
 
-The `--focus-file` form lets a caller (the issue-lead filing a
-specific deferral, or the user piping in a pre-written description)
-name the next-action directly, skipping candidate collection and the
-"ask if ambiguous" step. The file path points to a plain-text file
-whose contents are the focus description (one-line or multi-line both
-OK). A file is used instead of a CLI string to avoid shell-quoting
-hazards when the description contains quotes, backticks, or
-parentheses.
+The `--focus-file` form lets a caller (the issue-lead filing a specific deferral, or the user piping in a pre-written description) name the next-action directly, skipping candidate collection and the "ask if ambiguous" step.
+The file path points to a plain-text file whose contents are the focus description (one-line or multi-line both OK).
+A file is used instead of a CLI string to avoid shell-quoting hazards when the description contains quotes, backticks, or parentheses.
 
 ## Workflow
 
 ### Step 1: Parse arguments and identify the source
 
 Parse `$ARGUMENTS` as whitespace-separated tokens:
-- Extract a PR reference if present (first token that looks like a
-  URL or a `#?NNN` pattern). A PR is optional.
-- Extract `--focus-file <path>` if present and read the file contents
-  as the focus description. Strip leading/trailing whitespace but
-  preserve interior content verbatim. If the file is missing or
-  empty, stop and report the error — do not fall back to
-  candidate-picking.
+- Extract a PR reference if present (first token that looks like a URL or a `#?NNN` pattern).
+  A PR is optional.
+- Extract `--focus-file <path>` if present and read the file contents as the focus description.
+  Strip leading/trailing whitespace but preserve interior content verbatim.
+  If the file is missing or empty, stop and report the error — do not fall back to candidate-picking.
 
-Duplicate-detection is the caller's responsibility — if called twice
-with the same focus, two issues will be filed. The issue-lead guards
-against this via `completed_at` (which makes the terminal ceremony
-run at most once per session).
+Duplicate-detection is the caller's responsibility — if called twice with the same focus, two issues will be filed.
+The issue-lead guards against this via `completed_at` (which makes the terminal ceremony run at most once per session).
 
 Then resolve the source, in this order:
-- If a PR URL or number was given, use it
-  (`gh pr view <arg> --json number,title,body,comments,reviews,baseRefName,headRefName`)
-- Else if `--focus-file` was given without a PR, the focus is the
-  source — no PR resolution needed
-- Else scan conversation history: the source may be a recently
-  discussed PR, an idea raised in conversation, or a stated topic.
+- If a PR URL or number was given, use it (`gh pr view <arg> --json number,title,body,comments,reviews,baseRefName,headRefName`)
+- Else if `--focus-file` was given without a PR, the focus is the source — no PR resolution needed
+- Else scan conversation history: the source may be a recently discussed PR, an idea raised in conversation, or a stated topic.
   Use whichever is most recent and most relevant
 - If still unclear, ask the user what the next issue should be about
 
-The repo for the new issue is whichever is most natural: the PR's
-repo if a PR is in play, otherwise the current working directory's
-repo (inferred via `gh repo view --json nameWithOwner`).
+The repo for the new issue is whichever is most natural: the PR's repo if a PR is in play, otherwise the current working directory's repo (inferred via `gh repo view --json nameWithOwner`).
 
 ### Step 2: Determine the next-action
 
-**If `--focus-file` was provided**, use the file's contents as the
-next-action directly. Skip candidate collection. If a PR is also in
-play, read its body, comments, and review threads only to enrich the
-motivation (quantitative results, linked issues) — not to override
-the focus.
+**If `--focus-file` was provided**, use the file's contents as the next-action directly.
+Skip candidate collection.
+If a PR is also in play, read its body, comments, and review threads only to enrich the motivation (quantitative results, linked issues) — not to override the focus.
 
-**Else if a PR is in play**, read the PR body, comments, and review
-threads and look for:
+**Else if a PR is in play**, read the PR body, comments, and review threads and look for:
 
 - **Explicit next-steps**: "next issue should …", "follow-up:", "TODO for next PR"
-- **Decisions with implications**: a hypothesis confirmed/falsified, an
-  approach chosen over alternatives, a scope item deferred
+- **Decisions with implications**: a hypothesis confirmed/falsified, an approach chosen over alternatives, a scope item deferred
 - **Reviewer requests** that were marked out-of-scope for this PR
 - **Unfinished checkboxes** in the PR's test plan or task list
 
-Collect these into a bullet list of candidate next-actions. If there are
-multiple independent next-actions, pick the single most impactful one
-(ask the user if it's ambiguous).
+Collect these into a bullet list of candidate next-actions.
+If there are multiple independent next-actions, pick the single most impactful one (ask the user if it's ambiguous).
 
-**Else (no PR, no focus-file)**, use the current conversation as the
-source. The next-action is whatever the user has been discussing or
-asked you to file. Skip candidate collection — there is one focus,
-and it is the topic at hand. Ask the user only if the topic is
-genuinely ambiguous.
+**Else (no PR, no focus-file)**, use the current conversation as the source.
+The next-action is whatever the user has been discussing or asked you to file.
+Skip candidate collection — there is one focus, and it is the topic at hand.
+Ask the user only if the topic is genuinely ambiguous.
 
 Also gather what's relevant from whichever source is in play:
 
@@ -98,68 +77,61 @@ Also gather what's relevant from whichever source is in play:
 
 Use the repo to fill in concrete details:
 
-1. **Code context**: Read key source files mentioned in the PR to
-   understand current state after the PR merges
-2. **Experiment results**: If the PR includes benchmark numbers or
-   experiment outcomes, note them as motivation / baseline
-3. **Existing issues**: Run `gh issue list -R <repo> --limit 20 --json number,title`
-   to check for duplicates or related open issues
-4. **Project docs**: Check for `CONSTITUTION.md`, `DESIGN.md`, or
-   `experiments/CLAUDE.md` in the repo for conventions
+1. **Code context**: Read key source files mentioned in the PR to understand current state after the PR merges
+2. **Experiment results**: If the PR includes benchmark numbers or experiment outcomes, note them as motivation / baseline
+3. **Existing issues**: Run `gh issue list -R <repo> --limit 20 --json number,title` to check for duplicates or related open issues
+4. **Project docs**: Check for `CONSTITUTION.md`, `DESIGN.md`, or `experiments/CLAUDE.md` in the repo for conventions
 
 ### Step 4: Draft the issue file
 
-Write `ISSUE-<slug>.md` in the current working directory. The slug
-should be a short kebab-case summary (e.g., `ISSUE-quartet-timing-instrumentation.md`).
+Write `ISSUE-<slug>.md` in the current working directory.
+The slug should be a short kebab-case summary (e.g., `ISSUE-quartet-timing-instrumentation.md`).
 
 **The issue MUST follow matsengrp standards:**
 
 - **Title** (H1): concise, imperative mood (e.g., "Add timing instrumentation for quartet NNI")
 - **🤖** robot emoji as the first character of the body (after the H1 title)
-- **Motivation**: 2-3 sentences linking back to the source — the PR
-  decision, the conversation, or the focus-file context. Reference
-  the PR by number if one exists. Include quantitative results if
-  relevant
+- **Motivation**: 2-3 sentences linking back to the source — the PR decision, the conversation, or the focus-file context.
+  Reference the PR by number if one exists.
+  Include quantitative results if relevant
 - **Problem / Root cause**: What gap remains after the source PR
-- **Proposed implementation**: Phased if complex, with numbered phases
-  and explicit phase-gating. Reference exact file paths and function
-  names where possible
-- **Files to modify**: Bulleted list of files with brief description of
-  changes
-- **Test plan**: Concrete test cases with expected outcomes; include a
-  fast test config if the project expects one (< 1 minute)
-- **Experiment** (if applicable): Question, Hypothesis, Conditions
-  table, Dataset, Running instructions (exact CLI), Success criteria
-  (quantitative thresholds), Diagnostics
+- **Proposed implementation**: Phased if complex, with numbered phases and explicit phase-gating.
+  Reference exact file paths and function names where possible
+- **Files to modify**: Bulleted list of files with brief description of changes
+- **Test plan**: Concrete test cases with expected outcomes; include a fast test config if the project expects one (< 1 minute)
+- **Experiment** (if applicable): Question, Hypothesis, Conditions table, Dataset, Running instructions (exact CLI), Success criteria (quantitative thresholds), Diagnostics
 - **Success criteria**: Numbered, falsifiable, with concrete thresholds
 - **Scope boundaries**: Explicit "In scope" / "Out of scope" lists
-- **References**: Link to source PR (if any), EPIC, related issues,
-  papers if applicable
+- **References**: Link to source PR (if any), EPIC, related issues, papers if applicable
 - **Depends on / Blocked by**: If there are dependency relationships
 
-**Avoid vague language.** Every adjective must have a measurable
-criterion. No "fast", "scalable", "robust" without numbers.
+**Avoid vague language.**
+Every adjective must have a measurable criterion.
+No "fast", "scalable", "robust" without numbers.
 
-**Apply prose discipline.** Read `PROSE-DISCIPLINE.md` at the bipartite repo root before drafting and apply its rules. Defaults toward shorter: lead with the deliverable, state each fact once, bullets for enumerations, show the change site (not its surroundings), drop non-contested options, list bug-catching tests (not invariants).
+**Apply prose discipline.**
+Read `PROSE-DISCIPLINE.md` at the bipartite repo root before drafting and apply its rules.
+Defaults toward shorter: lead with the deliverable, state each fact once, bullets for enumerations, show the change site (not its surroundings), drop non-contested options, list bug-catching tests (not invariants).
 
-**No hard-wrapping.** Write each paragraph as a single long line. Do NOT insert newlines at 70-80 characters within paragraphs or bullet points. Let GitHub's renderer handle line wrapping. Only use newlines for actual structural breaks (between paragraphs, list items, headings).
+**No hard-wrapping.**
+Write each paragraph as a single long line.
+Do NOT insert newlines at 70-80 characters within paragraphs or bullet points.
+Let GitHub's renderer handle line wrapping.
+Only use newlines for actual structural breaks (between paragraphs, list items, headings).
 
 ### Step 4b: Re-check for duplicates immediately before filing
 
-Minutes may have passed since Step 3's search (drafting, gathering
-context). Re-run it now, scoped to what's new:
+Minutes may have passed since Step 3's search (drafting, gathering context).
+Re-run it now, scoped to what's new:
 
 ```
 gh issue list -R <repo> --state open --search "sort:created-desc" \
   --limit 10 --json number,title,createdAt
 ```
 
-If any issue created since the Step 3 check has a title or scope that
-substantially overlaps the draft, stop — do not file. This is the
-common failure mode when another agent (e.g. a concurrent epic worker)
-reached the same "obvious next step" independently while this one was
-drafting. Report the collision and ask the user whether to close/link
-the draft against the existing issue instead of filing a duplicate.
+If any issue created since the Step 3 check has a title or scope that substantially overlaps the draft, stop — do not file.
+This is the common failure mode when another agent (e.g. a concurrent epic worker) reached the same "obvious next step" independently while this one was drafting.
+Report the collision and ask the user whether to close/link the draft against the existing issue instead of filing a duplicate.
 
 ### Step 5: Run /bip-issue-check
 
@@ -169,15 +141,12 @@ Invoke the `/bip-issue-check` skill on the drafted file:
 /bip-issue-check ISSUE-<slug>.md
 ```
 
-This will review the issue for completeness (constitution alignment,
-data paths, algorithm spec, success criteria, vague language, etc.),
-fix gaps, and submit the issue via `/bip-issue-file`.
+This will review the issue for completeness (constitution alignment, data paths, algorithm spec, success criteria, vague language, etc.), fix gaps, and submit the issue via `/bip-issue-file`.
 
 ### Step 6: Report
 
 Summarize:
-- The source (PR + decision, focus-file, or conversation topic) that
-  triggered this issue
+- The source (PR + decision, focus-file, or conversation topic) that triggered this issue
 - The new issue URL
 - Key success criteria from the issue
 - Any open questions or items the user should weigh in on

--- a/skills/bip-issue-update/SKILL.md
+++ b/skills/bip-issue-update/SKILL.md
@@ -6,15 +6,12 @@ allowed-tools: Agent, Bash, Read, Edit, Skill, Glob, Grep
 
 # /bip-issue-update
 
-Re-evaluate an existing GitHub issue against the current state of all
-relevant repositories. Fix stale content (resolved blockers, landed
-PRs, outdated flag names, superseded designs), then run `/bip-issue-check`
-for mechanical completeness.
+Re-evaluate an existing GitHub issue against the current state of all relevant repositories.
+Fix stale content (resolved blockers, landed PRs, outdated flag names, superseded designs), then run `/bip-issue-check` for mechanical completeness.
 
-This is the "think, then check" complement to `/bip-issue-check`. Use
-`/bip-issue-check` for a new issue that hasn't been filed yet. Use
-`/bip-issue-update` for an existing issue that may have drifted from
-reality.
+This is the "think, then check" complement to `/bip-issue-check`.
+Use `/bip-issue-check` for a new issue that hasn't been filed yet.
+Use `/bip-issue-update` for an existing issue that may have drifted from reality.
 
 ## Usage
 
@@ -27,8 +24,8 @@ reality.
 
 ### Step 1: Load the issue
 
-Parse `$ARGUMENTS` to get the repo and issue number. If only a number
-is given, infer the repo from the current working directory.
+Parse `$ARGUMENTS` to get the repo and issue number.
+If only a number is given, infer the repo from the current working directory.
 
 ```bash
 gh issue view <number> --repo <org/repo> --json title,body,state,labels,updatedAt
@@ -42,30 +39,28 @@ gh issue view <number> --repo <org/repo> --json body --jq '.body' > /tmp/issue-<
 
 ### Step 2: Gather current state
 
-This is the key step that distinguishes `/bip-issue-update` from
-`/bip-issue-check`. Examine the real world, not just the issue text.
+This is the key step that distinguishes `/bip-issue-update` from `/bip-issue-check`.
+Examine the real world, not just the issue text.
 
 #### 2a: Scan referenced issues and PRs
 
-Parse the issue body for references to other issues (`#N`, `org/repo#N`)
-and PRs. For each reference, check current status:
+Parse the issue body for references to other issues (`#N`, `org/repo#N`) and PRs.
+For each reference, check current status:
 
 ```bash
 gh issue view <ref> --repo <repo> --json state,title
 gh pr view <ref> --repo <repo> --json state,title,mergedAt
 ```
 
-Build a table of references and their current state. Flag any that
-the issue marks as "blocked" or "depends on" but are now closed/merged.
+Build a table of references and their current state.
+Flag any that the issue marks as "blocked" or "depends on" but are now closed/merged.
 
 #### 2b: Check dependency repos
 
-If the issue references other repositories (e.g., `matsengrp/phyz#812`),
-pull them and check relevant state:
+If the issue references other repositories (e.g., `matsengrp/phyz#812`), pull them and check relevant state:
 
 - Has the blocking PR/issue been merged/closed?
-- Have the proposed API names (CLI flags, function signatures, file
-  formats) changed in the landed implementation?
+- Have the proposed API names (CLI flags, function signatures, file formats) changed in the landed implementation?
 - Are there new issues or PRs in those repos that affect this issue?
 
 For each referenced repo, if a local checkout exists:
@@ -90,31 +85,24 @@ Check whether:
 
 #### 2d: Architectural review
 
-Check whether the issue's proposed code organization aligns with the
-repo's current structure:
+Check whether the issue's proposed code organization aligns with the repo's current structure:
 
-- Does the repo have a Python package? If so, does the issue put core
-  logic there or in naked scripts?
-- Have new modules or patterns been established since the issue was
-  written that the issue should follow?
+- Does the repo have a Python package?
+  If so, does the issue put core logic there or in naked scripts?
+- Have new modules or patterns been established since the issue was written that the issue should follow?
 - Has the repo's CLAUDE.md or design documentation changed?
 
 #### 2e: Infrastructure reuse check
 
-Search for existing infrastructure that the issue could extend instead
-of building from scratch. This is a common failure mode — issues
-proposing new Snakefiles, experiment directories, or pipelines when
-an existing one already covers 80% of the work.
+Search for existing infrastructure that the issue could extend instead of building from scratch.
+This is a common failure mode — issues proposing new Snakefiles, experiment directories, or pipelines when an existing one already covers 80% of the work.
 
-- Search merged PRs for related keywords (dataset names, method names,
-  tool names):
+- Search merged PRs for related keywords (dataset names, method names, tool names):
   ```bash
   gh pr list --repo <org/repo> --state merged --search "<keywords>" --limit 20
   ```
-- Search the repo for existing Snakefiles, experiment directories, or
-  pipeline configs that overlap with the proposed work.
-- If a substantial overlap is found, flag as **HIGH** and recommend
-  extending the existing infrastructure rather than duplicating it.
+- Search the repo for existing Snakefiles, experiment directories, or pipeline configs that overlap with the proposed work.
+- If a substantial overlap is found, flag as **HIGH** and recommend extending the existing infrastructure rather than duplicating it.
   Name the specific file/directory.
 
 ### Step 3: Domain-aware review
@@ -132,8 +120,7 @@ Think through the issue at a higher level than mechanical checks:
 
 - Has the scope of the parent EPIC or project shifted?
 - Are there new results or findings that change what this issue should do?
-- Is any part of the issue already done (landed in another PR, completed
-  as part of a different issue)?
+- Is any part of the issue already done (landed in another PR, completed as part of a different issue)?
 
 #### Dependency freshness
 
@@ -143,18 +130,14 @@ Think through the issue at a higher level than mechanical checks:
 
 ### Step 4: Apply fixes
 
-Edit the temp file (`/tmp/issue-<number>-body.md`) to fix all
-identified problems. Common fixes:
+Edit the temp file (`/tmp/issue-<number>-body.md`) to fix all identified problems.
+Common fixes:
 
-- **Resolved blockers**: Change "BLOCKED on X" to
-  "~~BLOCKED on X~~ -- **resolved** by PR Y (merged DATE)"
-- **Landed implementations**: Update proposed flag names, output
-  formats, and API signatures to match the actual landed code
+- **Resolved blockers**: Change "BLOCKED on X" to "~~BLOCKED on X~~ -- **resolved** by PR Y (merged DATE)"
+- **Landed implementations**: Update proposed flag names, output formats, and API signatures to match the actual landed code
 - **Completed work**: Mark tasks as done (`- [x]`) with a note
-- **Stale estimates**: Update PCP counts, file sizes, runtime estimates
-  based on current data
-- **Code organization**: Move proposed scripts to library modules
-  following the repo's established patterns
+- **Stale estimates**: Update PCP counts, file sizes, runtime estimates based on current data
+- **Code organization**: Move proposed scripts to library modules following the repo's established patterns
 - **Missing validations**: Add concrete checks with measurable criteria
 
 ### Step 5: Run /bip-issue-check
@@ -165,13 +148,10 @@ After applying domain-aware fixes, run the mechanical checklist:
 /bip-issue-check /tmp/issue-<number>-body.md
 ```
 
-This catches anything the domain review missed: vague language,
-missing data paths, unresolved placeholders, etc.
+This catches anything the domain review missed: vague language, missing data paths, unresolved placeholders, etc.
 
 **Important**: `/bip-issue-check` will try to submit via `/bip-issue-file`.
-Since we're updating an existing issue (not creating from an
-`ISSUE-*.md` file), intercept before submission and instead push
-the update directly:
+Since we're updating an existing issue (not creating from an `ISSUE-*.md` file), intercept before submission and instead push the update directly:
 
 ```bash
 gh issue edit <number> --repo <org/repo> --body-file /tmp/issue-<number>-body.md
@@ -180,10 +160,8 @@ gh issue edit <number> --repo <org/repo> --body-file /tmp/issue-<number>-body.md
 ### Step 6: Report
 
 Summarize:
-- **Staleness**: How many references were out of date (resolved blockers,
-  landed PRs, changed APIs)
-- **Domain fixes**: Architectural changes, validation additions, scope
-  adjustments
+- **Staleness**: How many references were out of date (resolved blockers, landed PRs, changed APIs)
+- **Domain fixes**: Architectural changes, validation additions, scope adjustments
 - **Mechanical fixes**: From `/bip-issue-check` (grouped by severity)
 - The updated issue URL
 - Any remaining open questions for the user

--- a/skills/bip-issue-work/SKILL.md
+++ b/skills/bip-issue-work/SKILL.md
@@ -29,7 +29,8 @@ Read both the issue body and any comments for full context.
 
 ### Step 2: Brainstorm clarifying questions
 
-Think hard about the issue requirements. If you have any clarifying questions, **STOP and ask them before writing any code**.
+Think hard about the issue requirements.
+If you have any clarifying questions, **STOP and ask them before writing any code**.
 
 Once everything is clear, proceed.
 
@@ -55,7 +56,10 @@ Use the issue number as a branch prefix for traceability.
 ls PRE-MERGE-CHECKLIST.md 2>/dev/null
 ```
 
-- **If `PRE-MERGE-CHECKLIST.md` exists**: read it **line by line** and verify every numbered item. For each item, either confirm it passes or explicitly state why it is not applicable (e.g. "item 4: parity — skipped, no alignment code changed"). Do not rely on memory — re-read the file fresh each time. Issue-lead approval does **not** substitute for this: the lead evaluates issue scope; the checklist catches cross-cutting concerns (citations, formatting, README sync) that the issue body won't mention.
+- **If `PRE-MERGE-CHECKLIST.md` exists**: read it **line by line** and verify every numbered item.
+  For each item, either confirm it passes or explicitly state why it is not applicable (e.g. "item 4: parity — skipped, no alignment code changed").
+  Do not rely on memory — re-read the file fresh each time.
+  Issue-lead approval does **not** substitute for this: the lead evaluates issue scope; the checklist catches cross-cutting concerns (citations, formatting, README sync) that the issue body won't mention.
 - **Otherwise**: run `/bip-pr-check` as the baseline quality gate.
 
 ### Step 6: Fix review findings
@@ -74,21 +78,18 @@ gh pr create --title "<concise title>" --body "<body>"
 - Include `Closes #$ARGUMENTS` in the body to auto-close the issue on merge
 - Do NOT manually close the issue — GitHub handles it when the PR merges
 
-**Report findings in the PR body.** If the work involved experiments or benchmarks, include key results (tables, numbers, conclusions) directly in the PR body. Don't just point at branch files — the PR body is the permanent record.
+**Report findings in the PR body.**
+If the work involved experiments or benchmarks, include key results (tables, numbers, conclusions) directly in the PR body.
+Don't just point at branch files — the PR body is the permanent record.
 
 ### Step 8: Summary for the user
 
-After creating the PR, provide a concise summary that highlights
-things the user needs to **judge**:
+After creating the PR, provide a concise summary that highlights things the user needs to **judge**:
 
 - **Underlying bugs or tech debt** discovered during the work (even if worked around)
 - **Structural concerns** — places where the fix is a workaround rather than a root-cause fix
 - **Performance implications** of the approach taken
 
-Record any deferred work in the PR body `DEFERRED` section (one line
-per item, with rationale per the DEFERRAL RULE). In EPIC mode the
-issue-lead will scan these at terminal `completed` and file the
-legitimate ones as follow-up issues; standalone users can review the
-list and run `/bip-issue-next` for the ones worth filing. Either way,
-do not list follow-ups in this summary — the PR body is the source of
-truth.
+Record any deferred work in the PR body `DEFERRED` section (one line per item, with rationale per the DEFERRAL RULE).
+In EPIC mode the issue-lead will scan these at terminal `completed` and file the legitimate ones as follow-up issues; standalone users can review the list and run `/bip-issue-next` for the ones worth filing.
+Either way, do not list follow-ups in this summary — the PR body is the source of truth.

--- a/skills/bip-kaizen/SKILL.md
+++ b/skills/bip-kaizen/SKILL.md
@@ -9,7 +9,8 @@ Reflect on friction or confusion from the current session and propose a concrete
 
 ## Context
 
-"Kaizen" means continuous improvement. After any interaction where something didn't go smoothly—agent couldn't find files, a skill was confusing, documentation was missing, a workflow was clunky—the user can invoke `/bip-kaizen` and the agent will:
+"Kaizen" means continuous improvement.
+After any interaction where something didn't go smoothly—agent couldn't find files, a skill was confusing, documentation was missing, a workflow was clunky—the user can invoke `/bip-kaizen` and the agent will:
 
 1. Diagnose what went wrong (or what could be better)
 2. Propose a specific, actionable fix
@@ -22,13 +23,15 @@ Reflect on friction or confusion from the current session and propose a concrete
 /bip-kaizen "the bip search kept failing because the schema was stale"
 ```
 
-`$ARGUMENTS` is an optional hint about what to improve. If empty, infer from conversation context.
+`$ARGUMENTS` is an optional hint about what to improve.
+If empty, infer from conversation context.
 
 ## Workflow
 
 ### Step 1: Diagnose
 
-Review the conversation history for friction points. Look for:
+Review the conversation history for friction points.
+Look for:
 
 - **Confusion**: Agent searched for files in the wrong place, couldn't find source code, misunderstood project structure
 - **Failed commands**: CLI errors, missing flags, wrong syntax, stale schemas
@@ -37,9 +40,11 @@ Review the conversation history for friction points. Look for:
 - **Repetitive work**: Something the agent had to figure out repeatedly that should be documented
 - **Workflow friction**: Too many manual steps, missing automation, unclear handoffs
 
-If `$ARGUMENTS` is provided, focus the diagnosis there. Otherwise, scan the full conversation.
+If `$ARGUMENTS` is provided, focus the diagnosis there.
+Otherwise, scan the full conversation.
 
-Identify the **root cause**, not just the symptom. For example:
+Identify the **root cause**, not just the symptom.
+For example:
 - Symptom: "Agent couldn't find the database" → Root cause: Database path not documented in CLAUDE.md
 - Symptom: "bip search returned errors" → Root cause: Skill doc doesn't mention `bip rebuild` as a first step
 
@@ -78,7 +83,8 @@ Then show the specific change—either as a diff, a new section to add, or a des
 
 ### Step 4: Ask before acting
 
-**STOP and ask the user** before making any changes. Present options:
+**STOP and ask the user** before making any changes.
+Present options:
 
 1. **Apply now** — Make the edit directly (for small CLAUDE.md or skill changes)
 2. **Create a PR** — For changes to the bipartite repo (skills, code)
@@ -123,8 +129,11 @@ gh pr create --title "kaizen: <description>" --body "..."
 ## Guidelines
 
 - **Be specific**: "Add database path to CLAUDE.md" not "improve documentation"
-- **Be minimal**: Propose the smallest change that fixes the problem. Don't refactor adjacent code
+- **Be minimal**: Propose the smallest change that fixes the problem.
+  Don't refactor adjacent code
 - **One improvement per invocation**: If you see multiple issues, pick the highest-impact one and mention the others briefly
 - **Respect existing structure**: Follow the conventions already in CLAUDE.md and skill files
-- **Bipartite repo awareness**: Skills live in `/Users/matsen/re/bipartite/skills/`. The repo is `matsen/bipartite` on GitHub
-- **Don't over-document**: If something is obvious from the code, it doesn't need a CLAUDE.md entry. Only document things the agent genuinely couldn't figure out on its own
+- **Bipartite repo awareness**: Skills live in `/Users/matsen/re/bipartite/skills/`.
+  The repo is `matsen/bipartite` on GitHub
+- **Don't over-document**: If something is obvious from the code, it doesn't need a CLAUDE.md entry.
+  Only document things the agent genuinely couldn't figure out on its own

--- a/skills/bip-lit-edges/SKILL.md
+++ b/skills/bip-lit-edges/SKILL.md
@@ -42,19 +42,23 @@ for key in Key1 Key2 Key3; do
 done
 ```
 
-**When a key is NOT FOUND**, the paper may still be in the library under a different key suffix (e.g., `Sethna2019-lv` in bib vs `Sethna2019-at` in library). Search by title or keyword:
+**When a key is NOT FOUND**, the paper may still be in the library under a different key suffix (e.g., `Sethna2019-lv` in bib vs `Sethna2019-at` in library).
+Search by title or keyword:
 
 ```bash
 bip search "OLGA"  # search by tool/method name or keyword
 ```
 
-If found under a different key, **ask the user** if they want to fix the bib and tex files to use the library's key. If yes, update both `main.bib` (the `@ARTICLE{...}` key) and all `\cite{...}` references in `.tex` files.
+If found under a different key, **ask the user** if they want to fix the bib and tex files to use the library's key.
+If yes, update both `main.bib` (the `@ARTICLE{...}` key) and all `\cite{...}` references in `.tex` files.
 
-For papers truly not in library, add via `bip s2 add "DOI:..."`. If rate-limited, note for later.
+For papers truly not in library, add via `bip s2 add "DOI:..."`.
+If rate-limited, note for later.
 
 ### 4. Identify concepts
 
-Look at the highly-cited papers and the subagent analysis. Create concept nodes for:
+Look at the highly-cited papers and the subagent analysis.
+Create concept nodes for:
 - Named algorithms or methods (e.g., "beta-splitting", "F-matrices")
 - Biological processes (e.g., "affinity-maturation")
 - Modeling frameworks (e.g., "mutation-selection-model")
@@ -127,7 +131,8 @@ make viz && open -a "Google Chrome" viz/knowledge-graph.html
 ## Tips
 
 - **Citation keys ≈ paper IDs** — check directly first, but key suffixes can differ
-- **Key mismatch?** Search by keyword (`bip search "OLGA"`), then fix bib+tex to match the library key
+- **Key mismatch?**
+  Search by keyword (`bip search "OLGA"`), then fix bib+tex to match the library key
 - **Citation frequency** from grep helps prioritize which papers matter most
 - **Use subagents** for exploring TeX repos — keeps main context clean
 - **Create concepts conservatively** — only for named methods that bridge papers

--- a/skills/bip-lit-import/SKILL.md
+++ b/skills/bip-lit-import/SKILL.md
@@ -34,7 +34,10 @@ Always dry-run first to show what will change:
 bip import --format paperpile "<file>" --dry-run --human
 ```
 
-Report the counts (new, updated, skipped, warnings) to the user. By default, entries missing required fields (title, author, published.year) are imported with sentinel placeholders (`[no title]`, `Unknown`, year `0`) and listed under `warnings` so they're not silently dropped — review the warning list and fix the affected Paperpile records when convenient. Entries with no useful metadata at all (no title, author, year, or DOI — typically Paperpile auto-stubs for unparsed web pages) are still skipped and counted under `skipped`. Pass `--strict` to revert to the old behavior of dropping any entry with a missing required field.
+Report the counts (new, updated, skipped, warnings) to the user.
+By default, entries missing required fields (title, author, published.year) are imported with sentinel placeholders (`[no title]`, `Unknown`, year `0`) and listed under `warnings` so they're not silently dropped — review the warning list and fix the affected Paperpile records when convenient.
+Entries with no useful metadata at all (no title, author, year, or DOI — typically Paperpile auto-stubs for unparsed web pages) are still skipped and counted under `skipped`.
+Pass `--strict` to revert to the old behavior of dropping any entry with a missing required field.
 
 ### 3. Import
 
@@ -56,7 +59,8 @@ rm "<file>"
 
 ### 6. Report
 
-Summarize: new refs added, total count, file deleted. Notes from Paperpile are preserved and searchable via `bip search`.
+Summarize: new refs added, total count, file deleted.
+Notes from Paperpile are preserved and searchable via `bip search`.
 
 ### 7. Recommend cleanup if warnings fired
 
@@ -66,4 +70,5 @@ If the import reported a non-zero `warnings` count, recommend the cleanup query 
 bip search --tag paperpile:incomplete
 ```
 
-Every reference imported with a sentinel field (`[no title]`, `Unknown`, year `0`) is auto-tagged `paperpile:incomplete`. Once the user fixes the entry in Paperpile and re-imports, the next import replaces the stored reference and the tag disappears automatically, so the list shrinks until empty without any manual untagging step.
+Every reference imported with a sentinel field (`[no title]`, `Unknown`, year `0`) is auto-tagged `paperpile:incomplete`.
+Once the user fixes the entry in Paperpile and re-imports, the next import replaces the stored reference and the tag disappears automatically, so the list shrinks until empty without any manual untagging step.

--- a/skills/bip-lit/SKILL.md
+++ b/skills/bip-lit/SKILL.md
@@ -13,14 +13,22 @@ A CLI tool for managing academic references with local storage and external pape
 
 ## ⚠️ CRITICAL: Local-First, Paper-First Policy
 
-**ALWAYS search locally before using external APIs. NEVER call ASTA without explicit user permission.**
+**ALWAYS search locally before using external APIs.
+NEVER call ASTA without explicit user permission.**
 
-**When answering questions about papers, READ THE ACTUAL PAPER PDF.** Do not rely on abstracts, S2 metadata, or ASTA when the paper is in the local library. Reach for the right reader for the job:
+**When answering questions about papers, READ THE ACTUAL PAPER PDF.**
+Do not rely on abstracts, S2 metadata, or ASTA when the paper is in the local library.
+Reach for the right reader for the job:
 
-- **Text and search → pdf-navigator MCP (MuPDF).** Use `search_pdf_text` to jump to the relevant pages, then `read_pdf_text` / `read_pdf_page`. MuPDF keeps reading order across columns and inline math intact, and the text is searchable. This is the default.
-- **Figures, panels, rendered equations, tables → built-in `Read` with a narrow `pages` range.** The built-in reader renders pages as *images* (token-heavy, not searchable), so use it only for the 1–3 pages that hold the visual you need — never the whole paper.
+- **Text and search → pdf-navigator MCP (MuPDF).**
+  Use `search_pdf_text` to jump to the relevant pages, then `read_pdf_text` / `read_pdf_page`.
+  MuPDF keeps reading order across columns and inline math intact, and the text is searchable.
+  This is the default.
+- **Figures, panels, rendered equations, tables → built-in `Read` with a narrow `pages` range.**
+  The built-in reader renders pages as *images* (token-heavy, not searchable), so use it only for the 1–3 pages that hold the visual you need — never the whole paper.
 
-The nexus library has ~6000 papers. Most relevant papers are already there.
+The nexus library has ~6000 papers.
+Most relevant papers are already there.
 
 ### Required Search Order
 
@@ -28,26 +36,24 @@ The nexus library has ~6000 papers. Most relevant papers are already there.
    ```bash
    bip search -a "LastName" "keyword" --human
    ```
-   **Always use `--human`** — the default JSON output is verbose and easy to mis-scan.
+**Always use `--human`** — the default JSON output is verbose and easy to mis-scan.
 
 2. **If `bip search` fails** (e.g., schema error), rebuild the database:
    ```bash
    bip rebuild
    ```
-   Then retry the search.
+Then retry the search.
 
 3. **If found locally, READ THE PAPER** to answer the question:
    ```bash
    bip get <id> --human   # Get PDF path
    ```
-   Then use `mcp__pdf-navigator__search_pdf_text` (jump to the page) and `mcp__pdf-navigator__read_pdf_text` to find the answer directly in the paper. For a figure or equation you need to *see*, use the built-in `Read` tool on a narrow `pages` range instead. The PDF base path is `/Users/matsen/Google Drive/My Drive/Paperpile`.
+Then use `mcp__pdf-navigator__search_pdf_text` (jump to the page) and `mcp__pdf-navigator__read_pdf_text` to find the answer directly in the paper.
+For a figure or equation you need to *see*, use the built-in `Read` tool on a narrow `pages` range instead.
+The PDF base path is `/Users/matsen/Google Drive/My Drive/Paperpile`.
 
-4. **Before concluding a paper is absent, try an exact-match check** —
-   `bip search -a "LastName"` or `bip search --doi "..."` — rather than another
-   keyword permutation. `bip search` reports when results are truncated
-   (`Found N references (showing M; ...)`), so a plain "not found" is
-   trustworthy, but a truncated keyword search on its own is not proof of
-   absence.
+4. **Before concluding a paper is absent, try an exact-match check** — `bip search -a "LastName"` or `bip search --doi "..."` — rather than another keyword permutation.
+   `bip search` reports when results are truncated (`Found N references (showing M; ...)`), so a plain "not found" is trustworthy, but a truncated keyword search on its own is not proof of absence.
 
 5. **Only if not found locally AND user confirms**, use ASTA:
    ```
@@ -143,10 +149,7 @@ bip search "deep mutational scanning" --author "Bloom" --year 2023:
 
 ### Query Formulation Tips
 
-**Keep queries short and specific** - long conceptual queries are a correctness
-hazard, not just slow: `bip search` uses exact-token AND matching, so one
-inflected or half-remembered word (e.g. plural vs. singular) can zero out an
-otherwise-matching query:
+**Keep queries short and specific** - long conceptual queries are a correctness hazard, not just slow: `bip search` uses exact-token AND matching, so one inflected or half-remembered word (e.g. plural vs. singular) can zero out an otherwise-matching query:
 - Bad: `"correlation between BME criterion and Felsenstein likelihood around correct tree"`
 - Good: `"BME Felsenstein likelihood phylogeny"` or `"Bruno WEIGHBOR likelihood"`
 
@@ -203,7 +206,8 @@ For finding a specific paper or result:
 
 ### Snippet Search Caveats
 
-The `bip asta snippet` command can be **slow and unreliable** (timeouts are common). Alternatives:
+The `bip asta snippet` command can be **slow and unreliable** (timeouts are common).
+Alternatives:
 - Use keyword search first to find candidate papers
 - Use MCP `mcp__asta__snippet_search` directly with smaller limits
 - If snippet times out, fall back to `bip asta search`
@@ -222,7 +226,8 @@ S2 and ASTA both access Semantic Scholar; NCBI is a separate ID-resolution servi
 | Get citations/references | Either S2 or ASTA | ASTA is faster |
 | Backfill PMCIDs (e.g., for NIH RPPR) | `bip ncbi backfill` | NCBI is the canonical source; S2/ASTA do not return PMCIDs reliably |
 
-**Rule of thumb**: Use `bip asta` for exploration, `bip s2` when you want to modify your library, `bip ncbi` for authoritative PMCID resolution. NCBI only knows PMCIDs for papers actually in PMC — absence is not a signal that the paper is missing.
+**Rule of thumb**: Use `bip asta` for exploration, `bip s2` when you want to modify your library, `bip ncbi` for authoritative PMCID resolution.
+NCBI only knows PMCIDs for papers actually in PMC — absence is not a signal that the paper is missing.
 
 See [api-guide.md](api-guide.md) for detailed comparison.
 
@@ -249,13 +254,11 @@ See [api-guide.md](api-guide.md) for detailed comparison.
    mcp__pdf-navigator__search_pdf_text(file_path, "phage display")
    mcp__pdf-navigator__read_pdf_text(file_path, 2, 3)
    ```
-   For a **figure, panel, or rendered equation** you need to *see*, use the
-   built-in `Read` tool on a narrow page range instead (it renders pages as
-   images — token-heavy, so read only the page(s) with the visual):
+For a **figure, panel, or rendered equation** you need to *see*, use the built-in `Read` tool on a narrow page range instead (it renders pages as images — token-heavy, so read only the page(s) with the visual):
    ```
    Read(file_path, pages="4")
    ```
-   **Always prefer reading the paper over relying on abstracts or external metadata.**
+**Always prefer reading the paper over relying on abstracts or external metadata.**
 
 4. **Only if not in library**, search externally (with user permission):
    ```bash
@@ -306,7 +309,8 @@ See [workflows.md](workflows.md) for detailed workflow instructions.
 
 ## Output Format
 
-All commands output JSON by default. Add `--human` for readable format:
+All commands output JSON by default.
+Add `--human` for readable format:
 
 ```bash
 bip asta search "phylogenetics" --human
@@ -324,10 +328,8 @@ Both S2 and ASTA accept these identifier formats:
 
 ### Opening a paper page in the browser
 
-The reliable way to open an S2 paper page in Chrome is to resolve the
-identifier to the 40-char paper ID, then open the **website** URL. The
-`https://api.semanticscholar.org/...` redirect form is NOT reliable — Chrome
-often gets a JSON/non-navigable response instead of the rendered page.
+The reliable way to open an S2 paper page in Chrome is to resolve the identifier to the 40-char paper ID, then open the **website** URL.
+The `https://api.semanticscholar.org/...` redirect form is NOT reliable — Chrome often gets a JSON/non-navigable response instead of the rendered page.
 
 ```bash
 # From a DOI: resolve to paperId, then open the website page
@@ -340,9 +342,8 @@ open -a "Google Chrome" "https://www.semanticscholar.org/paper/$pid"
 open -a "Google Chrome" "https://www.semanticscholar.org/paper/<sha>"
 ```
 
-Note: the bare `https://www.semanticscholar.org/paper/CorpusID:...` form does
-NOT resolve (404s) — you must use the SHA paper ID. To resolve a CorpusId
-instead of a DOI, swap `DOI:$doi` above for `CorpusId:236964352`.
+Note: the bare `https://www.semanticscholar.org/paper/CorpusID:...` form does NOT resolve (404s) — you must use the SHA paper ID.
+To resolve a CorpusId instead of a DOI, swap `DOI:$doi` above for `CorpusId:236964352`.
 
 ## Concept Nodes (Knowledge Graph)
 
@@ -421,7 +422,8 @@ bip concept merge shm somatic-hypermutation --human
 
 ### Snippet Search Timeouts
 
-`bip asta snippet` frequently times out with "context deadline exceeded". Workarounds:
+`bip asta snippet` frequently times out with "context deadline exceeded".
+Workarounds:
 
 1. **Reduce limit**: `--limit 5` instead of default
 2. **Use MCP directly**: `mcp__asta__snippet_search` with small limit
@@ -458,7 +460,8 @@ If you see errors like `no such column: pmid` or similar schema mismatches:
 bip rebuild
 ```
 
-The SQLite database is ephemeral and rebuilt from the JSONL source of truth. Schema changes require deleting and rebuilding.
+The SQLite database is ephemeral and rebuilt from the JSONL source of truth.
+Schema changes require deleting and rebuilding.
 
 ### Slow Performance
 

--- a/skills/bip-marimo/SKILL.md
+++ b/skills/bip-marimo/SKILL.md
@@ -7,8 +7,7 @@ description: Generate and edit marimo reactive notebooks correctly. Auto-trigger
 
 Reactive Python notebooks stored as plain `.py` files.
 
-**Docs**: https://docs.marimo.io/
-**API Reference**: https://docs.marimo.io/api/
+**Docs**: https://docs.marimo.io/ **API Reference**: https://docs.marimo.io/api/
 
 ## Environment
 

--- a/skills/bip-ms-audit/SKILL.md
+++ b/skills/bip-ms-audit/SKILL.md
@@ -6,11 +6,14 @@ allowed-tools: Agent, Bash, Read, Glob, Grep, Edit, Write
 
 # /bip-ms-audit
 
-Audit a manuscript against its implementation(s). Find places where the **paper claims one thing** and the **code does another** — wrong tensor dimensions, formulas that disagree between paper and code, complexity claims that don't match the algorithm, parameter values out of step with config files, etc.
+Audit a manuscript against its implementation(s).
+Find places where the **paper claims one thing** and the **code does another** — wrong tensor dimensions, formulas that disagree between paper and code, complexity claims that don't match the algorithm, parameter values out of step with config files, etc.
 
-This is **not** a paper proofreader (`@scientific-tex-editor`, `@tex-grammar-checker`), **not** a code reviewer for a diff (`@clean-code-reviewer`), and **not** a PR check (`/bip-pr-review`). It is the cross-cutting check that nobody runs because each side feels like someone else's job — yet it's where the worst bugs hide, because each side looks internally consistent.
+This is **not** a paper proofreader (`@scientific-tex-editor`, `@tex-grammar-checker`), **not** a code reviewer for a diff (`@clean-code-reviewer`), and **not** a PR check (`/bip-pr-review`).
+It is the cross-cutting check that nobody runs because each side feels like someone else's job — yet it's where the worst bugs hide, because each side looks internally consistent.
 
-Run from a **TeX repository** with `.ms-config.json` configured (see `/bip-ms`). The skill reads the paper, reads the tracked code repo(s), and reports mismatches.
+Run from a **TeX repository** with `.ms-config.json` configured (see `/bip-ms`).
+The skill reads the paper, reads the tracked code repo(s), and reports mismatches.
 
 ## Usage
 
@@ -24,12 +27,17 @@ Run from a **TeX repository** with `.ms-config.json` configured (see `/bip-ms`).
 
 ## Core principle
 
-**Trust nothing. Read both sides.** A surprising mismatch ("the paper says $f^u_b$ but the code uses $f^d_b$") is exactly the kind of finding that is most often either a real bug or a misreading on one side. Either outcome is valuable, but never report it without a skeptic agent independently verifying.
+**Trust nothing.
+Read both sides.**
+A surprising mismatch ("the paper says $f^u_b$ but the code uses $f^d_b$") is exactly the kind of finding that is most often either a real bug or a misreading on one side.
+Either outcome is valuable, but never report it without a skeptic agent independently verifying.
 
 The two failure modes are symmetric and both cost the user trust:
 
-- **False positive**: report a "bug" that isn't, sending the user on a wild-goose chase. Avoid by running `@surprising-conclusion-skeptic` before propagating any non-trivial finding.
-- **False negative**: skim the formulas, miss the bug. Avoid by reading the actual implementation file with `Read`, not just grepping for keywords.
+- **False positive**: report a "bug" that isn't, sending the user on a wild-goose chase.
+  Avoid by running `@surprising-conclusion-skeptic` before propagating any non-trivial finding.
+- **False negative**: skim the formulas, miss the bug.
+  Avoid by reading the actual implementation file with `Read`, not just grepping for keywords.
 
 ## Workflow
 
@@ -42,67 +50,48 @@ cat .ms-config.json
 Determine:
 - **Paper file**: from `.manuscript` field (e.g., `main.tex`).
 - **Tracked code repos**: from `.tracked_repos[].local_path` — these are the implementations to audit against.
-- **Audit scope**: from the user's argument. Default to the full Methods/Algorithms section of the paper.
+- **Audit scope**: from the user's argument.
+  Default to the full Methods/Algorithms section of the paper.
 
 If `.ms-config.json` is missing, ask the user for the paper path and code repo path(s) and offer to create the config (see `/bip-ms`).
 
 ### Step 2: Partition the scope and fan out
 
-The primary partitions the audit scope into independent chunks, then
-dispatches one `general-purpose` subagent per chunk **in parallel** —
-single message, multiple `Agent` tool calls. Follow the dispatch
-pattern in `SUBAGENT-SCAN.md` (bipartite repo root).
+The primary partitions the audit scope into independent chunks, then dispatches one `general-purpose` subagent per chunk **in parallel** — single message, multiple `Agent` tool calls.
+Follow the dispatch pattern in `SUBAGENT-SCAN.md` (bipartite repo root).
 
 Partitioning rules:
-- **Whole paper** (default): one subagent per top-level Methods /
-  Algorithms section.
-- **One section** (`/bip-ms-audit Methods`): one subagent per
-  subsection, or per claim cluster (formula + its surrounding text)
-  if subsections are missing.
-- **One formula or label** (`/bip-ms-audit --formula eq:loss`): one
-  subagent.
+- **Whole paper** (default): one subagent per top-level Methods / Algorithms section.
+- **One section** (`/bip-ms-audit Methods`): one subagent per subsection, or per claim cluster (formula + its surrounding text) if subsections are missing.
+- **One formula or label** (`/bip-ms-audit --formula eq:loss`): one subagent.
 
-Brief for each audit subagent (the **line-by-line investigation**
-framing is mandatory — this is what separates an audit from a skim):
+Brief for each audit subagent (the **line-by-line investigation** framing is mandatory — this is what separates an audit from a skim):
 
-> **Line-by-line investigation** of paper section `<section>`
-> against tracked code repo(s) `<local_path(s)>`. This is not a
-> scan. For every checkable claim in scope, you must read the
-> implementation file in full with the `Read` tool — not a grep
-> excerpt — and cite the specific paper line and code line that
-> back your verdict. A verdict without a `file:line` citation on
-> both sides will be rejected and re-dispatched.
+> **Line-by-line investigation** of paper section `<section>` against tracked code repo(s) `<local_path(s)>`.
+> This is not a scan.
+> For every checkable claim in scope, you must read the implementation file in full with the `Read` tool — not a grep excerpt — and cite the specific paper line and code line that back your verdict.
+> A verdict without a `file:line` citation on both sides will be rejected and re-dispatched.
 >
 > Tasks:
-> 1. Read the paper section with `Read`. List every checkable,
->    falsifiable claim: tensor/array dimensions, formulas
->    (`align`/`equation`/display math), algorithm steps,
->    hyperparameter values, counts/complexity, variable bindings,
->    loss/metric definitions, data pipeline steps, theorem
->    statements. Skip subjective claims ("our results suggest…").
+> 1. Read the paper section with `Read`.
+>    List every checkable, falsifiable claim: tensor/array dimensions, formulas (`align`/`equation`/display math), algorithm steps, hyperparameter values, counts/complexity, variable bindings, loss/metric definitions, data pipeline steps, theorem statements.
+>    Skip subjective claims ("our results suggest…").
 >    Record paper `file:line` for each.
-> 2. For each claim, locate the code-side counterpart. Use `rg` to
->    find files, but then `Read` the file. Common keyword maps:
->    tensor dims → `torch.zeros`/`np.zeros`/`torch.full`;
->    formulas → `forward`/`loss`/aggregation; hyperparameters →
->    `config.yaml`/`Snakefile`/CLI defaults; loss/mask → training
->    loop; data filtering → preprocessing pipeline/snakemake rules.
->    If a claim has multiple implementations (e.g., vectorized
->    batch path + tree-iteration reference path), check **both** —
->    that's a frequent source of divergence.
+> 2. For each claim, locate the code-side counterpart.
+>    Use `rg` to find files, but then `Read` the file.
+>    Common keyword maps: tensor dims → `torch.zeros`/`np.zeros`/`torch.full`; formulas → `forward`/`loss`/aggregation; hyperparameters → `config.yaml`/`Snakefile`/CLI defaults; loss/mask → training loop; data filtering → preprocessing pipeline/snakemake rules.
+>    If a claim has multiple implementations (e.g., vectorized batch path + tree-iteration reference path), check **both** — that's a frequent source of divergence.
 > 3. For each claim, classify with a verdict:
 >    - `MATCH` — paper and code agree
 >    - `MISMATCH` — disagree on a substantive, falsifiable point
->    - `AMBIGUOUS` — paper is unclear/underspecified; code makes a
->      specific choice
->    - `MULTIPLE IMPLS DISAGREE` — two code paths disagree with
->      each other (and at most one matches the paper)
+>    - `AMBIGUOUS` — paper is unclear/underspecified; code makes a specific choice
+>    - `MULTIPLE IMPLS DISAGREE` — two code paths disagree with each other (and at most one matches the paper)
 >    - `STALE PAPER` — paper describes an earlier code version
 >    - `STALE CODE` — paper describes a fix code hasn't picked up
 >
-> **MATCH is the default.** Most claims are correct. If your
-> report is mostly `MISMATCH`, you are misreading the code — stop
-> and re-check the worst offenders before returning.
+> **MATCH is the default.**
+> Most claims are correct.
+> If your report is mostly `MISMATCH`, you are misreading the code — stop and re-check the worst offenders before returning.
 >
 > Return under 500 words, structured:
 > - `findings`: one entry per non-`MATCH` claim with:
@@ -111,30 +100,21 @@ framing is mandatory — this is what separates an audit from a skim):
 >   - verdict
 >   - one-sentence rationale (why they disagree)
 > - `matches`: count of `MATCH` verdicts (no quotes needed)
-> - `surprises`: claims you couldn't certify a `file:line` for,
->   variable names that mean different things in different places,
->   `RECOMMEND DEEPER LOOK` flags
+> - `surprises`: claims you couldn't certify a `file:line` for, variable names that mean different things in different places, `RECOMMEND DEEPER LOOK` flags
 
-If a subagent returns a finding without both `file:line` citations,
-re-dispatch with a narrower brief covering just that finding.
+If a subagent returns a finding without both `file:line` citations, re-dispatch with a narrower brief covering just that finding.
 
 ### Step 3: Primary consolidates findings
 
-The primary collects all subagent reports and assembles a single
-working list of non-`MATCH` findings, sorted by verdict severity
-(`MULTIPLE IMPLS DISAGREE` and `MISMATCH` first). No prose pasted
-verbatim from subagents — quote only the paper and code line excerpts
-they cited.
+The primary collects all subagent reports and assembles a single working list of non-`MATCH` findings, sorted by verdict severity (`MULTIPLE IMPLS DISAGREE` and `MISMATCH` first).
+No prose pasted verbatim from subagents — quote only the paper and code line excerpts they cited.
 
-If any subagent's report has many findings (say >5 in a 10-claim
-section), treat that as the "everything looks like a mismatch"
-failure mode and re-dispatch the subagent with explicit instruction
-to verify each claim by reading the full implementation file before
-classifying.
+If any subagent's report has many findings (say >5 in a 10-claim section), treat that as the "everything looks like a mismatch" failure mode and re-dispatch the subagent with explicit instruction to verify each claim by reading the full implementation file before classifying.
 
 ### Step 4: Skeptic confirmation for non-trivial findings
 
-For any finding that is **not** a `MATCH`, spawn `@surprising-conclusion-skeptic` to independently verify before reporting it. Skip this step only if the user passed `--no-skeptic`.
+For any finding that is **not** a `MATCH`, spawn `@surprising-conclusion-skeptic` to independently verify before reporting it.
+Skip this step only if the user passed `--no-skeptic`.
 
 Brief the skeptic with:
 - The exact paper claim (with line number)
@@ -147,13 +127,18 @@ Brief the skeptic with:
   - "Maybe one of them is dead code."
   - "Maybe the variable names mean something different in this context than I think."
 
-The skeptic's job is to **try to refute** the finding. If they confirm it survives scrutiny, escalate it. If they refute it, drop it from the report. If they say "partially," report with the qualification.
+The skeptic's job is to **try to refute** the finding.
+If they confirm it survives scrutiny, escalate it.
+If they refute it, drop it from the report.
+If they say "partially," report with the qualification.
 
-This step is the difference between a useful audit and one that cries wolf. Do not skip it.
+This step is the difference between a useful audit and one that cries wolf.
+Do not skip it.
 
 ### Step 5: Write the report
 
-Produce a markdown report in the manuscript repo as `MS-AUDIT-<ISO-date>.md`. Format:
+Produce a markdown report in the manuscript repo as `MS-AUDIT-<ISO-date>.md`.
+Format:
 
 ```markdown
 # Manuscript audit — <paper title> — <ISO date>
@@ -195,25 +180,40 @@ Allocates `max_n_nodes` ≈ 2n-2 entries, indexed by every non-root node — pap
 ...
 ```
 
-For each finding include: paper quote + line, code quote + line, skeptic verdict, suggested action. Group by verdict, with `MULTIPLE IMPLS DISAGREE` and `MISMATCH` first.
+For each finding include: paper quote + line, code quote + line, skeptic verdict, suggested action.
+Group by verdict, with `MULTIPLE IMPLS DISAGREE` and `MISMATCH` first.
 
 ### Step 6: Hand off
 
-Show the report path. Offer:
+Show the report path.
+Offer:
 1. Open the report (`zed <path>` or `tmux display-popup -E -- less <path>`).
 2. For each `MISMATCH` finding, ask whether to draft a paper edit, file a code issue (via `/bip-issue-check` → `/bip-issue-file`), or both.
-3. Do not auto-edit the paper or auto-file issues. The user decides.
+3. Do not auto-edit the paper or auto-file issues.
+   The user decides.
 
 ## Guidelines
 
-- **Read the actual files.** Every reported finding must have a `Read` (not just a `grep`) backing it on both sides.
-- **Default to MATCH.** Most claims are correct. A report with 30 mismatches in a 40-claim audit is almost certainly the auditor misreading.
-- **Always run the skeptic on non-MATCH findings** unless the user explicitly waives it. Surprising bug reports cost user trust when wrong; the skeptic round trip is cheap insurance.
-- **Cite both sides with line numbers.** Future-you (or the authors) need to be able to jump straight to both the paper line and the code line. `main.tex:296` and `dpvt/wrapper.py:228` — never just "around line 200ish."
-- **Don't fix anything.** This skill produces a report. Edits to the paper and changes to the code happen in separate, explicit steps.
-- **Two implementations of the same thing are a high-yield search target.** When a repo has both a vectorized batch path and a tree-iteration reference path of the same algorithm, they are an excellent place to find bugs even when neither side disagrees with the paper individually.
-- **Hyperparameter drift is real.** Paper says lr=$5 \times 10^{-5}$; config says lr=$1 \times 10^{-4}$ because someone tuned and forgot to update the paper. Cheap to check, often wrong.
-- **Beware notation that seems internally consistent.** A formula using $v$ for a node and $v$ for a function is a warning sign; check that the paper's $v$ in storage matches the code's `v` in storage and not just both being plausible.
+- **Read the actual files.**
+  Every reported finding must have a `Read` (not just a `grep`) backing it on both sides.
+- **Default to MATCH.**
+  Most claims are correct.
+  A report with 30 mismatches in a 40-claim audit is almost certainly the auditor misreading.
+- **Always run the skeptic on non-MATCH findings** unless the user explicitly waives it.
+  Surprising bug reports cost user trust when wrong; the skeptic round trip is cheap insurance.
+- **Cite both sides with line numbers.**
+  Future-you (or the authors) need to be able to jump straight to both the paper line and the code line.
+  `main.tex:296` and `dpvt/wrapper.py:228` — never just "around line 200ish."
+- **Don't fix anything.**
+  This skill produces a report.
+  Edits to the paper and changes to the code happen in separate, explicit steps.
+- **Two implementations of the same thing are a high-yield search target.**
+  When a repo has both a vectorized batch path and a tree-iteration reference path of the same algorithm, they are an excellent place to find bugs even when neither side disagrees with the paper individually.
+- **Hyperparameter drift is real.**
+  Paper says lr=$5 \times 10^{-5}$; config says lr=$1 \times 10^{-4}$ because someone tuned and forgot to update the paper.
+  Cheap to check, often wrong.
+- **Beware notation that seems internally consistent.**
+  A formula using $v$ for a node and $v$ for a function is a warning sign; check that the paper's $v$ in storage matches the code's `v` in storage and not just both being plausible.
 
 ## When to use this vs siblings
 
@@ -229,14 +229,22 @@ Show the report path. Offer:
 
 ## Why this shape
 
-- **Reads paper as source of truth for *intent*, code as source of truth for *behavior*.** Either can be wrong; the audit's job is to surface the gap.
-- **Skeptic step is non-optional by default.** Without it the skill is a false-positive machine; with it the skill earns its place. The skeptic exists precisely for "the paper says X but the code says Y" claims, and this skill is its highest-yield caller.
-- **Output is a markdown report, not auto-applied edits.** A bad finding propagated as a paper edit is much more expensive than the same finding in a markdown report. The user reads, decides, and dispatches.
-- **No state directory.** Unlike `/bip-decay-audit`, this skill does not maintain a per-repo baseline — papers and code change together, so a "regression since last audit" framing isn't useful here. Re-run as needed; the report is the artifact.
+- **Reads paper as source of truth for *intent*, code as source of truth for *behavior*.**
+  Either can be wrong; the audit's job is to surface the gap.
+- **Skeptic step is non-optional by default.**
+  Without it the skill is a false-positive machine; with it the skill earns its place.
+  The skeptic exists precisely for "the paper says X but the code says Y" claims, and this skill is its highest-yield caller.
+- **Output is a markdown report, not auto-applied edits.**
+  A bad finding propagated as a paper edit is much more expensive than the same finding in a markdown report.
+  The user reads, decides, and dispatches.
+- **No state directory.**
+  Unlike `/bip-decay-audit`, this skill does not maintain a per-repo baseline — papers and code change together, so a "regression since last audit" framing isn't useful here.
+  Re-run as needed; the report is the artifact.
 
 ## References
 
 - Sibling skills: `/bip-ms`, `/bip-ms-poll`, `/bip-ms-tuckin`, `/bip-decay-audit`, `/bip-comment-check`, `/bip-pr-review`.
 - Subagents used: `@surprising-conclusion-skeptic` (mandatory for non-MATCH findings).
 - Optional subagents: `@scientific-tex-editor` for follow-up paper edits; `@clean-code-reviewer` for follow-up code review on the code-side of a mismatch.
-- Precipitating case: `dpvt` audit 2026-05-06 — paper said tensor was `(n-3) × N × 4` but code allocated `(2n-2, N, 4)`; vectorized RNN path used both downward features for the downward pass while paper and tree-based path used downward+upward. Both bugs sat in `main.tex` and `models.py` for months because no one read them in parallel.
+- Precipitating case: `dpvt` audit 2026-05-06 — paper said tensor was `(n-3) × N × 4` but code allocated `(2n-2, N, 4)`; vectorized RNN path used both downward features for the downward pass while paper and tree-based path used downward+upward.
+  Both bugs sat in `main.tex` and `models.py` for months because no one read them in parallel.

--- a/skills/bip-ms-poll/SKILL.md
+++ b/skills/bip-ms-poll/SKILL.md
@@ -5,88 +5,65 @@ description: Quick poll of tracked EPICs and code repos for new manuscript-relev
 
 # /bip-ms-poll
 
-Lightweight mid-session update for a manuscript session. Checks what
-changed in tracked code repos and EPICs since last check and fetches new
-artifacts from remote, so you can react to new results **as a scientific
-discussant**: judge what each result means and orchestrate what happens next
-(through issues and PRs). Per `/bip-ms`, the paper itself is updated when a
-thread of research *completes*, not on every incremental result surfaced here.
+Lightweight mid-session update for a manuscript session.
+Checks what changed in tracked code repos and EPICs since last check and fetches new artifacts from remote, so you can react to new results **as a scientific discussant**: judge what each result means and orchestrate what happens next (through issues and PRs).
+Per `/bip-ms`, the paper itself is updated when a thread of research *completes*, not on every incremental result surfaced here.
 
-For continuous monitoring, prefer the **persistent result monitor**
-started by `/bip-ms` (Step 5) — it uses SSH polling to detect new
-result files on remote servers in real time. Use `/bip-ms-poll` for:
+For continuous monitoring, prefer the **persistent result monitor** started by `/bip-ms` (Step 5) — it uses SSH polling to detect new result files on remote servers in real time.
+Use `/bip-ms-poll` for:
 - Full GitHub reconciliation (EPIC updates, merged PRs, new issues)
 - Running `fetch_cmds` to pull results locally after the monitor flags them
 - When the result monitor isn't running
 
 For periodic auto-polling: `/loop 10m /bip-ms-poll`
 
-**Never modify remote server state.** Do not run `snakemake` (even
-dry-run), `zig build`, `git pull`, `snakemake --unlock`, or any
-write command via SSH on remote servers (ermine, quokka, orca, etc.).
-Other agents are actively running experiments there. SSH is fine for
-read-only inspection (`ls`, `cat`, `head`, `grep`, checking file
-dates/sizes), but never run anything that modifies files, locks, or
-builds. Local `git pull` and `make remote-fetch` (which uses `rsync`
-to copy FROM remote) are fine — they only modify the local clone.
+**Never modify remote server state.**
+Do not run `snakemake` (even dry-run), `zig build`, `git pull`, `snakemake --unlock`, or any write command via SSH on remote servers (ermine, quokka, orca, etc.).
+Other agents are actively running experiments there.
+SSH is fine for read-only inspection (`ls`, `cat`, `head`, `grep`, checking file dates/sizes), but never run anything that modifies files, locks, or builds.
+Local `git pull` and `make remote-fetch` (which uses `rsync` to copy FROM remote) are fine — they only modify the local clone.
 
 ## What to check
 
-Fan out one `general-purpose` subagent per entry in `tracked_repos` —
-single message, multiple `Agent` calls in parallel. Follow the
-dispatch pattern in `SUBAGENT-SCAN.md` (bipartite repo root). Per-repo
-granularity avoids racing on `git pull` when one repo has multiple
-EPICs.
+Fan out one `general-purpose` subagent per entry in `tracked_repos` — single message, multiple `Agent` calls in parallel.
+Follow the dispatch pattern in `SUBAGENT-SCAN.md` (bipartite repo root).
+Per-repo granularity avoids racing on `git pull` when one repo has multiple EPICs.
 
 Brief for each subagent:
 
-> Lightweight delta poll for repo `<org/repo>` since the previous
-> manuscript poll. Local path: `<local_path>`. EPIC numbers:
-> `<epics>`. Fetch commands: `<fetch_cmds>`. Last-seen EPIC
-> `updatedAt`: `<timestamps>` (from primary's memory; if unknown,
-> compare against the last 24h).
+> Lightweight delta poll for repo `<org/repo>` since the previous manuscript poll.
+> Local path: `<local_path>`.
+> EPIC numbers: `<epics>`.
+> Fetch commands: `<fetch_cmds>`.
+> Last-seen EPIC `updatedAt`: `<timestamps>` (from primary's memory; if unknown, compare against the last 24h).
 >
 > Tasks:
-> 1. For each EPIC, `gh issue view <N> --repo <org/repo> --json
->    body,updatedAt`. If `updatedAt` is unchanged from baseline,
->    skip body parsing. Otherwise extract newly checked items, new
->    key findings, and changes to active clone assignments.
-> 2. `gh pr list --repo <org/repo> --search "is:merged
->    sort:updated-desc" --limit 5 --json
->    number,title,body,mergedAt`. Report only PRs newer than the
->    last poll.
-> 3. `git -C <local_path> fetch origin` (read-only — never `git
->    pull`), then report `main` vs `origin/main` from `git -C
->    <local_path> rev-list --left-right --count main...origin/main`
->    (local-ahead / remote-ahead). Clones are often checked out on a
->    feature branch, so do NOT `pull --ff-only origin main`: that
->    fast-forwards the *current* branch and fails whenever it isn't
->    main — a failure that is NOT main diverging. Call main
->    "diverged" only when both counts are nonzero; "0 / N" is a clean
->    fast-forward. Then run each fetch_cmd from `<local_path>`
->    (idempotent; safe to re-run).
-> 4. `find <local_path> \( -name "*.svg" -o -name "*.html" \) -mmin
->    -60`. For each new file, identify the producing EPIC or PR.
-> 5. `gh pr list --repo <org/repo> --json
->    number,title,headRefName,state`. Note any PRs approaching merge
->    that will produce results soon.
+> 1. For each EPIC, `gh issue view <N> --repo <org/repo> --json body,updatedAt`.
+>    If `updatedAt` is unchanged from baseline, skip body parsing.
+>    Otherwise extract newly checked items, new key findings, and changes to active clone assignments.
+> 2. `gh pr list --repo <org/repo> --search "is:merged sort:updated-desc" --limit 5 --json number,title,body,mergedAt`.
+>    Report only PRs newer than the last poll.
+> 3. `git -C <local_path> fetch origin` (read-only — never `git pull`), then report `main` vs `origin/main` from `git -C <local_path> rev-list --left-right --count main...origin/main` (local-ahead / remote-ahead).
+>    Clones are often checked out on a feature branch, so do NOT `pull --ff-only origin main`: that fast-forwards the *current* branch and fails whenever it isn't main — a failure that is NOT main diverging.
+>    Call main "diverged" only when both counts are nonzero; "0 / N" is a clean fast-forward.
+>    Then run each fetch_cmd from `<local_path>` (idempotent; safe to re-run).
+> 4. `find <local_path> \( -name "*.svg" -o -name "*.html" \) -mmin -60`.
+>    For each new file, identify the producing EPIC or PR.
+> 5. `gh pr list --repo <org/repo> --json number,title,headRefName,state`.
+>    Note any PRs approaching merge that will produce results soon.
 >
 > Return under 300 words, structured per `SUBAGENT-SCAN.md`:
 > - `changes_since_baseline`: EPIC deltas, new merges, new findings
 > - `active_items`: PRs approaching merge with brief status
 > - `new_artifacts`: paths to new SVGs/notebooks with source EPIC/PR
-> - `action_candidates`: import figure X, open notebook Y, draft
->   text for finding Z
-> - `surprises`: anything else, including `RECOMMEND DEEPER LOOK`
->   flags
+> - `action_candidates`: import figure X, open notebook Y, draft text for finding Z
+> - `surprises`: anything else, including `RECOMMEND DEEPER LOOK` flags
 >
-> Use Read (not grep excerpts) for PR bodies or finding text you
-> cite. Do not paste full bodies.
+> Use Read (not grep excerpts) for PR bodies or finding text you cite.
+> Do not paste full bodies.
 
-If every subagent reports zero `changes_since_baseline` and zero
-`surprises`, the poll output is one line: "All quiet across tracked
-repos." Otherwise compose the "React to new artifacts" sections below
-from the structured reports.
+If every subagent reports zero `changes_since_baseline` and zero `surprises`, the poll output is one line: "All quiet across tracked repos."
+Otherwise compose the "React to new artifacts" sections below from the structured reports.
 
 ## React to new artifacts
 
@@ -106,8 +83,8 @@ When new SVGs are found after a fetch:
    make pdf-figures
    ```
 
-3. If imported, check if the manuscript already references it. If not,
-   suggest placement and draft the `\includegraphics` block.
+3. If imported, check if the manuscript already references it.
+   If not, suggest placement and draft the `\includegraphics` block.
 
 ### New HTML notebooks
 
@@ -122,29 +99,18 @@ After they review, ask which plots or findings to incorporate.
 
 ### New key findings in EPICs
 
-When an EPIC body has new findings (numbered items in the Key Findings
-section that weren't there before), react as a discussant first, not as a
-transcriber:
+When an EPIC body has new findings (numbered items in the Key Findings section that weren't there before), react as a discussant first, not as a transcriber:
 
 1. Quote the finding.
-2. Read the relevant PR or experiment that produced it (full body, not a
-   truncated read).
-3. Present the key points as a **bullet-point summary**, with your read on
-   whether the result holds up, what it means, and how it sits against what
-   the manuscript already claims.
-4. Decide with the user what happens next. Usually this is orchestration —
-   request a follow-up analysis on the PR, draft an issue for a gap (via the
-   Issue quality gate), or log an open question — because the paper is updated
-   when a thread of research *completes*, not per finding.
-5. **Only when a thread is complete**, draft it into the manuscript: propose
-   placement, write the LaTeX, run the `@scientific-tex-editor` agent on the
-   new text, and present the edited draft for final approval.
+2. Read the relevant PR or experiment that produced it (full body, not a truncated read).
+3. Present the key points as a **bullet-point summary**, with your read on whether the result holds up, what it means, and how it sits against what the manuscript already claims.
+4. Decide with the user what happens next.
+   Usually this is orchestration — request a follow-up analysis on the PR, draft an issue for a gap (via the Issue quality gate), or log an open question — because the paper is updated when a thread of research *completes*, not per finding.
+5. **Only when a thread is complete**, draft it into the manuscript: propose placement, write the LaTeX, run the `@scientific-tex-editor` agent on the new text, and present the edited draft for final approval.
 
 ### Issue creation
 
-If during polling you notice gaps — an experiment that should be run,
-a comparison that's missing, a figure variant that would strengthen
-the paper — propose raising an issue on the tracked repo:
+If during polling you notice gaps — an experiment that should be run, a comparison that's missing, a figure variant that would strengthen the paper — propose raising an issue on the tracked repo:
 
 1. Describe what's needed and why (from the manuscript perspective)
 2. After user confirmation, run `/bip-issue-next` targeting the tracked repo
@@ -154,20 +120,17 @@ the paper — propose raising an issue on the tracked repo:
 
 ### Output structure
 
-1. **New results** (lead with this): Figures, notebooks, or findings
-   that arrived since last poll. One line each with source and age.
+1. **New results** (lead with this): Figures, notebooks, or findings that arrived since last poll.
+   One line each with source and age.
 
 2. **Active work**: Which EPICs have active clones, brief status.
    Only mention if something changed.
 
-3. **Approaching completion**: PRs close to merge that will produce
-   results soon.
+3. **Approaching completion**: PRs close to merge that will produce results soon.
 
-4. **Proposed actions**: Concrete list — import figure X, open
-   notebook Y, draft text for finding Z, raise issue for gap W.
+4. **Proposed actions**: Concrete list — import figure X, open notebook Y, draft text for finding Z, raise issue for gap W.
 
-Ring the terminal bell and send a phone notification if a major new
-result arrives (new figure or quantitative finding):
+Ring the terminal bell and send a phone notification if a major new result arrives (new figure or quantitative finding):
 ```bash
 printf '\a'
 NTFY_TOPIC=$(grep ntfy_topic ~/.config/bip/config.yml | awk '{print $2}')
@@ -176,26 +139,21 @@ NTFY_TOPIC=$(grep ntfy_topic ~/.config/bip/config.yml | awk '{print $2}')
 
 ### Verify state before reporting
 
-When mentioning any PR or issue in the poll output, always verify its
-current state programmatically (`gh pr view --json state`, `gh issue
-view --json state`) rather than relying on earlier poll results or
-conversation memory. Stale state leads to confusing reports (e.g.,
-reporting a merged PR as "open").
+When mentioning any PR or issue in the poll output, always verify its current state programmatically (`gh pr view --json state`, `gh issue view --json state`) rather than relying on earlier poll results or conversation memory.
+Stale state leads to confusing reports (e.g., reporting a merged PR as "open").
 
-When a claim rests on a PR/issue *body* or comments — especially an
-absence claim ("reports no result", "no mention of Y") — read the full
-text. Do not pipe `gh ... --json body` through `head`/`tail`: Results
-and conclusions usually sit at the bottom, which is exactly what a
-truncated read drops. To narrow, `grep -n -i -A30` for the section
-rather than chopping at a line count; never assert absence from output
-you truncated yourself.
+When a claim rests on a PR/issue *body* or comments — especially an absence claim ("reports no result", "no mention of Y") — read the full text.
+Do not pipe `gh ... --json body` through `head`/`tail`: Results and conclusions usually sit at the bottom, which is exactly what a truncated read drops.
+To narrow, `grep -n -i -A30` for the section rather than chopping at a line count; never assert absence from output you truncated yourself.
 
 ### Keep it brief
 
-This is a poll, not a cold start. Only report what changed. If nothing
-changed, say so in one line:
+This is a poll, not a cold start.
+Only report what changed.
+If nothing changed, say so in one line:
 
-> All quiet across tracked repos. No new results since last check.
+> All quiet across tracked repos.
+> No new results since last check.
 
 ## Housekeeping (silent)
 

--- a/skills/bip-ms-sweep/SKILL.md
+++ b/skills/bip-ms-sweep/SKILL.md
@@ -6,11 +6,14 @@ allowed-tools: Agent, Bash, Read, Glob, Grep, Edit, Write
 
 # /bip-ms-sweep
 
-Pre-share or pre-submission polish sweep of a TeX manuscript. Run from a TeX repository when you want to look the manuscript over carefully before sending it to a colleague or to a journal.
+Pre-share or pre-submission polish sweep of a TeX manuscript.
+Run from a TeX repository when you want to look the manuscript over carefully before sending it to a colleague or to a journal.
 
-This is **not** a code-vs-paper audit (`/bip-ms-audit`), **not** a cold-start dashboard (`/bip-ms`), and **not** a writing-style review on its own (`@scientific-tex-editor`). It is the cross-cutting manuscript sweep that runs many small, mechanical scans in parallel, plus a literature-gap check and a submission-hygiene check, and then talks through the findings with the user interactively.
+This is **not** a code-vs-paper audit (`/bip-ms-audit`), **not** a cold-start dashboard (`/bip-ms`), and **not** a writing-style review on its own (`@scientific-tex-editor`).
+It is the cross-cutting manuscript sweep that runs many small, mechanical scans in parallel, plus a literature-gap check and a submission-hygiene check, and then talks through the findings with the user interactively.
 
-The output style mirrors a careful colleague reading the manuscript with you: a conversational punch list, not a markdown report. The user decides what to fix; the skill does not auto-edit the paper.
+The output style mirrors a careful colleague reading the manuscript with you: a conversational punch list, not a markdown report.
+The user decides what to fix; the skill does not auto-edit the paper.
 
 ## Usage
 
@@ -21,15 +24,27 @@ The output style mirrors a careful colleague reading the manuscript with you: a 
                                     # (mechanical scans always run on the full paper)
 ```
 
-Default scope is the **full paper** (main + SI + bib). The mechanical scans always run on the full paper. Only the writing-style review can be narrowed with `--since`.
+Default scope is the **full paper** (main + SI + bib).
+The mechanical scans always run on the full paper.
+Only the writing-style review can be narrowed with `--since`.
 
 ## Core principle
 
-**Many small, focused scans beat one big "review my paper."** A single scientific-tex-editor invocation against the whole paper will skim. Eight specialist subagents running in parallel — each with one job and a tight output format — produce a tighter, higher-precision punch list and don't waste primary-agent context on intermediate reasoning. The primary's job is to consolidate, dedupe, and bin findings into "real fix," "judgment call," and "noise" for the user to triage.
+**Many small, focused scans beat one big "review my paper."**
+A single scientific-tex-editor invocation against the whole paper will skim.
+Eight specialist subagents running in parallel — each with one job and a tight output format — produce a tighter, higher-precision punch list and don't waste primary-agent context on intermediate reasoning.
+The primary's job is to consolidate, dedupe, and bin findings into "real fix," "judgment call," and "noise" for the user to triage.
 
-**Editorial markers are signal, not noise.** `%EM`, `%HH`, `% TODO`, `% NOTE` etc. are often live communication channels between co-authors. The sweep lists them but does not classify them as warts unless they look unfinished or self-contradictory. The user decides what's a wart.
+**Editorial markers are signal, not noise.**
+`%EM`, `%HH`, `% TODO`, `% NOTE` etc. are often live communication channels between co-authors.
+The sweep lists them but does not classify them as warts unless they look unfinished or self-contradictory.
+The user decides what's a wart.
 
-**No assumptions about repo layout.** Do not require `.ms-config.json`. Do not assume `main.tex`. Detect TeX files in the cwd, accept an explicit path, or ask. If you need transient scratch space, use `_ignore/sweep/` in the manuscript repo (gitignored by convention; create if missing).
+**No assumptions about repo layout.**
+Do not require `.ms-config.json`.
+Do not assume `main.tex`.
+Detect TeX files in the cwd, accept an explicit path, or ask.
+If you need transient scratch space, use `_ignore/sweep/` in the manuscript repo (gitignored by convention; create if missing).
 
 ## Workflow
 
@@ -44,19 +59,25 @@ Identify:
 - The **SI file**, if any (commonly `si.tex`, `supplement.tex`, `supp.tex`).
 - The **bib file** (commonly `main.bib` or `refs.bib`).
 
-If ambiguous, ask the user before proceeding. State what you identified.
+If ambiguous, ask the user before proceeding.
+State what you identified.
 
 If the user passed `--since <ref>`, capture that ref for Phase 2.
 
 ### Step 2: Fan out all sweeps in parallel
 
-Dispatch **all eight scans in one message** with multiple Agent tool calls. Follow the pattern in `SUBAGENT-SCAN.md`. Sequential dispatch defeats the purpose.
+Dispatch **all eight scans in one message** with multiple Agent tool calls.
+Follow the pattern in `SUBAGENT-SCAN.md`.
+Sequential dispatch defeats the purpose.
 
 The eight scans:
 
 #### Scan 1 — Writing review (`scientific-tex-editor`)
 
-Brief the agent on the manuscript path(s), whether `--since <ref>` was passed, and any project-specific style rules (semantic line breaks, citation style, etc. — read from the project's `CLAUDE.md` if one exists). Cap output around 400 words. Ask for **real problems only** (factual or logical inconsistencies, broken sentences, undefined terms, awkward phrasings introduced by recent edits) — explicitly tell it not to propose stylistic reshaping or reorganization. Group findings as **Must-fix / Should-fix / Optional**.
+Brief the agent on the manuscript path(s), whether `--since <ref>` was passed, and any project-specific style rules (semantic line breaks, citation style, etc. — read from the project's `CLAUDE.md` if one exists).
+Cap output around 400 words.
+Ask for **real problems only** (factual or logical inconsistencies, broken sentences, undefined terms, awkward phrasings introduced by recent edits) — explicitly tell it not to propose stylistic reshaping or reorganization.
+Group findings as **Must-fix / Should-fix / Optional**.
 
 #### Scan 2 — Citation graph audit (`Explore`)
 
@@ -70,14 +91,17 @@ Output two lists with `file:line` citations, plus a one-line verdict.
 
 Combined because both are label/string-level greps.
 
-- For every `\label{fig:…}` / `\label{tab:…}` / `\label{eq:…}`, check that the label is referenced via `\ref`, `\autoref`, `\Cref`, `\cref`, or `\eqref` somewhere. Account for the `xr` cross-document convention (SI labels referenced from main with `supp-` prefix).
+- For every `\label{fig:…}` / `\label{tab:…}` / `\label{eq:…}`, check that the label is referenced via `\ref`, `\autoref`, `\Cref`, `\cref`, or `\eqref` somewhere.
+  Account for the `xr` cross-document convention (SI labels referenced from main with `supp-` prefix).
 - Scan for common tool names (UShER, larch, nextclade, PastML, taxonium, BEAST, IQ-TREE, MUSCLE, matUtils, etc.) and report any tool whose typesetting varies across the document.
 
 Output: two labeled lists.
 
 #### Scan 4 — Numerical consistency (`general-purpose`)
 
-Find numbers that appear in multiple places in the manuscript (counts, percentages, fold-changes, correlation coefficients, p-values, thresholds, hyperparameters). For each, list every appearance with `file:line` and confirm they match. Flag any inconsistency.
+Find numbers that appear in multiple places in the manuscript (counts, percentages, fold-changes, correlation coefficients, p-values, thresholds, hyperparameters).
+For each, list every appearance with `file:line` and confirm they match.
+Flag any inconsistency.
 
 The agent should **discover** the numbers to check by reading the manuscript, not work from a fixed list — different papers have different repeated quantitative claims.
 
@@ -87,9 +111,12 @@ Output: one line per checked quantity: ✓ consistent (with line numbers) or ✗
 
 Combined because all three are grep-driven with simple classification.
 
-- **Editorial markers**: list every `%EM`, `%HH`, `%TODO`, `%XXX`, `%FIXME`, `% note`, `% NOTE` with `file:line` and truncated text. Classify by whether the comment looks **still in flight** (a question to a co-author, a suggestion not yet acted on) vs. **stale** (refers to deleted code, or to changes that have since been made). Do not call live in-flight comments "warts" — they're communication.
+- **Editorial markers**: list every `%EM`, `%HH`, `%TODO`, `%XXX`, `%FIXME`, `% note`, `% NOTE` with `file:line` and truncated text.
+  Classify by whether the comment looks **still in flight** (a question to a co-author, a suggestion not yet acted on) vs. **stale** (refers to deleted code, or to changes that have since been made).
+  Do not call live in-flight comments "warts" — they're communication.
 - **URL consistency**: extract every URL (`\url{…}` and bare `http(s)://`); group by host/path prefix; flag any inconsistencies in trailing slashes, repo names, or subpath conventions.
-- **Cross-reference direction**: list every "as above," "described below," "see above," "see below," "next section," "previous section" with surrounding context. The primary decides whether each points in the right direction (the subagent just enumerates — section reorderings can flip these without the writer noticing).
+- **Cross-reference direction**: list every "as above," "described below," "see above," "see below," "next section," "previous section" with surrounding context.
+  The primary decides whether each points in the right direction (the subagent just enumerates — section reorderings can flip these without the writer noticing).
 
 #### Scan 6 — Terminology consistency (`general-purpose`)
 
@@ -102,11 +129,13 @@ Output: each finding with `file:line`, classified "real inconsistency that shoul
 
 #### Scan 7 — Literature-gap check (`general-purpose`)
 
-This is the one that's easy to skip but valuable. Brief the agent with:
+This is the one that's easy to skip but valuable.
+Brief the agent with:
 
 - The manuscript's **topic** (read the abstract + introduction to summarize in 1–2 sentences).
 - The **current citation list** (extract all `\cite{}` keys from main.tex and si.tex; pass as a deduplicated list, or `gh`-style sample if too long).
-- The instruction: use **`bip asta`** to sweep for recent papers in the topic area, plus `bip search` against the local library to catch anything already imported but not cited. Look for papers that look directly relevant — same problem, same methods, same organism, same theoretical framework — that are not cited.
+- The instruction: use **`bip asta`** to sweep for recent papers in the topic area, plus `bip search` against the local library to catch anything already imported but not cited.
+  Look for papers that look directly relevant — same problem, same methods, same organism, same theoretical framework — that are not cited.
 
 Example shape of the agent's queries:
 ```bash
@@ -114,23 +143,28 @@ bip asta search "<topic-specific keywords>" --limit 30
 bip search "<topic-specific keywords>" --limit 30
 ```
 
-Output: a short list of candidate citations to consider, each with title, authors, year, venue, and a one-sentence reason why the manuscript might want to cite it. Do **not** include papers the manuscript already cites — diff against the citation list.
+Output: a short list of candidate citations to consider, each with title, authors, year, venue, and a one-sentence reason why the manuscript might want to cite it.
+Do **not** include papers the manuscript already cites — diff against the citation list.
 
-Aim for high precision over recall: the user does not want to read about 40 tangentially-related papers. Five strong candidates beat fifty weak ones. If the agent finds nothing relevant, say so.
+Aim for high precision over recall: the user does not want to read about 40 tangentially-related papers.
+Five strong candidates beat fifty weak ones.
+If the agent finds nothing relevant, say so.
 
 #### Scan 8 — Submission hygiene (`journal-submission-checker`)
 
 Check:
 - Every GitHub / external repository referenced in the manuscript is publicly accessible (curl/WebFetch each URL).
 - Every URL in the manuscript resolves (no 404s).
-- Recent preprint citations may have been published in journals since posting — flag candidates for bib updates, with **verified DOIs**. Web-search results can be wrong; the agent must verify each preprint→published claim against the primary source before reporting it.
+- Recent preprint citations may have been published in journals since posting — flag candidates for bib updates, with **verified DOIs**.
+  Web-search results can be wrong; the agent must verify each preprint→published claim against the primary source before reporting it.
 - Standard acknowledgment text (GISAID, funding sources) is present and matches required wording, if applicable.
 
 Output: a short punch list of submission-blockers vs. nice-to-haves.
 
 ### Step 3: Wait for all scans, then consolidate
 
-As each agent completes, deliver its findings to the user immediately — don't batch them up. The user can start triaging in parallel with later scans completing.
+As each agent completes, deliver its findings to the user immediately — don't batch them up.
+The user can start triaging in parallel with later scans completing.
 
 For each completed scan, give a **terse, conversational summary** in the chat:
 
@@ -147,7 +181,8 @@ For each completed scan, give a **terse, conversational summary** in the chat:
 - <item>
 ```
 
-Cite specific `file:line` for every actionable finding so the user can jump straight to it. Quote the exact text where ambiguity would otherwise force the user to re-read context.
+Cite specific `file:line` for every actionable finding so the user can jump straight to it.
+Quote the exact text where ambiguity would otherwise force the user to re-read context.
 
 When all eight scans are in, give a single consolidated punch list with three bins:
 
@@ -159,14 +194,17 @@ Numbered, deduplicated across scans, with `file:line` for each item.
 
 ### Step 4: Interactive triage
 
-Ask the user how they want to proceed. Common patterns:
+Ask the user how they want to proceed.
+Common patterns:
 
 - **Apply the mechanical fixes** — the user says "fix items 1–6," you apply them with `Edit`.
-- **Annotate the TeX** — the user wants `%EM`-style comments left in the source as TODOs for a co-author. Draft them inline near the relevant lines, with attribution (e.g., `%TODO from sweep`).
+- **Annotate the TeX** — the user wants `%EM`-style comments left in the source as TODOs for a co-author.
+  Draft them inline near the relevant lines, with attribution (e.g., `%TODO from sweep`).
 - **Defer** — the user wants a few items kept in mind for later but not acted on now.
 - **Ship as is** — the user reviews and decides nothing needs changing.
 
-Do **not** auto-apply any change without explicit confirmation. Treat the sweep's findings as recommendations, not commits.
+Do **not** auto-apply any change without explicit confirmation.
+Treat the sweep's findings as recommendations, not commits.
 
 ### Step 5: Verify build (only if edits were applied)
 
@@ -176,20 +214,33 @@ If you applied edits, recompile:
 make 2>&1 | tail -10        # or: latexmk main.tex
 ```
 
-Surface any new warnings/errors. Do not commit.
+Surface any new warnings/errors.
+Do not commit.
 
 ## Subagent dispatch reference
 
-See `SUBAGENT-SCAN.md` in the bipartite repo root for the shared fan-out pattern (parallel dispatch, structured output, when to re-dispatch). The eight scans above plug into that pattern. Re-dispatch any scan whose output is empty or shorter than 50 words — that's the "the subagent didn't look hard" failure mode.
+See `SUBAGENT-SCAN.md` in the bipartite repo root for the shared fan-out pattern (parallel dispatch, structured output, when to re-dispatch).
+The eight scans above plug into that pattern.
+Re-dispatch any scan whose output is empty or shorter than 50 words — that's the "the subagent didn't look hard" failure mode.
 
 ## Guidelines
 
-- **Default to MATCH / consistent / clean.** Most claims in a manuscript are correct. A sweep that returns 40 problems in a 50-page paper is almost certainly an over-eager subagent. If a scan looks like that, re-dispatch with a tighter brief.
-- **Quote `file:line` for every actionable item.** The user must be able to jump straight to the source. Never say "around line 200ish."
-- **Treat `%EM` / `%HH` markers as communication, not warts.** Classify them, list them, but don't tell the user to strip them unless they look stale or self-contradictory.
-- **The literature-gap check is on by default.** It is the highest-yield thing the user is most likely to forget to run.
-- **No report file.** Findings live in the chat. If you need transient scratch (e.g., a long list of citation keys you want to pass between subagents), write to `_ignore/sweep/` in the manuscript repo (create the directory if missing; assume it's gitignored by convention or warn the user if not).
-- **Do not auto-edit, do not auto-commit.** The user drives.
+- **Default to MATCH / consistent / clean.**
+  Most claims in a manuscript are correct.
+  A sweep that returns 40 problems in a 50-page paper is almost certainly an over-eager subagent.
+  If a scan looks like that, re-dispatch with a tighter brief.
+- **Quote `file:line` for every actionable item.**
+  The user must be able to jump straight to the source.
+  Never say "around line 200ish."
+- **Treat `%EM` / `%HH` markers as communication, not warts.**
+  Classify them, list them, but don't tell the user to strip them unless they look stale or self-contradictory.
+- **The literature-gap check is on by default.**
+  It is the highest-yield thing the user is most likely to forget to run.
+- **No report file.**
+  Findings live in the chat.
+  If you need transient scratch (e.g., a long list of citation keys you want to pass between subagents), write to `_ignore/sweep/` in the manuscript repo (create the directory if missing; assume it's gitignored by convention or warn the user if not).
+- **Do not auto-edit, do not auto-commit.**
+  The user drives.
 
 ## When to use this vs siblings
 
@@ -206,15 +257,30 @@ See `SUBAGENT-SCAN.md` in the bipartite repo root for the shared fan-out pattern
 
 ## Why this shape
 
-- **Eight parallel scans, not one big review.** Each scan has one job and a tight output contract. Parallelism keeps wall-clock latency low and primary-agent context clean. The primary's job is consolidation, not analysis.
-- **Literature gap is in the default flow.** It's the single most often-skipped check before submission, and `bip asta` makes it cheap. Putting it behind a flag would mean it never runs.
-- **Interactive output, not a markdown report.** The user reads the punch list in the chat and decides as findings arrive. A report file is overhead for a workflow designed to drive same-session edits.
-- **No config dependency.** Most TeX manuscripts have an obvious main file. Requiring `.ms-config.json` would add friction for the common case. The skill detects what it can, asks when ambiguous.
-- **Editorial markers are communication.** Co-authors leave `%EM`/`%HH` notes for each other. The sweep helps the user see them all in one place but doesn't moralize about them.
+- **Eight parallel scans, not one big review.**
+  Each scan has one job and a tight output contract.
+  Parallelism keeps wall-clock latency low and primary-agent context clean.
+  The primary's job is consolidation, not analysis.
+- **Literature gap is in the default flow.**
+  It's the single most often-skipped check before submission, and `bip asta` makes it cheap.
+  Putting it behind a flag would mean it never runs.
+- **Interactive output, not a markdown report.**
+  The user reads the punch list in the chat and decides as findings arrive.
+  A report file is overhead for a workflow designed to drive same-session edits.
+- **No config dependency.**
+  Most TeX manuscripts have an obvious main file.
+  Requiring `.ms-config.json` would add friction for the common case.
+  The skill detects what it can, asks when ambiguous.
+- **Editorial markers are communication.**
+  Co-authors leave `%EM`/`%HH` notes for each other.
+  The sweep helps the user see them all in one place but doesn't moralize about them.
 
 ## References
 
 - Sibling skills: `/bip-ms`, `/bip-ms-poll`, `/bip-ms-tuckin`, `/bip-ms-audit`, `/bip-comment-check`, `/bip-pr-review`.
-- Subagents used: `@scientific-tex-editor`, `@journal-submission-checker`, `general-purpose`, `Explore`. None mandatory.
+- Subagents used: `@scientific-tex-editor`, `@journal-submission-checker`, `general-purpose`, `Explore`.
+  None mandatory.
 - Subagent dispatch pattern: `SUBAGENT-SCAN.md` (bipartite repo root).
-- Precipitating session: flu mutation rates manuscript pre-share sweep, 2026-05-14. Ran the eight scans by hand and caught: 7-panel-letter cascade after a figure caption change; orphan SI floats; bib duplicates; URL-trailing-slash inconsistency; `$R$` vs. `$r$` for Pearson; mutation-vs-substitution rate slippage; missing `float` package for `[H]` floats; a stale `\autoref{fig:summary}D and …` cross-reference. Without the parallel-scan structure, any one of these would likely have shipped.
+- Precipitating session: flu mutation rates manuscript pre-share sweep, 2026-05-14.
+  Ran the eight scans by hand and caught: 7-panel-letter cascade after a figure caption change; orphan SI floats; bib duplicates; URL-trailing-slash inconsistency; `$R$` vs. `$r$` for Pearson; mutation-vs-substitution rate slippage; missing `float` package for `[H]` floats; a stale `\autoref{fig:summary}D and …` cross-reference.
+  Without the parallel-scan structure, any one of these would likely have shipped.

--- a/skills/bip-ms-tuckin/SKILL.md
+++ b/skills/bip-ms-tuckin/SKILL.md
@@ -5,8 +5,8 @@ description: Persist manuscript session state before context reset
 
 # /bip-ms-tuckin
 
-Flush manuscript session state to durable storage before a context reset
-or session end. Run this when context is getting long or before stopping.
+Flush manuscript session state to durable storage before a context reset or session end.
+Run this when context is getting long or before stopping.
 
 ## Usage
 
@@ -24,20 +24,16 @@ git diff --stat
 git diff --cached --stat
 ```
 
-If there are uncommitted changes to TeX files, ask the user whether to
-commit them. Draft a commit message summarizing what changed (e.g.,
-"Update implementation notes: Phase 1b done, branchScale normalization").
+If there are uncommitted changes to TeX files, ask the user whether to commit them.
+Draft a commit message summarizing what changed (e.g., "Update implementation notes: Phase 1b done, branchScale normalization").
 Do not commit without confirmation.
 
-If there are only untracked `ISSUE-*.md` files, note them but do not
-commit (these are intentionally untracked per CLAUDE.md).
+If there are only untracked `ISSUE-*.md` files, note them but do not commit (these are intentionally untracked per CLAUDE.md).
 
 ### Step 2: Push EPIC body updates
 
-For each tracked repo in `.ms-config.json`, check whether the EPIC
-body was edited this session (compare the `updatedAt` from the start
-of the session to the current `updatedAt`). If not pushed yet, push
-any pending EPIC body updates:
+For each tracked repo in `.ms-config.json`, check whether the EPIC body was edited this session (compare the `updatedAt` from the start of the session to the current `updatedAt`).
+If not pushed yet, push any pending EPIC body updates:
 
 ```bash
 gh issue view <epic-number> --repo <org/repo> --json updatedAt
@@ -47,9 +43,8 @@ Report which EPICs were pushed and which were already up to date.
 
 ### Step 3: Update `.ms-config.json`
 
-Check whether `fetch_cmds` should be updated based on new experiments
-or results that arrived this session. If new result paths were
-discovered but not added to `fetch_cmds`, note them for the user.
+Check whether `fetch_cmds` should be updated based on new experiments or results that arrived this session.
+If new result paths were discovered but not added to `fetch_cmds`, note them for the user.
 
 ### Step 4: Update memory
 
@@ -60,21 +55,18 @@ Update the auto-memory files to reflect the session's work:
    - Update open issue list
    - Note the current bottleneck
    - Record any key decisions made this session
-   - Record **in-flight research threads**: analyses requested on PRs/issues
-     this session, open scientific questions, and what each thread is waiting
-     on — so the next session resumes the orchestration, not just the
-     manuscript. (A thread that has *completed* is what triggers a paper
-     update; one still open stays here.)
+   - Record **in-flight research threads**: analyses requested on PRs/issues this session, open scientific questions, and what each thread is waiting on — so the next session resumes the orchestration, not just the manuscript.
+     (A thread that has *completed* is what triggers a paper update; one still open stays here.)
 
 2. **`project_pending_decisions.md`** (if it exists):
    - Remove resolved decisions
    - Update status of pending decisions
    - Add any new unresolved items
 
-3. **Feedback memories**: If the user corrected an approach or
-   confirmed a non-obvious choice, save it.
+3. **Feedback memories**: If the user corrected an approach or confirmed a non-obvious choice, save it.
 
-Only update memories that changed. Do not rewrite unchanged files.
+Only update memories that changed.
+Do not rewrite unchanged files.
 
 ### Step 5: Verify build
 
@@ -82,8 +74,8 @@ Only update memories that changed. Do not rewrite unchanged files.
 make pdf
 ```
 
-Ensure the manuscript builds cleanly. If it doesn't, fix the build
-error before completing tuckin.
+Ensure the manuscript builds cleanly.
+If it doesn't, fix the build error before completing tuckin.
 
 ### Step 6: Report
 

--- a/skills/bip-ms/SKILL.md
+++ b/skills/bip-ms/SKILL.md
@@ -5,74 +5,50 @@ description: Cold-start for a manuscript session — the paper is the source of 
 
 # /bip-ms
 
-Cold-start for a manuscript session. Run from a **TeX repository** (e.g.
-`~/writing/cosine` or `~/re/peak-origins/paper`). The manuscript is the
-**source of truth** about the project: one should be able to understand the
-project's state by reading it. This session practices *manuscript-driven
-development* — its first job is to act as a scientific discussant and
-orchestrate the research (in the context of the paper, directed through issues
-and PRs), updating the manuscript itself as each thread of research completes.
+Cold-start for a manuscript session.
+Run from a **TeX repository** (e.g. `~/writing/cosine` or `~/re/peak-origins/paper`).
+The manuscript is the **source of truth** about the project: one should be able to understand the project's state by reading it.
+This session practices *manuscript-driven development* — its first job is to act as a scientific discussant and orchestrate the research (in the context of the paper, directed through issues and PRs), updating the manuscript itself as each thread of research completes.
 
-Use this at **session start** to establish context. For mid-session
-updates, use `/bip-ms-poll`.
+Use this at **session start** to establish context.
+For mid-session updates, use `/bip-ms-poll`.
 
 ## Conventions
 
 ### Naming
-- `iN` = issue #N, `pN` = PR #N. Never bare `#N`.
+- `iN` = issue #N, `pN` = PR #N.
+  Never bare `#N`.
 - First mention in bullet lists: full URL inline.
 - EPIC issues are referenced as `EPIC-N` when ambiguous across repos.
 
 ### Session role
 
-The manuscript is the **source of truth** about the project — it holds the
-background, framing, and current understanding, and one should be able to grasp
-the project's state by reading it. It is the shared context you reason *from*,
-not a running log you append to.
+The manuscript is the **source of truth** about the project — it holds the background, framing, and current understanding, and one should be able to grasp the project's state by reading it.
+It is the shared context you reason *from*, not a running log you append to.
 
-Within that context, the agent's **first job is to be a scientific discussant
-and to orchestrate the research**: read new results closely enough to argue
-about them as a collaborator, judge whether a result holds up and what it
-means, weigh it against related work and against what the manuscript already
-claims, and decide what should happen next. This is *manuscript-driven
-development*: the PI directs the science at the level of the paper while agents
-handle the implementation.
+Within that context, the agent's **first job is to be a scientific discussant and to orchestrate the research**: read new results closely enough to argue about them as a collaborator, judge whether a result holds up and what it means, weigh it against related work and against what the manuscript already claims, and decide what should happen next.
+This is *manuscript-driven development*: the PI directs the science at the level of the paper while agents handle the implementation.
 
-Research is directed **through issues and PRs**, not through constant edits to
-the paper. Comment on PRs/issues to request analyses, draft issues for the
-implementor (via the Issue quality gate), and advise the code-side owner on
-what to build next.
+Research is directed **through issues and PRs**, not through constant edits to the paper.
+Comment on PRs/issues to request analyses, draft issues for the implementor (via the Issue quality gate), and advise the code-side owner on what to build next.
 
-The manuscript is **updated when a thread of research is complete** — you then
-reconcile the finished result into the paper (the manuscript prevails on
-disagreement; cf. `/bip-ms-audit`), rather than appending every incremental
-finding as it lands. Until then the paper stays the stable context the
-discussion runs against.
+The manuscript is **updated when a thread of research is complete** — you then reconcile the finished result into the paper (the manuscript prevails on disagreement; cf. `/bip-ms-audit`), rather than appending every incremental finding as it lands.
+Until then the paper stays the stable context the discussion runs against.
 
-Supporting mechanics, in service of the above: monitor tracked EPICs, pull
-clones and run Makefile fetch targets, import SVGs into `prep-figures/`, open
-HTML notebooks in Chrome.
+Supporting mechanics, in service of the above: monitor tracked EPICs, pull clones and run Makefile fetch targets, import SVGs into `prep-figures/`, open HTML notebooks in Chrome.
 
-**Out of scope — a safety boundary, not a limit on what you may think about or
-direct:** this session does not itself run experiments or modify remote server
-state (other agents are actively working there — see the next rule). Guiding,
-scoping, and *requesting* that work is central and in scope. Do **not** create
-issues on your own initiative — surface gaps to the user; when the user
-explicitly asks to file one, follow the Issue quality gate below.
+**Out of scope — a safety boundary, not a limit on what you may think about or direct:** this session does not itself run experiments or modify remote server state (other agents are actively working there — see the next rule).
+Guiding, scoping, and *requesting* that work is central and in scope.
+Do **not** create issues on your own initiative — surface gaps to the user; when the user explicitly asks to file one, follow the Issue quality gate below.
 
-**Never modify remote server state.** Do not run `snakemake` (even
-dry-run), `zig build`, `git pull`, `snakemake --unlock`, or any
-write command on remote servers (ermine, quokka, orca, etc.). Other
-agents are actively running experiments there. SSH is fine for
-read-only inspection (`ls`, `cat`, `head`, `grep`, checking file
-dates/sizes), but never run anything that modifies files, locks, or
-builds. Report what you observe and let the user or the responsible
-agent handle modifications.
+**Never modify remote server state.**
+Do not run `snakemake` (even dry-run), `zig build`, `git pull`, `snakemake --unlock`, or any write command on remote servers (ermine, quokka, orca, etc.).
+Other agents are actively running experiments there.
+SSH is fine for read-only inspection (`ls`, `cat`, `head`, `grep`, checking file dates/sizes), but never run anything that modifies files, locks, or builds.
+Report what you observe and let the user or the responsible agent handle modifications.
 
-**Issue quality gate:** When the user asks to file an issue during a
-manuscript session, always run `/bip-issue-check` on the draft before
-submitting via `/bip-issue-file`. Do not shortcut to `gh issue create`
-directly, regardless of perceived simplicity.
+**Issue quality gate:** When the user asks to file an issue during a manuscript session, always run `/bip-issue-check` on the draft before submitting via `/bip-issue-file`.
+Do not shortcut to `gh issue create` directly, regardless of perceived simplicity.
 
 ## Configuration
 
@@ -111,24 +87,30 @@ Fields:
   - **repo**: `org/repo` for `gh` commands
   - **local_path**: Local checkout of the repo
   - **epics**: EPIC issue numbers to monitor
-  - **fetch_cmds**: Shell commands to run **inside `local_path`** to fetch specific result directories from remote. Each command should be selective — pull only the results the manuscript needs, not the entire experiment tree. Uses the repo's own Makefile targets (which know the remote host and rsync config).
-  - **remote_watch** (optional): Configuration for the persistent result monitor (Step 5). Fields:
+  - **fetch_cmds**: Shell commands to run **inside `local_path`** to fetch specific result directories from remote.
+    Each command should be selective — pull only the results the manuscript needs, not the entire experiment tree.
+    Uses the repo's own Makefile targets (which know the remote host and rsync config).
+  - **remote_watch** (optional): Configuration for the persistent result monitor (Step 5).
+    Fields:
     - **host**: SSH hostname for the remote server
     - **paths**: Remote directories to watch for new results
     - **patterns**: File glob patterns to match (e.g. `*.svg`, `*.html`, `*.tsv`)
 
-**Updating fetch_cmds**: As new experiments land and the manuscript
-needs different results, update this list. Old entries can be kept
-(re-fetching is idempotent) or removed when no longer relevant.
+**Updating fetch_cmds**: As new experiments land and the manuscript needs different results, update this list.
+Old entries can be kept (re-fetching is idempotent) or removed when no longer relevant.
 
 **If the file does not exist**, stop and ask the user:
-1. What is the main TeX file? (e.g. `main.tex`)
-2. Where is `prep-figures/`? (or equivalent)
-3. Which code repos does this manuscript track? For each:
+1. What is the main TeX file?
+   (e.g. `main.tex`)
+2. Where is `prep-figures/`?
+   (or equivalent)
+3. Which code repos does this manuscript track?
+   For each:
    - GitHub `org/repo`
    - Local checkout path
    - EPIC issue numbers
-   - Which result directories should be fetched? (check the repo's Makefile for `remote-fetch`, `artifacts-pull`, etc. — run `grep -E '^[a-z].*:' Makefile` to see targets)
+   - Which result directories should be fetched?
+     (check the repo's Makefile for `remote-fetch`, `artifacts-pull`, etc. — run `grep -E '^[a-z].*:' Makefile` to see targets)
 
 Then create `.ms-config.json` and proceed.
 
@@ -140,21 +122,18 @@ Then create `.ms-config.json` and proceed.
 cat .ms-config.json
 ```
 
-Read `MEMORY.md` from the auto-memory directory. For each memory file
-listed there, read it and apply:
+Read `MEMORY.md` from the auto-memory directory.
+For each memory file listed there, read it and apply:
 
-- **Project memories** (e.g., `project_dasmfit_status.md`): Use as
-  the baseline for what's done vs pending. Cross-check against live
-  GitHub state — memories can be stale. When a memory says "PR open"
-  but `gh pr view` says merged, trust GitHub and update the memory.
-- **Pending decisions** (e.g., `project_pending_decisions.md`): Check
-  whether they've been resolved since last session. Remove resolved
-  items, flag unresolved ones in the status table.
-- **Feedback memories**: Apply silently — these are behavioral
-  guidelines, not status items.
+- **Project memories** (e.g., `project_dasmfit_status.md`): Use as the baseline for what's done vs pending.
+  Cross-check against live GitHub state — memories can be stale.
+  When a memory says "PR open" but `gh pr view` says merged, trust GitHub and update the memory.
+- **Pending decisions** (e.g., `project_pending_decisions.md`): Check whether they've been resolved since last session.
+  Remove resolved items, flag unresolved ones in the status table.
+- **Feedback memories**: Apply silently — these are behavioral guidelines, not status items.
 
-After loading, briefly note what the memory says the current state is,
-then verify it in Steps 1-4. Do not trust memory over live state.
+After loading, briefly note what the memory says the current state is, then verify it in Steps 1-4.
+Do not trust memory over live state.
 
 ### Step 1: Check manuscript state
 
@@ -167,58 +146,45 @@ Note any uncommitted changes or recent work.
 
 ### Step 2: Fan out per-repo scanners
 
-For each entry in `tracked_repos`, dispatch one `general-purpose`
-subagent **in parallel** — single message, multiple `Agent` tool calls.
-Follow the dispatch pattern in `SUBAGENT-SCAN.md` (bipartite repo
-root). Per-repo (not per-EPIC) granularity avoids racing on `git pull`
-when one repo has multiple EPICs.
+For each entry in `tracked_repos`, dispatch one `general-purpose` subagent **in parallel** — single message, multiple `Agent` tool calls.
+Follow the dispatch pattern in `SUBAGENT-SCAN.md` (bipartite repo root).
+Per-repo (not per-EPIC) granularity avoids racing on `git pull` when one repo has multiple EPICs.
 
 Brief for each subagent:
 
-> Scan repo `<org/repo>` for the manuscript session. Local path:
-> `<local_path>`. EPIC numbers: `<epics>`. Fetch commands:
-> `<fetch_cmds>`.
+> Scan repo `<org/repo>` for the manuscript session.
+> Local path: `<local_path>`.
+> EPIC numbers: `<epics>`.
+> Fetch commands: `<fetch_cmds>`.
 >
 > Tasks:
-> 1. `git -C <local_path> pull --ff-only origin main` (continue on
->    failure; note it).
+> 1. `git -C <local_path> pull --ff-only origin main` (continue on failure; note it).
 > 2. From `<local_path>`, run each fetch_cmd.
-> 3. For each EPIC, `gh issue view <N> --repo <org/repo> --json
->    title,body,updatedAt`. Parse Status dashboard, Key findings,
->    and active clone assignments.
-> 4. `gh pr list --repo <org/repo> --search "is:merged
->    sort:updated-desc" --limit 10 --json
->    number,title,mergedAt,body`. Note which produced figures or
->    quantitative results.
-> 5. Find SVGs and HTMLs under `<local_path>` modified in the last
->    120 minutes. For each, identify the EPIC or PR that produced
->    it.
+> 3. For each EPIC, `gh issue view <N> --repo <org/repo> --json title,body,updatedAt`.
+>    Parse Status dashboard, Key findings, and active clone assignments.
+> 4. `gh pr list --repo <org/repo> --search "is:merged sort:updated-desc" --limit 10 --json number,title,mergedAt,body`.
+>    Note which produced figures or quantitative results.
+> 5. Find SVGs and HTMLs under `<local_path>` modified in the last 120 minutes.
+>    For each, identify the EPIC or PR that produced it.
 >
 > Return under 400 words, structured per `SUBAGENT-SCAN.md`:
-> - `changes_since_baseline`: EPIC items newly checked, new key
->   findings, PRs merged that produced relevant results
+> - `changes_since_baseline`: EPIC items newly checked, new key findings, PRs merged that produced relevant results
 > - `active_items`: clone assignments from EPIC tables, brief status
 > - `new_artifacts`: paths to new SVGs/notebooks with EPIC/PR source
-> - `action_candidates`: figures to import, notebooks to open, text
->   to draft
-> - `surprises`: anything else, including `RECOMMEND DEEPER LOOK`
->   flags
+> - `action_candidates`: figures to import, notebooks to open, text to draft
+> - `surprises`: anything else, including `RECOMMEND DEEPER LOOK` flags
 >
-> Quote specific EPIC/PR lines that show what changed — do not paste
-> full bodies. Use Read (not grep excerpts) for any PR body or
-> finding you cite.
+> Quote specific EPIC/PR lines that show what changed — do not paste full bodies.
+> Use Read (not grep excerpts) for any PR body or finding you cite.
 
-If any report has zero `surprises` *and* zero `changes_since_baseline`,
-dispatch a follow-up with a narrower question ("what changed in the
-last 7 days on this EPIC even if no boxes were checked?") before
-concluding "all quiet" for that repo.
+If any report has zero `surprises` *and* zero `changes_since_baseline`, dispatch a follow-up with a narrower question ("what changed in the last 7 days on this EPIC even if no boxes were checked?")
+before concluding "all quiet" for that repo.
 
 ### Step 3: Build status table
 
-Compose from the per-repo subagent reports (do not paste their prose
-verbatim). Cross-reference the reports against each other — the
-primary sees all of them; the subagents don't. Display a summary of
-what's happening across all tracked repos:
+Compose from the per-repo subagent reports (do not paste their prose verbatim).
+Cross-reference the reports against each other — the primary sees all of them; the subagents don't.
+Display a summary of what's happening across all tracked repos:
 
 | Repo | EPIC | New Results | Active Work | Action Needed |
 |------|------|-------------|-------------|---------------|
@@ -243,19 +209,15 @@ Based on what's new, propose concrete next steps:
 1. **Import figures**: Copy new SVGs to `prep-figures/`, run `make pdf-figures`
 2. **Open notebooks**: Open HTML notebooks in Chrome for review
 3. **Draft text**: Summarize findings in bullets, then draft results/methods
-4. **Note gaps**: If manuscript work reveals missing experiments or analyses,
-   note them for the user; do not file issues on your own initiative. If the
-   user asks you to file one, follow the Issue quality gate
-   (`/bip-issue-check` → `/bip-issue-file`).
+4. **Note gaps**: If manuscript work reveals missing experiments or analyses, note them for the user; do not file issues on your own initiative.
+   If the user asks you to file one, follow the Issue quality gate (`/bip-issue-check` → `/bip-issue-file`).
 
 Wait for user confirmation before taking action.
 
 ### Step 5: Start result monitor
 
-If any tracked repo has a `remote_watch` configuration, offer to start a
-**persistent Monitor** that watches remote servers for new result files
-via SSH. This provides real-time awareness of experiment completion
-without waiting for the next `/bip-ms-poll` cycle.
+If any tracked repo has a `remote_watch` configuration, offer to start a **persistent Monitor** that watches remote servers for new result files via SSH.
+This provides real-time awareness of experiment completion without waiting for the next `/bip-ms-poll` cycle.
 
 Use the Monitor tool with `persistent: true`:
 
@@ -291,28 +253,24 @@ command: |
   done
 ```
 
-The conductor dynamically builds this script from `.ms-config.json` at
-startup — the template above shows the structure. Each repo's
-`remote_watch` contributes one SSH check block.
+The conductor dynamically builds this script from `.ms-config.json` at startup — the template above shows the structure.
+Each repo's `remote_watch` contributes one SSH check block.
 
 When a notification arrives showing new files:
 1. Run the repo's `fetch_cmds` to pull the new results locally
 2. Check if the files are SVGs/notebooks and react per the import workflows below
 3. Notify the user with a summary of what arrived
 
-**Prerequisites**: SSH access to the remote host with key-based auth
-(no password prompts). If SSH fails, the monitor logs the error to
-stderr and retries on the next cycle.
+**Prerequisites**: SSH access to the remote host with key-based auth (no password prompts).
+If SSH fails, the monitor logs the error to stderr and retries on the next cycle.
 
-**Alternative: sshfs + fswatch** — For lower latency, mount the remote
-result directories via `sshfs` and use `fswatch` locally:
+**Alternative: sshfs + fswatch** — For lower latency, mount the remote result directories via `sshfs` and use `fswatch` locally:
 ```bash
 sshfs host:/remote/results /local/mount -o reconnect,ServerAliveInterval=15
 fswatch --batch-marker=EOF /local/mount --include '*.svg' --include '*.html' --exclude '.*'
 ```
-This gives true real-time notification but requires `sshfs` (`brew
-install macfuse sshfs`) and is less robust on flaky networks. The SSH
-poll approach is the default recommendation.
+This gives true real-time notification but requires `sshfs` (`brew install macfuse sshfs`) and is less robust on flaky networks.
+The SSH poll approach is the default recommendation.
 
 ## Figure import workflow
 
@@ -324,8 +282,8 @@ cp "<local-path>/figure.svg" "$PREP_DIR/"
 make pdf-figures
 ```
 
-Then check if the figure is already referenced in the manuscript. If not,
-suggest where to add it and draft the `\includegraphics` block.
+Then check if the figure is already referenced in the manuscript.
+If not, suggest where to add it and draft the `\includegraphics` block.
 
 ## Notebook review workflow
 
@@ -344,38 +302,35 @@ When drafting new results or methods text:
 
 1. Read the relevant EPIC findings, PR descriptions, and experiment results
 2. Read the current manuscript to understand style, notation, and structure
-3. Present the key points as a **bullet-point summary** and ask the user
-   which to include and where in the manuscript they belong
+3. Present the key points as a **bullet-point summary** and ask the user which to include and where in the manuscript they belong
 4. After confirmation, draft the paragraph(s) in LaTeX
 5. Run the `@scientific-tex-editor` agent on the new text for style review
 6. Present the edited draft for final approval before inserting into the TeX file
 
 ## Remote server awareness
 
-Experiment results and data live on remote servers (orca/ermine), not
-locally. When validating claims about experiment results — especially
-when drafting or checking issues — use `ssh` to verify:
+Experiment results and data live on remote servers (orca/ermine), not locally.
+When validating claims about experiment results — especially when drafting or checking issues — use `ssh` to verify:
 - That data files exist at the stated paths
-- That intermediate outputs (filtered FASTAs, DAG protobufs) match
-  what READMEs and Snakefiles describe
+- That intermediate outputs (filtered FASTAs, DAG protobufs) match what READMEs and Snakefiles describe
 - That result TSVs have the expected columns and row counts
 
 Do not assume local READMEs and Snakefiles are the full picture.
-Experiments may produce filtered or transformed intermediates that
-change the data (e.g., filtered FASTAs with different taxa, condensed
-DAGs with extra leaves). Always check the actual files on disk.
+Experiments may produce filtered or transformed intermediates that change the data (e.g., filtered FASTAs with different taxa, condensed DAGs with extra leaves).
+Always check the actual files on disk.
 
 ## Error handling
 
 - **Config missing**: Ask user to configure (see above)
 - **Local path doesn't exist**: Warn — repo may need cloning
-- **Git pull fails**: Warn (dirty worktree? diverged?) and continue with stale state
-- **Fetch cmd fails**: Warn — remote may be unreachable or path may have changed. Report and continue.
+- **Git pull fails**: Warn (dirty worktree?
+  diverged?)
+  and continue with stale state
+- **Fetch cmd fails**: Warn — remote may be unreachable or path may have changed.
+  Report and continue.
 - **EPIC not found**: Check if issue number is correct
 - **No new results**: Report "all quiet" and suggest checking back later
 
 ## Session end
 
-Before ending a manuscript session or resetting context, run
-`/bip-ms-tuckin` to persist session state to memory and commit any
-manuscript changes.
+Before ending a manuscript session or resetting context, run `/bip-ms-tuckin` to persist session state to memory and commit any manuscript changes.

--- a/skills/bip-narrative/SKILL.md
+++ b/skills/bip-narrative/SKILL.md
@@ -15,12 +15,14 @@ Generate a themed narrative digest for a Slack channel.
 
 **Arguments:**
 - `<channel>` — Channel name (required, e.g., `dasm2`)
-- `--since <period>` — Time period to cover (default: `1w`). Examples: `1w`, `2d`, `3d`
+- `--since <period>` — Time period to cover (default: `1w`).
+  Examples: `1w`, `2d`, `3d`
 - `--verbose` — Include PR/issue body summaries in the raw activity
 
 ## Setup
 
-The nexus path is configured in `~/.config/bip/config.yml`. For the commands below, use the configured path (e.g., if `nexus_path` is `~/re/nexus`, substitute that).
+The nexus path is configured in `~/.config/bip/config.yml`.
+For the commands below, use the configured path (e.g., if `nexus_path` is `~/re/nexus`, substitute that).
 
 ## Workflow
 
@@ -49,8 +51,7 @@ Read the shared preferences file:
 cat <nexus>/narrative/preferences.md
 ```
 
-**If the file doesn't exist**, stop and report:
-"Missing shared preferences file: <nexus>/narrative/preferences.md"
+**If the file doesn't exist**, stop and report: "Missing shared preferences file: <nexus>/narrative/preferences.md"
 
 ### Step 3: Read Channel Configuration
 
@@ -60,9 +61,7 @@ Read the channel-specific config:
 cat <nexus>/narrative/{{channel}}.md
 ```
 
-**If the file doesn't exist**, stop and report:
-"Missing channel config: <nexus>/narrative/{{channel}}.md
-Create this file with Themes and Repo Context sections."
+**If the file doesn't exist**, stop and report: "Missing channel config: <nexus>/narrative/{{channel}}.md Create this file with Themes and Repo Context sections."
 
 ### Step 4: Generate Narrative
 
@@ -108,10 +107,13 @@ Using the raw activity from Step 1, the preferences from Step 2, and the channel
 - Stick to available information—do not invent context
 
 **CRITICAL — Include ALL Activity:**
-- You MUST include EVERY item from the raw activity output. Do NOT skip or omit ANY PR or issue.
+- You MUST include EVERY item from the raw activity output.
+  Do NOT skip or omit ANY PR or issue.
 - EVERY repository that appears in the raw output MUST be represented in the narrative.
-- If a repo has activity, it MUST appear somewhere in the digest. Missing repos is a failure.
-- When in doubt, include the item. Completeness is more important than brevity.
+- If a repo has activity, it MUST appear somewhere in the digest.
+  Missing repos is a failure.
+- When in doubt, include the item.
+  Completeness is more important than brevity.
 
 ### Step 5: Write Output
 
@@ -146,7 +148,8 @@ After the user has reviewed the narrative, ask if they want to post it to Slack.
    bip digest --channel {{channel}} --post
    ```
 
-3. Post the narrative link to Slack. Look up the webhook URL for the channel from `slack_webhooks` in `~/.config/bip/config.yml`, then:
+3. Post the narrative link to Slack.
+   Look up the webhook URL for the channel from `slack_webhooks` in `~/.config/bip/config.yml`, then:
    ```bash
    curl -s -X POST '{{webhook_url}}' -H 'Content-type: application/json' \
      -d '{"text":"https://github.com/matsengrp/nexus/blob/main/narrative/{{channel}}/{{YYYY-MM-DD}}.md"}'

--- a/skills/bip-plan/SKILL.md
+++ b/skills/bip-plan/SKILL.md
@@ -9,7 +9,9 @@ Enter plan mode with a rich context brief so the planning agent has everything i
 
 ## Why this skill exists
 
-Plan mode clears conversation history. If you've spent time discussing a bug, constraints, or pitfalls, that context is lost the moment the planning agent starts. This skill captures everything *before* entering plan mode and hands it off in a structured brief.
+Plan mode clears conversation history.
+If you've spent time discussing a bug, constraints, or pitfalls, that context is lost the moment the planning agent starts.
+This skill captures everything *before* entering plan mode and hands it off in a structured brief.
 
 ## Usage
 
@@ -24,7 +26,8 @@ Plan mode clears conversation history. If you've spent time discussing a bug, co
 
 ## Step 1: Gather context
 
-Before entering plan mode, collect the following. Run commands in parallel where possible.
+Before entering plan mode, collect the following.
+Run commands in parallel where possible.
 
 ### Git state
 ```bash
@@ -56,7 +59,9 @@ Read the most relevant changed files to understand the current state of implemen
 
 ## Step 2: Compose the brief
 
-Synthesize everything gathered into a structured **Context Brief**. This is what you'll hand to the planning agent. Include:
+Synthesize everything gathered into a structured **Context Brief**.
+This is what you'll hand to the planning agent.
+Include:
 
 ```markdown
 ## Context Brief for Planning Agent

--- a/skills/bip-pr-check/SKILL.md
+++ b/skills/bip-pr-check/SKILL.md
@@ -5,7 +5,8 @@ description: Quick PR readiness check — clean worktree, good description, squa
 
 # /bip-pr-check
 
-Quick sanity check before running the heavier `/bip-pr-review`. Catches common issues that waste review cycles.
+Quick sanity check before running the heavier `/bip-pr-review`.
+Catches common issues that waste review cycles.
 
 ## Usage
 
@@ -33,7 +34,8 @@ git status --short
 
 If there are uncommitted changes:
 - List them clearly
-- Ask the user: "There are uncommitted changes. Commit these before proceeding?"
+- Ask the user: "There are uncommitted changes.
+  Commit these before proceeding?"
 - **Do not proceed** until the worktree is clean or the user explicitly says to continue
 
 ### Step 3: Fetch and rebase on base branch
@@ -81,15 +83,9 @@ Fetch the PR body and evaluate whether it reads as a **clean summary** or as **h
 - Contains multiple "fix typo", "address review", "WIP" entries
 - Is auto-generated from concatenated commit messages (GitHub's default for squash merge)
 - Is empty or just whitespace
-- Accumulates one section per review round — headers like "Reviewer
-  follow-up: ...", "Human-flagged follow-up: ...", "Update:", or a
-  growing "History" section — even when each section is individually
-  well-written. This is the same defect as commit-message noise: the
-  reader has to reconstruct current truth from a chronological trail
-  instead of being told it directly. Long-running PRs that went
-  through several review rounds are the most likely to have this —
-  check specifically for it on any PR with more than one or two
-  rounds of feedback.
+- Accumulates one section per review round — headers like "Reviewer follow-up: ...", "Human-flagged follow-up: ...", "Update:", or a growing "History" section — even when each section is individually well-written.
+  This is the same defect as commit-message noise: the reader has to reconstruct current truth from a chronological trail instead of being told it directly.
+  Long-running PRs that went through several review rounds are the most likely to have this — check specifically for it on any PR with more than one or two rounds of feedback.
 
 **Signs of a good (squashed/summary) body:**
 - Has a `## Summary` or similar section with 1-3 bullet points explaining *what* and *why*
@@ -98,11 +94,12 @@ Fetch the PR body and evaluate whether it reads as a **clean summary** or as **h
 - Has a test plan or notes section if appropriate
 - Is concise but informative
 
-**Also apply `PROSE-DISCIPLINE.md`** (bipartite repo root) to the body. Flag violations and offer to rewrite.
+**Also apply `PROSE-DISCIPLINE.md`** (bipartite repo root) to the body.
+Flag violations and offer to rewrite.
 
-If the body looks like historical commit noise, revision-history
-accumulation, or is empty:
-1. Read the actual diff to understand the changes: `git diff origin/$(gh pr view --json baseRefName -q .baseRefName)...HEAD`. For a revision-history body specifically, also read the current body in full — later sections usually contain results/conclusions (recomputed numbers, resolved bugs, reconciled findings) that supersede earlier ones and must carry over into the rewrite; only the per-round framing gets dropped, not the substance.
+If the body looks like historical commit noise, revision-history accumulation, or is empty:
+1. Read the actual diff to understand the changes: `git diff origin/$(gh pr view --json baseRefName -q .baseRefName)...HEAD`.
+   For a revision-history body specifically, also read the current body in full — later sections usually contain results/conclusions (recomputed numbers, resolved bugs, reconciled findings) that supersede earlier ones and must carry over into the rewrite; only the per-round framing gets dropped, not the substance.
 2. Draft a clean replacement body in this format:
    ```
    ## Summary
@@ -128,7 +125,8 @@ EOF
 ### Step 7: Check draft status
 
 If the PR is marked as draft:
-- Ask: "PR is currently a draft. Ready to mark as ready for review?"
+- Ask: "PR is currently a draft.
+  Ready to mark as ready for review?"
 - If yes: `gh pr ready`
 
 ### Step 8: Summary

--- a/skills/bip-pr-land/SKILL.md
+++ b/skills/bip-pr-land/SKILL.md
@@ -16,13 +16,8 @@ Squash-merge the current branch's PR and clean up.
 
 ## Worktree mode
 
-If `bip spawn` created the working tree as a linked git worktree (because
-the user opted into the global `layout: { mode: worktree }` block in
-`~/.config/bip/config.yml`), this skill detects that in Step 7a and
-performs the base-branch pull from the primary clone, then removes the
-worktree in Step 8 before deleting the branch. In the common clone-mode
-case (no `layout:` block) every step runs as it always has — the worktree
-detection is a no-op.
+If `bip spawn` created the working tree as a linked git worktree (because the user opted into the global `layout: { mode: worktree }` block in `~/.config/bip/config.yml`), this skill detects that in Step 7a and performs the base-branch pull from the primary clone, then removes the worktree in Step 8 before deleting the branch.
+In the common clone-mode case (no `layout:` block) every step runs as it always has — the worktree detection is a no-op.
 
 ## Workflow
 
@@ -35,13 +30,20 @@ git diff --stat
 
 If there are uncommitted changes or untracked files, you MUST resolve each one explicitly — **never stash and move on**:
 
-1. **Identify every dirty file.** For each one, read enough of the diff or file content to understand what it is and why it exists.
+1. **Identify every dirty file.**
+   For each one, read enough of the diff or file content to understand what it is and why it exists.
 2. **Categorize each file:**
    - **Belongs to this PR** (e.g. forgotten formatting fix, test update): stage and commit with a short message.
    - **Unclear**: show the user the file and diff, explain what you see, and ask whether to commit it with the PR or move it aside.
-   - **Unrelated / stray**: move it to `_ignore/$(date -I)-landing/` so main stays clean. Create the directory if needed. Tell the user what you moved and why.
-3. **Never use `git stash`.** Stashing hides work and risks losing it. Every file must be either committed or moved to `_ignore/`.
-4. **Ask the user if unsure.** If you can't confidently categorize a file, ask. A quick question is always better than guessing wrong.
+   - **Unrelated / stray**: move it to `_ignore/$(date -I)-landing/` so main stays clean.
+     Create the directory if needed.
+     Tell the user what you moved and why.
+3. **Never use `git stash`.**
+   Stashing hides work and risks losing it.
+   Every file must be either committed or moved to `_ignore/`.
+4. **Ask the user if unsure.**
+   If you can't confidently categorize a file, ask.
+   A quick question is always better than guessing wrong.
 
 ### Step 2: Identify the PR
 
@@ -73,7 +75,8 @@ git fetch origin
 git rebase origin/<base>
 ```
 
-If rebase has conflicts, stop and report. Do not force-push or auto-resolve.
+If rebase has conflicts, stop and report.
+Do not force-push or auto-resolve.
 
 ### Step 5: Force-push rebased branch
 
@@ -89,11 +92,16 @@ Check whether the PR has any CI checks configured, and if so, block until they a
 gh pr checks "$BRANCH" --json name,state,conclusion
 ```
 
-- **No checks configured** (empty array): proceed immediately. This repo has no CI for this PR.
-- **Checks present**: wait until all required checks are `COMPLETED` with conclusion `SUCCESS` (or `NEUTRAL`/`SKIPPED`). Use `gh pr checks "$BRANCH" --watch --fail-fast` to block.
-- **Any check fails**: abort with the failing check name and a link via `gh pr view --web`. Do **not** merge. Report to user and stop.
+- **No checks configured** (empty array): proceed immediately.
+  This repo has no CI for this PR.
+- **Checks present**: wait until all required checks are `COMPLETED` with conclusion `SUCCESS` (or `NEUTRAL`/`SKIPPED`).
+  Use `gh pr checks "$BRANCH" --watch --fail-fast` to block.
+- **Any check fails**: abort with the failing check name and a link via `gh pr view --web`.
+  Do **not** merge.
+  Report to user and stop.
 
-Never merge a PR with failing or pending required checks. If checks are still queued/in progress, wait — do not assume they will pass.
+Never merge a PR with failing or pending required checks.
+If checks are still queued/in progress, wait — do not assume they will pass.
 
 ### Step 6: Squash merge via gh
 
@@ -109,8 +117,7 @@ Follow the squash merge conventions from global CLAUDE.md — PR title becomes t
 
 ### Step 7a: Detect worktree mode
 
-Before pulling the base branch, check whether you are landing from a
-linked git worktree (created by `bip spawn` in worktree mode):
+Before pulling the base branch, check whether you are landing from a linked git worktree (created by `bip spawn` in worktree mode):
 
 ```bash
 LAND_DIR=$(pwd -P)
@@ -120,13 +127,10 @@ if PRIMARY=$(bip worktree primary 2>/dev/null); then
 fi
 ```
 
-`bip worktree primary` exits 0 and prints the primary clone path **only**
-when the current directory is a linked worktree. In every other case
-(primary clone, non-bip checkout, non-git directory) it exits non-zero
-with no stdout — `$PRIMARY` remains empty and the `cd` is skipped.
+`bip worktree primary` exits 0 and prints the primary clone path **only** when the current directory is a linked worktree.
+In every other case (primary clone, non-bip checkout, non-git directory) it exits non-zero with no stdout — `$PRIMARY` remains empty and the `cd` is skipped.
 
-If `$PRIMARY` was set, Steps 7 and 7.5 below run in the primary clone;
-otherwise they run in `$LAND_DIR` exactly as today.
+If `$PRIMARY` was set, Steps 7 and 7.5 below run in the primary clone; otherwise they run in `$LAND_DIR` exactly as today.
 
 ### Step 7: Return to base branch and pull
 
@@ -137,31 +141,23 @@ git pull
 
 ### Step 7.5: Sync the primary clone (clone-mode only)
 
-**Skip this step if Step 7a already `cd`'d to the primary** — Step 7 has
-already pulled it.
+**Skip this step if Step 7a already `cd`'d to the primary** — Step 7 has already pulled it.
 
-If you landed from a scratch clone (EPIC worker, `bip spawn` without
-worktree mode, or any working copy that isn't the canonical one in
-`sources.yml`), the primary clone is now behind `origin/<base>`. Pull
-it forward so the canonical checkout matches `main`.
+If you landed from a scratch clone (EPIC worker, `bip spawn` without worktree mode, or any working copy that isn't the canonical one in `sources.yml`), the primary clone is now behind `origin/<base>`.
+Pull it forward so the canonical checkout matches `main`.
 
-1. Resolve the primary clone path the way `bip spawn` does (mirrors
-   `flow.ResolveRepoPath`: `nexus_path` from `~/.config/bip/config.yml`,
-   repo from `git remote get-url origin`, then `sources.yml` +
-   `config.yml` paths). If `$(pwd -P)` already equals it, or the repo
-   isn't listed, skip this step.
+1. Resolve the primary clone path the way `bip spawn` does (mirrors `flow.ResolveRepoPath`: `nexus_path` from `~/.config/bip/config.yml`, repo from `git remote get-url origin`, then `sources.yml` + `config.yml` paths).
+   If `$(pwd -P)` already equals it, or the repo isn't listed, skip this step.
 
-2. `git -C "$PRIMARY" pull --ff-only`. On failure, warn with the error
-   and continue — the merge is already upstream, nothing is lost. Never
-   stash.
+2. `git -C "$PRIMARY" pull --ff-only`.
+   On failure, warn with the error and continue — the merge is already upstream, nothing is lost.
+   Never stash.
 
 3. Report what you did in Step 10.
 
 ### Step 8: Remove worktree (if applicable) and delete branch
 
-If Step 7a found that you were landing from a linked worktree, remove
-the worktree **before** deleting its branch — git refuses to delete a
-branch that still has a worktree checked out on it:
+If Step 7a found that you were landing from a linked worktree, remove the worktree **before** deleting its branch — git refuses to delete a branch that still has a worktree checked out on it:
 
 ```bash
 if [ -n "$PRIMARY" ] && [ -n "$LAND_DIR" ] && [ "$LAND_DIR" != "$PRIMARY" ]; then
@@ -169,9 +165,8 @@ if [ -n "$PRIMARY" ] && [ -n "$LAND_DIR" ] && [ "$LAND_DIR" != "$PRIMARY" ]; the
 fi
 ```
 
-`bip worktree remove` defaults to `--force`, which is required because
-the squash-merge leaves the worktree carrying commits unreachable from
-the merged branch. Then delete the local branch:
+`bip worktree remove` defaults to `--force`, which is required because the squash-merge leaves the worktree carrying commits unreachable from the merged branch.
+Then delete the local branch:
 
 ```bash
 git branch -d <branch>
@@ -194,8 +189,7 @@ The goal is a **totally clean `git status`** on main when landing is done.
 
 ### Step 9.5: Clean up orchestration files
 
-Remove EPIC worker state files if present (these are gitignored and
-stale after landing):
+Remove EPIC worker state files if present (these are gitignored and stale after landing):
 
 ```bash
 rm -f .epic-status.json .epic-worklog.md
@@ -203,9 +197,9 @@ rm -f .epic-status.json .epic-worklog.md
 
 ### Step 10: Confirm
 
-Report: "Landed #42. On `<base>`, up to date, worktree clean. Branch `<branch>` deleted."
+Report: "Landed #42.
+On `<base>`, up to date, worktree clean.
+Branch `<branch>` deleted."
 If any files were moved to `_ignore/`, list them.
-If the primary clone was synced in Step 7.5, say so:
-"Primary clone `<path>` pulled."
-If Step 8 removed a linked worktree, say so:
-"Worktree `<path>` removed."
+If the primary clone was synced in Step 7.5, say so: "Primary clone `<path>` pulled."
+If Step 8 removed a linked worktree, say so: "Worktree `<path>` removed."

--- a/skills/bip-pr-review/SKILL.md
+++ b/skills/bip-pr-review/SKILL.md
@@ -5,7 +5,8 @@ description: Run comprehensive pre-merge quality checklist for current branch's 
 
 # /bip-pr-review
 
-Run a comprehensive quality checklist before merging a PR. Automatically detects project type and runs appropriate checks.
+Run a comprehensive quality checklist before merging a PR.
+Automatically detects project type and runs appropriate checks.
 
 ## Usage
 
@@ -38,7 +39,8 @@ Examine the repository to determine what checks apply:
 The two reviewers operate in **different modes** and complement each other — run them in parallel:
 
 - `clean-code-reviewer` reads the diff and evaluates each hunk against clean-code principles (naming, function size, single responsibility, DRY-within-hunk).
-- `code-reuse-reviewer` surveys the surrounding codebase *first*, then audits the diff for missed reuse of existing constants, helpers, conventions, and patterns. Its mandatory output tables (inline-import audit vs `pyproject.toml`; function-pair overlap audit) catch things a diff-only reviewer cannot see.
+- `code-reuse-reviewer` surveys the surrounding codebase *first*, then audits the diff for missed reuse of existing constants, helpers, conventions, and patterns.
+  Its mandatory output tables (inline-import audit vs `pyproject.toml`; function-pair overlap audit) catch things a diff-only reviewer cannot see.
 
 Multiple types can apply (e.g., Snakemake + Python).
 
@@ -56,7 +58,8 @@ Determine the base branch from the PR (if one exists), otherwise default to `mai
 gh pr view --json baseRefName -q .baseRefName 2>/dev/null || echo "main"
 ```
 
-Use `origin/<base>` (not local `<base>`) for all diffs below. This avoids false positives from a stale local main.
+Use `origin/<base>` (not local `<base>`) for all diffs below.
+This avoids false positives from a stale local main.
 
 ### Step 2: Identify Changed Files
 
@@ -96,11 +99,13 @@ Flag anything suspicious for user confirmation before proceeding.
 
 **For all projects with code changes:**
 - Launch `clean-code-reviewer` agent on modified source files (not tests)
-- **In parallel**, launch `code-reuse-reviewer` agent on the same branch — it surveys the surrounding codebase first to catch missed reuse of existing patterns, constants, helpers, and conventions. The two agents have different mandates (clean-code principles vs. pattern adherence) and report independently.
+- **In parallel**, launch `code-reuse-reviewer` agent on the same branch — it surveys the surrounding codebase first to catch missed reuse of existing patterns, constants, helpers, and conventions.
+  The two agents have different mandates (clean-code principles vs. pattern adherence) and report independently.
 
 ### Step 4.5: Scientific Conclusion Skeptic (conditional)
 
-**Always run this detection step.** Examine the PR title, body, and diff for signals that the PR reports a scientific conclusion or experimental result:
+**Always run this detection step.**
+Examine the PR title, body, and diff for signals that the PR reports a scientific conclusion or experimental result:
 
 - Benchmark results or comparison tables
 - Win/loss rates, accuracy numbers, or performance metrics
@@ -125,7 +130,8 @@ not just the description.
 Report your findings with Claim / Confidence / Concerns / Recommended Checks / Verdict.
 ```
 
-This step runs **in parallel** with the agent reviews in Step 4. Do not wait for it to complete before proceeding.
+This step runs **in parallel** with the agent reviews in Step 4.
+Do not wait for it to complete before proceeding.
 
 **If no scientific conclusion is detected**, skip this step and note "No scientific claims detected — skeptic review skipped" in the final report.
 
@@ -145,7 +151,8 @@ Detect and run available quality tools:
 
 ### Step 6: Test Audit
 
-Run a thorough test quality review using an agent. Grepping alone is insufficient—tests need semantic analysis to detect:
+Run a thorough test quality review using an agent.
+Grepping alone is insufficient—tests need semantic analysis to detect:
 
 - Placeholder tests (empty bodies, just `pass`, meaningless assertions)
 - Inappropriate use of mocks (if project forbids mocking)

--- a/skills/bip-remove-metaspeak/SKILL.md
+++ b/skills/bip-remove-metaspeak/SKILL.md
@@ -6,24 +6,15 @@ allowed-tools: Agent, Bash, Read, Edit, Write
 
 # /bip-remove-metaspeak
 
-Documents written incrementally with an agent accumulate a characteristic
-residue: they narrate their own drafting, argue with positions they used to
-hold, and pad every claim with rhetorical scaffolding. They also keep
-material that stopped being load-bearing — an argument the document raises
-and then demolishes, a proposal it talks itself out of, a retraction of
-something never published. Both have to go: the register is wrong, and some
-of the content has not earned its place. It reads like a transcript of
-someone still making up
-their mind, not a settled technical document.
+Documents written incrementally with an agent accumulate a characteristic residue: they narrate their own drafting, argue with positions they used to hold, and pad every claim with rhetorical scaffolding.
+They also keep material that stopped being load-bearing — an argument the document raises and then demolishes, a proposal it talks itself out of, a retraction of something never published.
+Both have to go: the register is wrong, and some of the content has not earned its place.
+It reads like a transcript of someone still making up their mind, not a settled technical document.
 
-The fix is a squash, in the git sense: many small revisions, each arguing
-with the one before it, collapse into a single statement of the final
-position. Nothing about the reasoning that justified a decision is lost —
-only the record of having changed your mind about it.
+The fix is a squash, in the git sense: many small revisions, each arguing with the one before it, collapse into a single statement of the final position.
+Nothing about the reasoning that justified a decision is lost — only the record of having changed your mind about it.
 
-This applies just as well to a PR body as to a file on disk: a description
-written across several rounds of push-and-revise tends to accumulate the same
-residue, and it's exactly the artifact reviewers read first.
+This applies just as well to a PR body as to a file on disk: a description written across several rounds of push-and-revise tends to accumulate the same residue, and it's exactly the artifact reviewers read first.
 
 ## Usage
 
@@ -37,202 +28,163 @@ residue, and it's exactly the artifact reviewers read first.
 
 ## When NOT to use it
 
-- **On a document that is genuinely a conversation record** — meeting notes,
-  a decision log, a postmortem where "we first thought X, then found Y" is
-  the content rather than the packaging.
-- **On someone else's prose**, unless asked. This changes voice.
-- **Before the content is settled.** Compressing an argument you are still
-  having wastes the pass; run it when the thinking is done.
+- **On a document that is genuinely a conversation record** — meeting notes, a decision log, a postmortem where "we first thought X, then found Y" is the content rather than the packaging.
+- **On someone else's prose**, unless asked.
+  This changes voice.
+- **Before the content is settled.**
+  Compressing an argument you are still having wastes the pass; run it when the thinking is done.
 
 ## Workflow
 
 ### Step 0: Decide what earns its place
 
-Do this before the register pass, on the whole document, and act on it — this
-is a removal step, not a report. Four signals mark content that has stopped
-being load-bearing:
+Do this before the register pass, on the whole document, and act on it — this is a removal step, not a report.
+Four signals mark content that has stopped being load-bearing:
 
-1. **A section raises an argument and then argues it fails.** Keep the
-   conclusion as a plain statement if a reader would otherwise walk into the
-   same argument. Delete the rest. Never keep both the argument and its
-   refutation.
-2. **A proposal arrives with reasons not to take it.** Delete the proposal.
+1. **A section raises an argument and then argues it fails.**
+   Keep the conclusion as a plain statement if a reader would otherwise walk into the same argument.
+   Delete the rest.
+   Never keep both the argument and its refutation.
+2. **A proposal arrives with reasons not to take it.**
+   Delete the proposal.
    If the reasons matter, one sentence: "not X, because Y."
-3. **Prose adjacent to a table or list restates its contents.** Keep the
-   table. Keep only the prose that argues something the cells cannot.
-4. **A section is wholly conditional on another section's outcome.** Collapse
-   it to one conditional sentence where the outcome is decided.
+3. **Prose adjacent to a table or list restates its contents.**
+   Keep the table.
+   Keep only the prose that argues something the cells cannot.
+4. **A section is wholly conditional on another section's outcome.**
+   Collapse it to one conditional sentence where the outcome is decided.
 
-Three more that recur, all deletions with nothing kept: framing the reader
-already agreed to in an earlier exchange or an earlier section; a retraction
-of a claim never published; advice about a method nobody proposed.
+Three more that recur, all deletions with nothing kept: framing the reader already agreed to in an earlier exchange or an earlier section; a retraction of a claim never published; advice about a method nobody proposed.
 
-This step is why the pass exists at all. Observed twice in one session:
-register-only passes cut 2.7% and 8% of two documents and reported them
-"already dense," after which the author cut 60% and 24% of the same
-documents — almost all of it material matching the signals above, which the
-register pass had carefully tidied on its way past.
+This step is why the pass exists at all.
+Observed twice in one session: register-only passes cut 2.7% and 8% of two documents and reported them "already dense," after which the author cut 60% and 24% of the same documents — almost all of it material matching the signals above, which the register pass had carefully tidied on its way past.
 
-Section-level deletions are recoverable: Step 2 takes a copy, and the
-deliverable requires every cut passage be quoted back. Cut, then let the
-review in Step 5 restore what mattered. Erring toward the cut is correct
-here; erring toward keeping is what produced the two failures above.
+Section-level deletions are recoverable: Step 2 takes a copy, and the deliverable requires every cut passage be quoted back.
+Cut, then let the review in Step 5 restore what mattered.
+Erring toward the cut is correct here; erring toward keeping is what produced the two failures above.
 
 ### Step 1: Determine the target
 
-Use `$ARGUMENTS` if given; otherwise the most recently discussed document in
-conversation. If unclear, ask.
+Use `$ARGUMENTS` if given; otherwise the most recently discussed document in conversation.
+If unclear, ask.
 
-If the target is a PR (`PR 123`, a PR URL, or bare `PR` for the current
-branch's PR), there is no file on disk — fetch the body instead:
+If the target is a PR (`PR 123`, a PR URL, or bare `PR` for the current branch's PR), there is no file on disk — fetch the body instead:
 
 ```bash
 gh pr view <number-or-branch> --json body -q .body
 ```
 
-Keep the fetched text in memory as the "before" copy; the rest of this
-workflow treats it the same as a file's contents, substituting "PR body" for
-"file" throughout. Applying the result means posting it back, per Step 5a.
+Keep the fetched text in memory as the "before" copy; the rest of this workflow treats it the same as a file's contents, substituting "PR body" for "file" throughout.
+Applying the result means posting it back, per Step 5a.
 
 ### Step 2: Get a recovery copy before the pass
 
-This is a large in-place rewrite, so a clean way back matters more than how
-it's taken.
+This is a large in-place rewrite, so a clean way back matters more than how it's taken.
 
 ```bash
 git status --short <file>
 ```
 
-- **Tracked and clean:** nothing to do — `git diff`/`git checkout <file>` are
-  the recovery path.
-- **Tracked and dirty:** say so and offer to commit before the pass. Do not
-  commit without approval.
-- **Untracked or gitignored** — this is the common case for `ISSUE-*.md`
-  files, which this repo's CLAUDE.md forbids ever committing — there is no
-  git history to fall back on. Instead copy the file to the scratchpad
-  (`cp <file> <scratchpad>/<name>.before.md`) and use that copy, not git, as
-  both the recovery path and the diff baseline in Step 5.
+- **Tracked and clean:** nothing to do — `git diff`/`git checkout <file>` are the recovery path.
+- **Tracked and dirty:** say so and offer to commit before the pass.
+  Do not commit without approval.
+- **Untracked or gitignored** — this is the common case for `ISSUE-*.md` files, which this repo's CLAUDE.md forbids ever committing — there is no git history to fall back on.
+  Instead copy the file to the scratchpad (`cp <file> <scratchpad>/<name>.before.md`) and use that copy, not git, as both the recovery path and the diff baseline in Step 5.
 
-PR bodies have no working tree to protect — skip this step for a PR target;
-the "before" copy from Step 1 already serves the same purpose.
+PR bodies have no working tree to protect — skip this step for a PR target; the "before" copy from Step 1 already serves the same purpose.
 
 ### Step 3: Spawn a subagent — one per section on anything large
 
-Do this in a subagent, not inline. The pass requires reading the whole
-document closely and making hundreds of small edits, and the judgment calls
-are local. Pass the file path (or PR body text) and the rules below **in
-full** — the keep-list is what stops the agent from cutting the argument
-along with the padding.
+Do this in a subagent, not inline.
+The pass requires reading the whole document closely and making hundreds of small edits, and the judgment calls are local.
+Pass the file path (or PR body text) and the rules below **in full** — the keep-list is what stops the agent from cutting the argument along with the padding.
 
-**Size matters, and getting it wrong wastes the run.** A single agent doing
-sequential in-place edits over a long document is a long-running,
-non-resumable job: one API hiccup and you get a partial rewrite with no
-report. Observed: a ~5,500-word EPIC completed cleanly in one pass; an
-~18,000-word document died partway with ~2% done and no deliverable.
+**Size matters, and getting it wrong wastes the run.**
+A single agent doing sequential in-place edits over a long document is a long-running, non-resumable job: one API hiccup and you get a partial rewrite with no report.
+Observed: a ~5,500-word EPIC completed cleanly in one pass; an ~18,000-word document died partway with ~2% done and no deliverable.
 
 - **Under ~8,000 words:** one subagent, whole document.
-- **Over that:** fan out, one subagent per top-level section, run in
-  parallel. Give each the same rules and keep-list plus its own section
-  range. Sections are independent for this purpose — the pass makes local
-  edits and never needs cross-section context.
-- **Either way, get the recovery copy first (Step 2).** A partial rewrite is
-  recoverable only if there is a clean commit or before-copy behind it.
+- **Over that:** fan out, one subagent per top-level section, run in parallel.
+  Give each the same rules and keep-list plus its own section range.
+  Sections are independent for this purpose — the pass makes local edits and never needs cross-section context.
+- **Either way, get the recovery copy first (Step 2).**
+  A partial rewrite is recoverable only if there is a clean commit or before-copy behind it.
 
-If a run does die partway, do not assume the target is broken. Verify instead
-(Step 5's integrity checks are fast), keep the partial work if it passes,
-and re-run only the untouched sections.
+If a run does die partway, do not assume the target is broken.
+Verify instead (Step 5's integrity checks are fast), keep the partial work if it passes, and re-run only the untouched sections.
 
 ### Step 4: Add document-specific keep items
 
-Before spawning, skim the document for what would be expensive to lose, and
-name it explicitly in the prompt. Typically:
+Before spawning, skim the document for what would be expensive to lose, and name it explicitly in the prompt.
+Typically:
 
 - Quantitative claims and their sources ("22 of 28 rates pegged at bounds")
 - Issue/PR references and citation keys
 - Gates, success criteria, acceptance thresholds
 - File paths, function names, command examples
-- Structural elements: heading hierarchy, phase numbering, tables,
-  placeholder sections, a leading emoji convention
+- Structural elements: heading hierarchy, phase numbering, tables, placeholder sections, a leading emoji convention
 
-Generic instructions produce generic damage. A named keep-list does not.
+Generic instructions produce generic damage.
+A named keep-list does not.
 
 ## The rules to pass to the subagent
 
 ### Remove
 
-1. **Narration of the drafting process.** "Two gaps assumed while drafting
-   this turned out to be already closed"; "this section used to claim";
-   "the document is written that way". State the current fact.
-2. **Arguing with a prior or anticipated position.** "This is *not* the
-   circularity it first looks like"; "worth being precise about what this
-   does *not* address"; "the right mental model is X, not Y". Assert the
-   correct thing once.
-3. **Throat-clearing and meta-framing.** "Worth noting", "worth stating",
-   "note that", "two things this is not", "work it through and…",
-   "it is worth being precise".
-4. **Hedging and intensifying adverbs that add no meaning**: frankly,
-   genuinely, deliberately, simply, actually, emphatically, clearly, and
-   *precisely* when used for emphasis rather than for precision.
-5. **Performative standards language.** "'We did X because it was
-   convenient' is not an outcome this gate passes" → "X is adopted only if
-   its diagnostics support it." State the requirement.
-6. **Tangents and asides** — usually dash-set — that do not affect a
-   decision.
+1. **Narration of the drafting process.**
+   "Two gaps assumed while drafting this turned out to be already closed"; "this section used to claim"; "the document is written that way".
+   State the current fact.
+2. **Arguing with a prior or anticipated position.**
+   "This is *not* the circularity it first looks like"; "worth being precise about what this does *not* address"; "the right mental model is X, not Y".
+   Assert the correct thing once.
+3. **Throat-clearing and meta-framing.**
+   "Worth noting", "worth stating", "note that", "two things this is not", "work it through and…", "it is worth being precise".
+4. **Hedging and intensifying adverbs that add no meaning**: frankly, genuinely, deliberately, simply, actually, emphatically, clearly, and *precisely* when used for emphasis rather than for precision.
+5. **Performative standards language.**
+   "'We did X because it was convenient' is not an outcome this gate passes" → "X is adopted only if its diagnostics support it."
+   State the requirement.
+6. **Tangents and asides** — usually dash-set — that do not affect a decision.
 
 ### Keep
 
 - Every number, and its source.
 - Every reference, link, citation key, path, function name, command.
 - Every gate and criterion, in full substance.
-- **All reasoning that justifies a decision the document is actually
-  making.** This is the load-bearing distinction and the one an agent gets
-  wrong. "We chose A over B because B fails when C" is content, not padding,
-  even when it runs several sentences. Compress the prose; keep the logic.
-  The qualifier is what stops this rule from protecting Step 0's material:
-  an argument the document raises and refutes, or a proposal it undercuts,
-  is also reasoning and also justifies a decision — the decision not to do
-  it. State that decision once and cut the deliberation behind it.
-- Markdown structure: heading hierarchy, numbering, tables,
-  placeholders. Heading *hierarchy* is structure and must survive; heading
-  *text* is prose and is in scope — a heading can narrate ("What I do not
-  know about X, and how to find out") and should be squashed like any other
-  sentence.
+- **All reasoning that justifies a decision the document is actually making.**
+  This is the load-bearing distinction and the one an agent gets wrong.
+  "We chose A over B because B fails when C" is content, not padding, even when it runs several sentences.
+  Compress the prose; keep the logic.
+  The qualifier is what stops this rule from protecting Step 0's material: an argument the document raises and refutes, or a proposal it undercuts, is also reasoning and also justifies a decision — the decision not to do it.
+  State that decision once and cut the deliberation behind it.
+- Markdown structure: heading hierarchy, numbering, tables, placeholders.
+  Heading *hierarchy* is structure and must survive; heading *text* is prose and is in scope — a heading can narrate ("What I do not know about X, and how to find out") and should be squashed like any other sentence.
 
 ### Style target
 
-Declarative and dense. Short direct sentences over long em-dash-chained
-ones. Do not convert argument-carrying prose to bullet fragments. Do not add
-claims, soften technical specificity, or invent anything.
+Declarative and dense.
+Short direct sentences over long em-dash-chained ones.
+Do not convert argument-carrying prose to bullet fragments.
+Do not add claims, soften technical specificity, or invent anything.
 
-Do not set a numeric cut target in the prompt: an agent told to cut a
-percentage will hit it regardless of whether the material supports it, and
-the last few points come out of the argument. Ask instead for "as much as
-comes out under these rules" and let the result be whatever size the squashed
-version actually is — sometimes that's a large cut, sometimes barely
-anything, if the document was already tight.
+Do not set a numeric cut target in the prompt: an agent told to cut a percentage will hit it regardless of whether the material supports it, and the last few points come out of the argument.
+Ask instead for "as much as comes out under these rules" and let the result be whatever size the squashed version actually is — sometimes that's a large cut, sometimes barely anything, if the document was already tight.
 
-"Already tight" is a real outcome and also the easiest wrong answer, so it has
-to be earned rather than asserted. A report claiming it must name the passages
-it considered and rejected, or it is indistinguishable from a pass that did
-not look. If Step 0's signals were checked and none fired, say so in the
-report.
+"Already tight" is a real outcome and also the easiest wrong answer, so it has to be earned rather than asserted.
+A report claiming it must name the passages it considered and rejected, or it is indistinguishable from a pass that did not look.
+If Step 0's signals were checked and none fired, say so in the report.
 
 ### Deliverable to request
 
-1. Every passage cut entirely, quoted by its first few words, with
-   Step 0 removals listed separately from register cuts — those are the ones
-   most worth a second look.
+1. Every passage cut entirely, quoted by its first few words, with Step 0 removals listed separately from register cuts — those are the ones most worth a second look.
 2. Anything it was unsure about, for review.
 
-Item 2 is the point. The uncertain calls are where substance gets lost, and
-they are cheap to review when listed.
+Item 2 is the point.
+The uncertain calls are where substance gets lost, and they are cheap to review when listed.
 
 ## Step 5: Review before accepting
 
-**First, integrity-check the target** — always, and especially if a run died
-partway. Diff against whatever the recovery copy from Step 2 turned out to
-be: for a tracked file, that's git; for an untracked/gitignored file (e.g.
-`ISSUE-*.md`) or a PR body, it's the scratchpad/in-memory "before" copy.
+**First, integrity-check the target** — always, and especially if a run died partway.
+Diff against whatever the recovery copy from Step 2 turned out to be: for a tracked file, that's git; for an untracked/gitignored file (e.g. `ISSUE-*.md`) or a PR body, it's the scratchpad/in-memory "before" copy.
 
 ```bash
 # tracked file:
@@ -246,33 +198,27 @@ grep -oE '`[A-Z][A-Za-z-]+[0-9]{4}-[a-z]{2}`' <file> | sort -u | diff /tmp/k_old
 grep -c '^## \|^### ' <file>
 ```
 
-Then spot-check a handful of the document's most distinctive numbers. A pass
-that silently dropped a citation or a figure is the failure mode worth
-catching, and it takes thirty seconds to rule out.
+Then spot-check a handful of the document's most distinctive numbers.
+A pass that silently dropped a citation or a figure is the failure mode worth catching, and it takes thirty seconds to rule out.
 
-Then read the report, not just the diff. Two checks:
+Then read the report, not just the diff.
+Two checks:
 
-- **Scan the Step 0 removals first.** A whole section is the expensive
-  mistake to get wrong in either direction. Restore one only if it states a
-  decision the document is making, rather than deliberation behind a decision
-  already stated elsewhere.
-- **Scan the register "cut entirely" list** for anything that was a policy
-  statement or a decision rather than framing. Restore those.
-- **Check flagged uncertainties.** The agent is right to be unsure about
-  short sharp lines that read as illustrative but are actually the crispest
-  statement of a rule.
+- **Scan the Step 0 removals first.**
+  A whole section is the expensive mistake to get wrong in either direction.
+  Restore one only if it states a decision the document is making, rather than deliberation behind a decision already stated elsewhere.
+- **Scan the register "cut entirely" list** for anything that was a policy statement or a decision rather than framing.
+  Restore those.
+- **Check flagged uncertainties.**
+  The agent is right to be unsure about short sharp lines that read as illustrative but are actually the crispest statement of a rule.
 
-If the agent reports it found little to cut because the remaining prose is
-fact-carrying, that is usually true and usually points at *structural*
-redundancy — the same argument restated in a design section, a gate, a risk,
-and a success criterion. That is a document-structure decision for the
-author, not something this pass should fix silently.
+If the agent reports it found little to cut because the remaining prose is fact-carrying, that is usually true and usually points at *structural* redundancy — the same argument restated in a design section, a gate, a risk, and a success criterion.
+That is a document-structure decision for the author, not something this pass should fix silently.
 
 ### Step 5a: Applying a PR body
 
-A PR body is visible to others the moment it's posted — per this repo's
-GitHub Action Sequencing rule, show the squashed body and get explicit
-approval before applying it. Once approved:
+A PR body is visible to others the moment it's posted — per this repo's GitHub Action Sequencing rule, show the squashed body and get explicit approval before applying it.
+Once approved:
 
 ```bash
 gh pr edit <number-or-branch> --body-file <scratchpad>/pr-body-squashed.md
@@ -280,5 +226,4 @@ gh pr edit <number-or-branch> --body-file <scratchpad>/pr-body-squashed.md
 
 ## Step 6: Report
 
-What came out by category, anything restored, and any structural redundancy
-the pass surfaced but did not touch.
+What came out by category, anything restored, and any structural redundancy the pass surfaced but did not touch.

--- a/skills/bip-scout/SKILL.md
+++ b/skills/bip-scout/SKILL.md
@@ -5,7 +5,8 @@ description: Check remote server CPU, memory, and GPU availability via SSH
 
 # /bip-scout
 
-Check remote server availability and resource usage. Runs `bip scout` to collect metrics, presents a human-readable summary, and answers follow-up questions by reasoning over the data.
+Check remote server availability and resource usage.
+Runs `bip scout` to collect metrics, presents a human-readable summary, and answers follow-up questions by reasoning over the data.
 
 ## Usage
 
@@ -79,7 +80,8 @@ The JSON output has this structure:
 - For offline servers: note them as unreachable
 - Highlight servers with low utilization (CPU < 20%, no busy GPUs) as good candidates
 
-**If a question was asked**, reason over the JSON data to answer it. Common question types:
+**If a question was asked**, reason over the JSON data to answer it.
+Common question types:
 
 | Question Type | How to Answer |
 |---------------|---------------|
@@ -104,20 +106,14 @@ After presenting results, briefly note that the user can ask follow-up questions
 
 ## Running After Scouting
 
-Once you've picked a host, three rules keep remote runs from silently breaking or
-clobbering a neighbor:
+Once you've picked a host, three rules keep remote runs from silently breaking or clobbering a neighbor:
 
-- **Never write `cd` in an ssh command string — pin the directory as a flag.** This is
-  a *hard mechanical rule*, not advice: composing `ssh host "cd /long/path && <cmd>"`,
-  the `cd /long/path && ` prefix gets silently dropped from what actually runs, so the
-  command executes in `$HOME` (→ "not a git repository", the wrong project resolved,
-  etc.). This recurs *every session* and prose warnings have not stopped it — the fix
-  is structural: make the working directory an un-droppable argument.
-  - **Single command → use the tool's dir flag:** `git -C <dir> …`,
-    `uv run --directory <dir> …`, `make -C <dir> …`, `tar -C <dir> …`,
-    `snakemake --directory <dir> …`.
-  - **Multi-step → write a script on the remote and run *that*.** Inside a here-doc'd
-    file, `cd` sits on its own line where it cannot be dropped:
+- **Never write `cd` in an ssh command string — pin the directory as a flag.**
+  This is a *hard mechanical rule*, not advice: composing `ssh host "cd /long/path && <cmd>"`, the `cd /long/path && ` prefix gets silently dropped from what actually runs, so the command executes in `$HOME` (→ "not a git repository", the wrong project resolved, etc.).
+  This recurs *every session* and prose warnings have not stopped it — the fix is structural: make the working directory an un-droppable argument.
+  - **Single command → use the tool's dir flag:** `git -C <dir> …`, `uv run --directory <dir> …`, `make -C <dir> …`, `tar -C <dir> …`, `snakemake --directory <dir> …`.
+  - **Multi-step → write a script on the remote and run *that*.**
+    Inside a here-doc'd file, `cd` sits on its own line where it cannot be dropped:
     ```bash
     ssh host 'cat > ~/run.sh <<"EOF"
     #!/bin/bash -l
@@ -126,24 +122,15 @@ clobbering a neighbor:
     EOF'
     ssh host 'tmux new-session -d -s job "bash ~/run.sh > ~/job.log 2>&1"'
     ```
-  - A bare inline `cd …` in the ssh argument string is *only* acceptable inside a
-    here-doc'd script body or a `make remote-tmux` window — never as a prefix you hand-compose.
-- **Scope the remote checkout to the clone corresponding to *your* repo.** Pass
-  `REMOTE_DIR` explicitly on every `make remote-sync`/`remote-run`/`remote-tmux` call
-  (or ssh to an explicit path). The config-derived default (`~/.config/dasm2/config.yaml`)
-  is the *same directory for every clone/worktree on the box*, so concurrent runs
-  overwrite each other's checkout — the rule `bip-conductor-spawn` states for EPIC slots
-  applies to any remote run. Don't trust that default to be non-empty either: the
-  Makefile resolves it with a bare `python3` that may lack the project's deps and
-  silently return `""` (`cd ` → "not a git repository"). **Before syncing, check the
-  target clone isn't dirty with unrelated in-progress work** (`git -C <dir> status`); if
-  it is, verify the changes are already in history (`git -C <dir> diff <pushed-HEAD>`
-  empty) *before* any `reset --hard`, and never discard uncommitted work you didn't create.
-- **Invoke through a login shell.** Use `make remote-tmux` (its tmux window is a login
-  shell) or `ssh <host> 'bash -lc "…"'` — not a bare
-  `ssh <host> "source .venv/bin/activate && …"`. A non-login shell skips lmod module
-  init, so a venv Python built against a module-provided libpython dies with
-  `libpython3.XX.so.1.0: cannot open shared object file`.
+  - A bare inline `cd …` in the ssh argument string is *only* acceptable inside a here-doc'd script body or a `make remote-tmux` window — never as a prefix you hand-compose.
+- **Scope the remote checkout to the clone corresponding to *your* repo.**
+  Pass `REMOTE_DIR` explicitly on every `make remote-sync`/`remote-run`/`remote-tmux` call (or ssh to an explicit path).
+  The config-derived default (`~/.config/dasm2/config.yaml`) is the *same directory for every clone/worktree on the box*, so concurrent runs overwrite each other's checkout — the rule `bip-conductor-spawn` states for EPIC slots applies to any remote run.
+  Don't trust that default to be non-empty either: the Makefile resolves it with a bare `python3` that may lack the project's deps and silently return `""` (`cd ` → "not a git repository").
+  **Before syncing, check the target clone isn't dirty with unrelated in-progress work** (`git -C <dir> status`); if it is, verify the changes are already in history (`git -C <dir> diff <pushed-HEAD>` empty) *before* any `reset --hard`, and never discard uncommitted work you didn't create.
+- **Invoke through a login shell.**
+  Use `make remote-tmux` (its tmux window is a login shell) or `ssh <host> 'bash -lc "…"'` — not a bare `ssh <host> "source .venv/bin/activate && …"`.
+  A non-login shell skips lmod module init, so a venv Python built against a module-provided libpython dies with `libpython3.XX.so.1.0: cannot open shared object file`.
 
 ## Error Handling
 

--- a/skills/bip-spawn-resume/SKILL.md
+++ b/skills/bip-spawn-resume/SKILL.md
@@ -5,19 +5,13 @@ description: Cold-start into a worktree/clone from a fresh conversation — read
 
 # /bip-spawn-resume
 
-For a fresh conversation dropped into a worktree/clone that was spawned
-(via `/bip-spawn` or `/bip-conductor-spawn`) and already has history — a PR
-out, review feedback waiting, an EPIC worker mid-phase, or something
-stalled. This skill's job is entirely **orientation**: gather context,
-report it, and stop. It does not decide what happens next — the most
-common case is a vetted PR the user wants to modify (directly, or via
-PR review comments), but treat that as a prior, not a restriction. Let
-the actual state (and the user) drive what happens after Step 2.
+For a fresh conversation dropped into a worktree/clone that was spawned (via `/bip-spawn` or `/bip-conductor-spawn`) and already has history — a PR out, review feedback waiting, an EPIC worker mid-phase, or something stalled.
+This skill's job is entirely **orientation**: gather context, report it, and stop.
+It does not decide what happens next — the most common case is a vetted PR the user wants to modify (directly, or via PR review comments), but treat that as a prior, not a restriction.
+Let the actual state (and the user) drive what happens after Step 2.
 
-This is **not** a crash-recovery tool — see `/bip-conductor-recover` for
-processes killed by a host reboot (`claude --resume`-based). This skill
-is for the ordinary case of a new conversation that needs to re-orient
-inside a slot that already has state.
+This is **not** a crash-recovery tool — see `/bip-conductor-recover` for processes killed by a host reboot (`claude --resume`-based).
+This skill is for the ordinary case of a new conversation that needs to re-orient inside a slot that already has state.
 
 ## Usage
 
@@ -25,8 +19,7 @@ inside a slot that already has state.
 /bip-spawn-resume
 ```
 
-Always run from inside the slot's worktree/clone, on its branch — `gh pr
-view` with no args resolves the PR (if any) from the current branch.
+Always run from inside the slot's worktree/clone, on its branch — `gh pr view` with no args resolves the PR (if any) from the current branch.
 
 ## Workflow
 
@@ -38,68 +31,42 @@ git log --oneline -10
 gh pr view --json number,url,state,isDraft,statusCheckRollup,reviews,comments 2>/dev/null
 ```
 
-If `.epic-status.json` exists (this is an EPIC slot), read it and
-`.epic-worklog.md` too — `phase`, `summary`, `blockers`, `stop_reason`,
-`lead_guidance`, `awaiting`. If the PR body (or the worklog) references
-an issue, `gh issue view N --comments` as well.
+If `.epic-status.json` exists (this is an EPIC slot), read it and `.epic-worklog.md` too — `phase`, `summary`, `blockers`, `stop_reason`, `lead_guidance`, `awaiting`.
+If the PR body (or the worklog) references an issue, `gh issue view N --comments` as well.
 
 ### Step 2: Branch on what you find, then report and STOP
 
-Don't act past this point without direction. Assemble a recap and present
-it, branching on state:
+Don't act past this point without direction.
+Assemble a recap and present it, branching on state:
 
-- **No PR yet, EPIC phase in progress** (`exploring`, `coding`, `testing`,
-  `awaiting-results`) — summarize the phase, the last worklog entry, and
-  any `blockers`/`awaiting` fields. Don't resume the ralph-loop or
-  continue coding on your own.
-- **`needs-human`** — lead the recap with `blockers` and `lead_guidance`;
-  this phase means a person's judgment was already requested.
+- **No PR yet, EPIC phase in progress** (`exploring`, `coding`, `testing`, `awaiting-results`) — summarize the phase, the last worklog entry, and any `blockers`/`awaiting` fields.
+  Don't resume the ralph-loop or continue coding on your own.
+- **`needs-human`** — lead the recap with `blockers` and `lead_guidance`; this phase means a person's judgment was already requested.
 - **`quality-gate`** — report gate iteration count and what's outstanding.
-- **PR open** — report CI status, unresolved review threads, and a diff
-  of what changed since the last commit/worklog entry (new comments or
-  reviews since then). Summarize new feedback content, don't just count
-  it.
-- **PR merged / phase `completed`** — say so plainly; there may be
-  nothing left, or the user may want a follow-up.
-- **Nothing recognizable** (no status file, no PR, just a branch) — say
-  so; report the branch/log state and let the user frame the task.
+- **PR open** — report CI status, unresolved review threads, and a diff of what changed since the last commit/worklog entry (new comments or reviews since then).
+  Summarize new feedback content, don't just count it.
+- **PR merged / phase `completed`** — say so plainly; there may be nothing left, or the user may want a follow-up.
+- **Nothing recognizable** (no status file, no PR, just a branch) — say so; report the branch/log state and let the user frame the task.
 
-End the recap with a direct question — what would you like to do? Do not
-guess at a next action (fix a comment, keep coding, open a PR, restart
-the loop) and do not restart any ralph-loop or autonomous machinery on
-your own initiative.
+End the recap with a direct question — what would you like to do?
+Do not guess at a next action (fix a comment, keep coding, open a PR, restart the loop) and do not restart any ralph-loop or autonomous machinery on your own initiative.
 
 ## After the user responds
 
-The user may hand you a specific instruction, point you at a PR comment
-or review thread, or just start talking through what they want changed.
-Whatever direction they give supersedes any default — there's no fixed
-Step 3+. A few things carry over regardless of what they ask for:
+The user may hand you a specific instruction, point you at a PR comment or review thread, or just start talking through what they want changed.
+Whatever direction they give supersedes any default — there's no fixed Step 3+.
+A few things carry over regardless of what they ask for:
 
-- Same branch, same PR — don't open a new branch or a second PR unless
-  told to.
-- Apply the DEFERRAL RULE from `/bip-conductor-spawn` if scope creep comes up
-  (fold small related fixes in; only defer clearly out-of-scope work).
-- Before pushing changes back out, re-run `/bip-pr-check` and
-  `/bip-pr-review`, same REVIEW TRIAGE as `/bip-conductor-spawn`.
-- Replying to or resolving someone else's review thread is a visible
-  GitHub action — draft it and confirm before posting/resolving, per the
-  standing GitHub Action Sequencing rule.
-- If this is an EPIC slot and the change is small and bounded, update
-  `.epic-status.json`/`.epic-worklog.md` directly rather than restarting
-  the ralph-loop. Only fall back to `/bip-conductor-spawn`'s RECOVERING
-  CONTEXT + ralph-loop protocol if the user actually wants ongoing
-  autonomous iteration, not just this one fix.
+- Same branch, same PR — don't open a new branch or a second PR unless told to.
+- Apply the DEFERRAL RULE from `/bip-conductor-spawn` if scope creep comes up (fold small related fixes in; only defer clearly out-of-scope work).
+- Before pushing changes back out, re-run `/bip-pr-check` and `/bip-pr-review`, same REVIEW TRIAGE as `/bip-conductor-spawn`.
+- Replying to or resolving someone else's review thread is a visible GitHub action — draft it and confirm before posting/resolving, per the standing GitHub Action Sequencing rule.
+- If this is an EPIC slot and the change is small and bounded, update `.epic-status.json`/`.epic-worklog.md` directly rather than restarting the ralph-loop.
+  Only fall back to `/bip-conductor-spawn`'s RECOVERING CONTEXT + ralph-loop protocol if the user actually wants ongoing autonomous iteration, not just this one fix.
 
 ## Notes
 
-- Distinct from `/bip-conductor-tuckin` (fleet-side, persists slot
-  status across many clones), `/bip-epic-tuckin` (topic-side, persists
-  EPIC dashboards), and `/bip-conductor-recover` (rebuilds processes
-  killed by a host reboot). This skill is for a plain new conversation
-  re-orienting inside one slot.
-- Its write-side counterpart is `/bip-spawn-tuckin` — run that before a
-  context reset so this skill has a clean commit/PR state to read on
-  the next cold-start.
-- Works for both EPIC slots (`.epic-status.json` present) and plain
-  `/bip-spawn` sessions (no status file — just a branch and maybe a PR).
+- Distinct from `/bip-conductor-tuckin` (fleet-side, persists slot status across many clones), `/bip-epic-tuckin` (topic-side, persists EPIC dashboards), and `/bip-conductor-recover` (rebuilds processes killed by a host reboot).
+  This skill is for a plain new conversation re-orienting inside one slot.
+- Its write-side counterpart is `/bip-spawn-tuckin` — run that before a context reset so this skill has a clean commit/PR state to read on the next cold-start.
+- Works for both EPIC slots (`.epic-status.json` present) and plain `/bip-spawn` sessions (no status file — just a branch and maybe a PR).

--- a/skills/bip-spawn-tuckin/SKILL.md
+++ b/skills/bip-spawn-tuckin/SKILL.md
@@ -5,18 +5,11 @@ description: Persist a plain (non-EPIC) spawn session's state before context res
 
 # /bip-spawn-tuckin
 
-Flush a `/bip-spawn` worker's state to durable storage before a context
-reset or session end. Run this when context is getting long or before
-stopping.
+Flush a `/bip-spawn` worker's state to durable storage before a context reset or session end.
+Run this when context is getting long or before stopping.
 
-This is the write-side counterpart to `/bip-spawn-resume` (which reads
-what this writes) and the single-slot, non-EPIC counterpart to
-`/bip-conductor-tuckin` (which persists the fleet's view across many
-slots). EPIC workers already have their own persistence built into
-`/bip-conductor-spawn`'s STOPPING POINTS protocol (`.epic-status.json` +
-`.epic-worklog.md` + issue-lead invocation) — if `.epic-status.json`
-exists in this worktree/clone, this is an EPIC slot: stop and use that
-protocol instead of this skill.
+This is the write-side counterpart to `/bip-spawn-resume` (which reads what this writes) and the single-slot, non-EPIC counterpart to `/bip-conductor-tuckin` (which persists the fleet's view across many slots).
+EPIC workers already have their own persistence built into `/bip-conductor-spawn`'s STOPPING POINTS protocol (`.epic-status.json` + `.epic-worklog.md` + issue-lead invocation) — if `.epic-status.json` exists in this worktree/clone, this is an EPIC slot: stop and use that protocol instead of this skill.
 
 ## Usage
 
@@ -34,13 +27,9 @@ Run from inside the slot's worktree/clone, on its branch.
 test -f .epic-status.json && echo "EPIC slot — use bip-conductor-spawn's STOPPING POINTS protocol instead"
 ```
 
-If it exists, this is an EPIC slot. If a ralph-loop/issue-lead cycle is
-actually running, use bip-conductor-spawn's STOPPING POINTS protocol. If
-you're just manually pausing a conversational EPIC slot (no active
-autonomous loop), the lightweight version is enough: update
-.epic-status.json/.epic-worklog.md in place and post the relevant
-PR/issue comments yourself — no need to spawn an issue-lead for a
-simple pause.
+If it exists, this is an EPIC slot.
+If a ralph-loop/issue-lead cycle is actually running, use bip-conductor-spawn's STOPPING POINTS protocol.
+If you're just manually pausing a conversational EPIC slot (no active autonomous loop), the lightweight version is enough: update .epic-status.json/.epic-worklog.md in place and post the relevant PR/issue comments yourself — no need to spawn an issue-lead for a simple pause.
 
 ### Step 1: Commit local work
 
@@ -48,17 +37,12 @@ simple pause.
 git status --short
 ```
 
-Plain spawn sessions have no worklog file — the commit log and PR are
-the only durable record a fresh conversation can read. Don't leave
-uncommitted changes behind:
+Plain spawn sessions have no worklog file — the commit log and PR are the only durable record a fresh conversation can read.
+Don't leave uncommitted changes behind:
 
-- Coherent, working changes → commit them with a clear message
-  describing what and why (this doubles as the "worklog entry" that
-  `/bip-spawn-resume`'s `git log --oneline -10` will surface).
-- Genuinely unfinished/broken state (mid-experiment, doesn't build) →
-  either finish it enough to commit safely, or tell the user explicitly
-  what's uncommitted and why, and let them decide. Don't silently
-  commit broken code or silently discard it.
+- Coherent, working changes → commit them with a clear message describing what and why (this doubles as the "worklog entry" that `/bip-spawn-resume`'s `git log --oneline -10` will surface).
+- Genuinely unfinished/broken state (mid-experiment, doesn't build) → either finish it enough to commit safely, or tell the user explicitly what's uncommitted and why, and let them decide.
+  Don't silently commit broken code or silently discard it.
 
 ### Step 2: Push the branch
 
@@ -67,8 +51,7 @@ git push
 ```
 
 (`git push -u origin <branch>` if this branch has never been pushed.)
-A branch that only exists locally in a tmux pane doesn't survive the
-pane closing or the host restarting — push it.
+A branch that only exists locally in a tmux pane doesn't survive the pane closing or the host restarting — push it.
 
 ### Step 3: Sync the PR (if one exists)
 
@@ -76,27 +59,16 @@ pane closing or the host restarting — push it.
 gh pr view --json number,url,body,state 2>/dev/null
 ```
 
-If a PR is open, make sure its body reflects where things actually
-stand right now — apply `PROSE-DISCIPLINE.md` before writing anything.
+If a PR is open, make sure its body reflects where things actually stand right now — apply `PROSE-DISCIPLINE.md` before writing anything.
 Two cases:
 
-- **Session reached a real stopping point (done, or blocked on the
-  user)** — rewrite the body to read as current state (premise,
-  results, interpretation), not as a log of how it got there. Same
-  discipline as the quality-gate loop in `/bip-conductor-spawn`: no growing
-  "History" section.
-- **Session is pausing mid-work, PR body would go stale if rewritten
-  as "done"** — leave the body alone and instead add a PR comment
-  describing what's done, what's left, and any open question, so
-  `/bip-spawn-resume`'s "PR open" branch (which reads comments) picks
-  it up. Don't describe unfinished work in body prose as if it were
-  complete.
+- **Session reached a real stopping point (done, or blocked on the user)** — rewrite the body to read as current state (premise, results, interpretation), not as a log of how it got there.
+  Same discipline as the quality-gate loop in `/bip-conductor-spawn`: no growing "History" section.
+- **Session is pausing mid-work, PR body would go stale if rewritten as "done"** — leave the body alone and instead add a PR comment describing what's done, what's left, and any open question, so `/bip-spawn-resume`'s "PR open" branch (which reads comments) picks it up.
+  Don't describe unfinished work in body prose as if it were complete.
 
-If no PR exists yet: only open one if the work is far enough along that
-a draft PR is a better home for "where things stand" than a bare
-branch. If it's a few commits into early exploration, leave it as a
-branch — don't force a PR into existence just to have somewhere to
-write status.
+If no PR exists yet: only open one if the work is far enough along that a draft PR is a better home for "where things stand" than a bare branch.
+If it's a few commits into early exploration, leave it as a branch — don't force a PR into existence just to have somewhere to write status.
 
 ### Step 4: Report
 

--- a/skills/bip-spawn/SKILL.md
+++ b/skills/bip-spawn/SKILL.md
@@ -9,7 +9,8 @@ Open a tmux window for GitHub issue or PR review.
 
 ## Instructions
 
-**Just run `bip spawn` directly.** Do not attempt to construct `claude` or `tmux` commands yourself — `bip spawn` handles all of that.
+**Just run `bip spawn` directly.**
+Do not attempt to construct `claude` or `tmux` commands yourself — `bip spawn` handles all of that.
 
 ```bash
 bip spawn org/repo#123
@@ -26,22 +27,19 @@ bip spawn org/repo#123 --prompt "Rebase and fix conflicts"
 
 ## Common modes
 
-There are two distinct ways to use `bip spawn`. **Pick deliberately**:
+There are two distinct ways to use `bip spawn`.
+**Pick deliberately**:
 
-- **Review** (default, no `--prompt`): opens a Claude session with the
-  issue or PR context loaded and waits at an empty prompt. Use this
-  when *you* will drive the next steps in the spawned window.
-- **Handoff-to-work**: pass `--prompt "/bip-issue-work <N>"` (for
-  issues) or `--prompt "/bip-pr-review"` (for PRs). The spawned Claude
-  starts the workflow autonomously — the right choice when the parent
-  session is delegating implementation and won't be steering.
+- **Review** (default, no `--prompt`): opens a Claude session with the issue or PR context loaded and waits at an empty prompt.
+  Use this when *you* will drive the next steps in the spawned window.
+- **Handoff-to-work**: pass `--prompt "/bip-issue-work <N>"` (for issues) or `--prompt "/bip-pr-review"` (for PRs).
+  The spawned Claude starts the workflow autonomously — the right choice when the parent session is delegating implementation and won't be steering.
 
 Example handoff:
 
-    bip spawn matsengrp/phyz#1453 --prompt "/bip-issue-work 1453"
+bip spawn matsengrp/phyz#1453 --prompt "/bip-issue-work 1453"
 
-If you're spawning from inside a `/bip-pr-land` or similar handoff
-context, the handoff form is almost always what you want.
+If you're spawning from inside a `/bip-pr-land` or similar handoff context, the handoff form is almost always what you want.
 
 ## Requirements
 
@@ -54,10 +52,8 @@ context, the handoff form is almost always what you want.
 
 ## Worktree mode (opt-in)
 
-By default, `bip spawn` opens its tmux window in the canonical clone of
-the repo — every spawn shares one working tree. To get one linked git
-worktree per issue instead (so concurrent spawns don't share a branch
-checkout), add a `layout:` block to `~/.config/bip/config.yml`:
+By default, `bip spawn` opens its tmux window in the canonical clone of the repo — every spawn shares one working tree.
+To get one linked git worktree per issue instead (so concurrent spawns don't share a branch checkout), add a `layout:` block to `~/.config/bip/config.yml`:
 
 ```yaml
 layout:
@@ -70,7 +66,5 @@ layout:
 Per-repo overrides live in `sources.yml` (see `docs/guides/layout.md`).
 With no `layout:` block, behavior is identical to before issue #149.
 
-When worktree mode fires, `bip spawn` runs `git worktree add` from the
-canonical clone on a fresh branch named `<N>-<slug>`, and the spawned
-tmux window opens in the new worktree. `bip pr-land` later detects the
-worktree, lands the PR from the primary clone, and removes the worktree.
+When worktree mode fires, `bip spawn` runs `git worktree add` from the canonical clone on a fresh branch named `<N>-<slug>`, and the spawned tmux window opens in the new worktree.
+`bip pr-land` later detects the worktree, lands the PR from the primary clone, and removes the worktree.

--- a/skills/bip-tmux/SKILL.md
+++ b/skills/bip-tmux/SKILL.md
@@ -6,7 +6,8 @@ allowed-tools: Bash
 
 # /bip-tmux
 
-Open a file in an 80%×80% tmux popup using `less` for scrolling. Press `q` to close.
+Open a file in an 80%×80% tmux popup using `less` for scrolling.
+Press `q` to close.
 
 ## Usage
 
@@ -22,4 +23,7 @@ Run:
 tmux display-popup -w 80% -h 80% -E -- less <file>
 ```
 
-That's it. No confirmation needed — just run it. After the command completes, stop and wait for the user to respond. Do not summarize the file contents, ask follow-up questions, or take any further action.
+That's it.
+No confirmation needed — just run it.
+After the command completes, stop and wait for the user to respond.
+Do not summarize the file contents, ask follow-up questions, or take any further action.


### PR DESCRIPTION
## Summary
PR #191 hard-wrapped its prose edits at ~70 characters, then a review round caught that the wrapping was actively hiding defects: three of the reviewer's `grep` checks against the issue's own success criteria returned false negatives because the matched phrase spanned a line break. This applies that PR's fix (semantic line breaks: one sentence per line) to the rest of `skills/`.

- Reflowed all 43 `skills/*/SKILL.md` files: every prose paragraph, list item, and blockquote now breaks after each sentence rather than at a fixed column. Code fences and table rows are untouched — verified byte-identical before/after using CommonMark-correct fence-closing semantics (a closing fence must be bare backticks with no info string).
- Verified zero wording changes: the multiset of words (ignoring bare `>` blockquote blank-line markers) is identical between the original and reflowed version of every file.
- Added `skills/CONVENTIONS.md` documenting the convention and its explicit carve-out from `PROSE-DISCIPLINE.md` (which governs issue/PR/comment bodies, not skill source files).
- Fixed one pre-existing indentation slip in `skills/bip-conductor-spawn/SKILL.md` surfaced by this pass: a trailing line after a lettered sub-list (`a./b./c.`) had lost its indentation.
- After #204 merged (fixing a pre-existing nested-fence bug in `bip-conductor-spawn/SKILL.md`), rebasing this branch surfaced a second, related bug: my reflow script's fence tracker used simple alternating open/close detection with no memory of which marker paired with which, so once #204's fix restored the file's true fence structure, two regions of that same file — the full "Prompt file" template and the "Common context additions" example blocks — had been mis-classified as prose and incorrectly reflowed. Both regions are now restored to byte-identical original content (verified against `origin/main` post-#204), and a full 43-file re-sweep after the fix found no other file affected.

Closes #192

## Test plan
- `awk '{print length}' skills/*/SKILL.md | sort -rn | uniq -c` shows no more spike at the old ~70-char hard-wrap column (was 239 lines at exactly 70 chars pre-reflow; post-reflow the length distribution is flat).
- Re-ran PR #191's own review-round criterion check: `grep -qF "spawn prompt or the issue body" skills/bip-conductor-poll/SKILL.md` (the successor to `bip-epic-poll` after the epic/conductor split) now matches directly — previously this needed `tr '\n' ' '` first because the phrase spanned a hard-wrap line break.
- Table and code-fence content confirmed byte-identical before/after across all 43 files (script-verified, including the `bip-conductor-spawn` fix, not spot-checked).
- `go vet ./...` clean; build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)