### PR TITLE
Fix nested-fence bug in skills/bip-conductor-spawn/SKILL.md

### DIFF
--- a/skills/bip-conductor-spawn/SKILL.md
+++ b/skills/bip-conductor-spawn/SKILL.md
@@ -225,7 +225,7 @@ target remote host. Without this annotation step those fleet warnings
 never make it into the prompt at all.
 
 **Prompt file** (written by conductor to /tmp/spawn-N.txt):
-```
+````
 You are working on GitHub issue #N TITLE.
 
 First, run this command to start the iteration loop:
@@ -459,7 +459,7 @@ instructions, remote execution notes, dependencies, key files)
 
 Now read the issue and begin work:
 /bip-issue-work N
-```
+````
 
 ### Common context additions
 


### PR DESCRIPTION
## Summary
The `**Prompt file**` template in `skills/bip-conductor-spawn/SKILL.md` (the literal text written to a spawned worker's prompt file) does not render as one contiguous code block on GitHub today, because its outer 3-backtick fence contains two nested example blocks using the same delimiter (a `PHONE NOTIFICATION` bash snippet and the `FINAL RECAP` template).

- Per CommonMark, a closing fence can't carry an info string, so `` ```bash `` never closes the outer fence — but the first bare `` ``` `` after it does, closing the outer fence early. Everything from `STOPPING POINTS` through `IMPORTANT CONTEXT` then renders as ordinary prose instead of literal template content, even though it's meant to be copy-pasted verbatim into a worker's prompt file.
- Fix: bump the outer fence (and its true closing marker, right before `### Common context additions`) from 3 backticks to 4. A 4-backtick fence is immune to nested 3-backtick blocks.
- Verified via a CommonMark-correct fence parser: before the fix, the block containing `You are working on GitHub issue #N TITLE.` is 81 lines and doesn't include `STOPPING POINTS` or `/bip-issue-work N`; after, it's 233 lines and includes both — the whole template is now one block.
- Word-multiset check confirms the only tokens that changed are the two fence delimiters themselves (`` ``` `` → `` ```` ``); no other content touched.

Closes #203

## Test plan
- Rendered the file with a CommonMark-correct fence-boundary parser before/after (see Summary) — the prompt-file block goes from 81 lines (missing most of the template) to 233 lines (complete, from `You are working on GitHub issue #N TITLE.` to `/bip-issue-work N`).
- `git diff --word-diff` shows only the two fence-delimiter lines changing.
- `go vet ./...` clean (docs-only change; no Go files touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)