### PR TITLE
Push completion notifications from worker to conductor and conductor to epic

### DIFF
--- a/skills/bip-conductor-poll/SKILL.md
+++ b/skills/bip-conductor-poll/SKILL.md
@@ -85,12 +85,8 @@ This tells the conductor what the workers are doing without having to read full 
 
 **Flag needs-human and completed** — if any clone has `phase: "needs-human"` (or legacy `blocked`) or `phase: "completed"`, highlight it prominently.
 These require conductor attention.
-**Ring the terminal bell and send a phone notification** so the user notices even if away:
-```bash
-printf '\a'
-NTFY_TOPIC=$(grep ntfy_topic ~/.config/bip/config.yml | awk '{print $2}')
-[ -n "$NTFY_TOPIC" ] && curl -s -H "Title: bip epic" -d "<clone> <phase> (<issue>)" "ntfy.sh/$NTFY_TOPIC" > /dev/null
-```
+Run `ListAgents` for an addressable epic session and, if one exists, `SendMessage` it the issue number and phase so `/bip-epic` can re-poll and update the EPIC body without waiting for its own cadence.
+If no epic session is addressable, this is a no-op — `/bip-epic`'s independent `gh` polling remains the fallback path.
 
 **Only report active clones** — clones with a tmux window that are actually doing something.
 Don't list completed or idle clones; that's noise.

--- a/skills/bip-conductor-poll/SKILL.md
+++ b/skills/bip-conductor-poll/SKILL.md
@@ -23,7 +23,11 @@ For periodic auto-polling: `/loop 10m /bip-conductor-poll`
 
 ## What to check
 
-Two things stay in the primary because they're cheap and structured:
+Three things stay in the primary because they're cheap and structured:
+
+**Refresh the completion-push address** — resolve `CLONE_ROOT` and rewrite `$CLONE_ROOT/.conductor-session` with this session's current `ListAgents` name.
+This is the file workers read to push a `needs-human`/`completed` notification without guessing among `ListAgents` rows — see `/bip-conductor`'s Conventions section ("Completion pushes") for why.
+Cheap (one `ListAgents` self-lookup, one file write) and bounds how stale the address can get between conductor cold starts.
 
 **Notifications log tail** — if `bip epic watch` is running, it appends one JSONL line per phase transition to `.epic-notifications.log` in the conductor cwd.
 The state file `/tmp/.epic-poll-last-read` records the previous poll time as Unix seconds; pass the elapsed window to `--since`:
@@ -85,8 +89,8 @@ This tells the conductor what the workers are doing without having to read full 
 
 **Flag needs-human and completed** — if any clone has `phase: "needs-human"` (or legacy `blocked`) or `phase: "completed"`, highlight it prominently.
 These require conductor attention.
-Run `ListAgents` for an addressable epic session and, if one exists, `SendMessage` it the issue number and phase so `/bip-epic` can re-poll and update the EPIC body without waiting for its own cadence.
-If no epic session is addressable, this is a no-op — `/bip-epic`'s independent `gh` polling remains the fallback path.
+Read `$CLONE_ROOT/.epic-session` and, if present, `SendMessage` that address the issue number and phase so `/bip-epic` can re-poll and update the EPIC body without waiting for its own cadence.
+If the file is absent or the send fails, this is a no-op — `/bip-epic`'s independent `gh` polling remains the fallback path.
 
 **Only report active clones** — clones with a tmux window that are actually doing something.
 Don't list completed or idle clones; that's noise.

--- a/skills/bip-conductor-spawn/SKILL.md
+++ b/skills/bip-conductor-spawn/SKILL.md
@@ -250,13 +250,12 @@ If you launch a long-running experiment:
 4. After 3 consecutive check failures, set stop_reason to
    mechanical-blocker and invoke the lead
 
-PHONE NOTIFICATION — When you set phase to needs-human or completed,
-ring the terminal bell and send a push notification so the user notices:
-```bash
-printf '\a'
-NTFY_TOPIC=$(grep ntfy_topic ~/.config/bip/config.yml | awk '{print $2}')
-[ -n "$NTFY_TOPIC" ] && curl -s -H "Title: bip epic" -d "#N <phase>: <one-line summary>" "ntfy.sh/$NTFY_TOPIC" > /dev/null
-```
+PUSH NOTIFICATION — When you set phase to needs-human or completed, run
+`ListAgents` for an addressable conductor session and, if one exists,
+`SendMessage` it a one-line notification (issue number, phase, one-line
+summary) so the conductor doesn't have to wait for its next poll cycle.
+`.epic-status.json` is written regardless, so `/bip-conductor-poll` and
+`bip epic watch` remain the fallback when no conductor is addressable.
 Do this EVERY time you write needs-human or completed to .epic-status.json.
 
 STOPPING POINTS — When you reach a natural stopping point:

--- a/skills/bip-conductor-spawn/SKILL.md
+++ b/skills/bip-conductor-spawn/SKILL.md
@@ -250,13 +250,20 @@ If you launch a long-running experiment:
 4. After 3 consecutive check failures, set stop_reason to
    mechanical-blocker and invoke the lead
 
-PUSH NOTIFICATION — When you set phase to needs-human or completed, run
-`ListAgents` for an addressable conductor session and, if one exists,
-`SendMessage` it a one-line notification (issue number, phase, one-line
-summary) so the conductor doesn't have to wait for its next poll cycle.
-`.epic-status.json` is written regardless, so `/bip-conductor-poll` and
-`bip epic watch` remain the fallback when no conductor is addressable.
-Do this EVERY time you write needs-human or completed to .epic-status.json.
+PUSH NOTIFICATION — When you set phase to needs-human or completed, read
+`$CLONE_ROOT/.conductor-session` (resolve `CLONE_ROOT` from
+`.epic-config.json` the usual way). If it exists, `SendMessage` that exact
+address a one-line notification (issue number, phase, one-line summary)
+so the conductor doesn't have to wait for its next poll cycle. Do NOT
+`ListAgents` and pick a plausible-looking row yourself — session names
+derive from working directory, so every other worker sharing your clone
+root shares your name prefix, and guessing risks messaging the wrong
+live session (see `/bip-conductor`'s Conventions section, "Completion
+pushes"). If the file is missing or the send fails (address went stale
+since the conductor's last refresh), skip silently — `.epic-status.json`
+is written regardless, so `/bip-conductor-poll` and `bip epic watch`
+remain the fallback. Do this EVERY time you write needs-human or
+completed to .epic-status.json.
 
 STOPPING POINTS — When you reach a natural stopping point:
 1. Append a worklog entry describing what you did and why you stopped

--- a/skills/bip-conductor/SKILL.md
+++ b/skills/bip-conductor/SKILL.md
@@ -92,6 +92,7 @@ Instead, each role self-registers its own current address in a file only it writ
 - A name is taken from `ListAgents`' own "This session is ..." row for the caller — never guessed from another row — so the file is always exact for whoever last refreshed it.
 
 To push, a role reads the other's file for the exact address and `SendMessage`s it, treating a missing file or a failed send (the named session is no longer reachable — the address drifted since the last refresh) as "not addressable right now": skip silently, fall back to the file-based state (`.epic-status.json`, `.epic-notifications.log`, `gh` polling), and never retry-loop or fall back to scanning `ListAgents` for a substitute.
+A failed `SendMessage` to a drifted name comes back with `success: false` and a "Did you mean: ..." suggestion list of other live sessions — **never act on that suggestion**; trying it is exactly the guessing this design exists to avoid, just prompted by the tool instead of self-initiated.
 The residual risk this doesn't close — an unrelated session claiming the exact same name string in the gap before a refresh — is accepted as rare; the push is a latency optimization, never a hard dependency.
 
 ## Configuration

--- a/skills/bip-conductor/SKILL.md
+++ b/skills/bip-conductor/SKILL.md
@@ -62,9 +62,6 @@ Issueless spawns break EPIC tracking, PR linking, and conductor polling.
 `ListAgents`/`SendMessage` reach other local Claude tmux sessions and let the conductor push an immediate correction to a live worker without killing and respawning its tmux window.
 Whether a correction needs this channel at all, and whether it's durable or transient, is `/bip-epic`'s call (see that skill's "Correcting a live worker" section) — this section covers the mechanics once the epic has decided and drafted the line, plus the case where the conductor itself spots something worth flagging (a fleet fact, not a scope change — always message-only, since fleet facts never redefine the deliverable).
 
-The same channel also carries completion signals the other direction: a worker pushes the conductor on reaching `needs-human`/`completed` (skills/bip-conductor-spawn/SKILL.md, PUSH NOTIFICATION step), and the conductor pushes the epic on observing the same transition (Step 7 below, and skills/bip-conductor-poll/SKILL.md's "Flag needs-human and completed" section).
-Those pushes share every addressability caveat below — run `ListAgents` first, fall back to the file-based state (`.epic-status.json`, `.epic-notifications.log`, `gh` polling) when no target is addressable, and never treat the push as a hard dependency.
-
 - **Send the correction directly — that is the channel's purpose.**
   No status-file write is a precondition for messaging.
   State the change in at least one line; a bare pointer ("re-read `lead_guidance`") is a no-op for a worker that already reads the status file every step, and it strips the priority signal (drop what you're doing vs. finish the current step).
@@ -81,6 +78,21 @@ Those pushes share every addressability caveat below — run `ListAgents` first,
 - Do not use `SendMessage` to route around the conductor's own restrictions (cross-session permission laundering) — the "should not write code or create branches for numbered issues" rule above applies equally to instructions phrased as a message to a worker.
 - **When not to nudge**: a worker in `awaiting-results` with a live `check_cmd` needs no ping.
   Use `notify_when_idle: true` instead of "tell me when this worker finishes" — it works only from the main conversation, only for sessions on this machine, and it is one-shot (omit `message` for a pure subscription that costs the target nothing; a subscription that never fires reports as expired).
+
+### Completion pushes: self-registered addresses, not ListAgents guessing
+
+The corrections channel above works because a human — the epic operator, or the conductor itself — is watching `ListAgents`' output and picking the right row before sending; a wrong or ambiguous name gets caught before it does damage.
+Completion pushes fire the other direction (worker → conductor, conductor → epic) with no human watching at send time, so they cannot reuse "run `ListAgents`, pick a plausible row": session names derive from working directory, so every session sharing a clone directory shares a name prefix, and a display name can itself drift mid-session (it can become a fragment of the session's own first message).
+Guessing among rows under those conditions doesn't just risk finding nothing — it risks silently messaging the *wrong* live session, a correctness failure the old dead bell/`ntfy` code could never produce.
+
+Instead, each role self-registers its own current address in a file only it writes, so the reader never has to disambiguate:
+
+- The conductor writes its own name to `$CLONE_ROOT/.conductor-session` (Step 1 at cold start, refreshed at the top of every `/bip-conductor-poll` run and immediately before reacting to a transition in Step 7 below).
+- `/bip-epic` writes its own name to `$CLONE_ROOT/.epic-session` the same way (see that skill's Step 1).
+- A name is taken from `ListAgents`' own "This session is ..." row for the caller — never guessed from another row — so the file is always exact for whoever last refreshed it.
+
+To push, a role reads the other's file for the exact address and `SendMessage`s it, treating a missing file or a failed send (the named session is no longer reachable — the address drifted since the last refresh) as "not addressable right now": skip silently, fall back to the file-based state (`.epic-status.json`, `.epic-notifications.log`, `gh` polling), and never retry-loop or fall back to scanning `ListAgents` for a substitute.
+The residual risk this doesn't close — an unrelated session claiming the exact same name string in the gap before a refresh — is accepted as rare; the push is a latency optimization, never a hard dependency.
 
 ## Configuration
 
@@ -148,6 +160,8 @@ There is no separate conductor clone — `clone_root` is just where worktrees ar
 Then create `.epic-config.json` with their answers and proceed.
 
 All subsequent steps use values from this config — never hardcode paths or clone names.
+
+**Self-register for completion pushes**: resolve `CLONE_ROOT` and write this session's own `ListAgents` name (the "This session is ..." row) as the sole line of `$CLONE_ROOT/.conductor-session` — see the Conventions section's "Completion pushes" for why this file exists and how it's kept fresh.
 
 ### Step 2: Pull main
 
@@ -254,7 +268,7 @@ The watcher runs forever, exits cleanly on SIGTERM, and emits one event per real
 To also receive events as Claude Code notifications when that pipeline is reliable, additionally start a Monitor with `command: tail -F .epic-notifications.log` and `persistent: true`.
 The notifications log is the contract; Monitor is a latency optimization, not a correctness requirement.
 
-When a transition arrives showing `needs-human` or `completed`, the conductor should react immediately — read the slot's status, check the lead guidance, run `ListAgents` for an addressable epic session and `SendMessage` it the issue number and phase if one exists (same addressability mechanics as "Correcting a live worker" above, just in the other direction), and either propose the next action or flag it for the user.
+When a transition arrives showing `needs-human` or `completed`, the conductor should react immediately: read the slot's status, check the lead guidance, refresh `$CLONE_ROOT/.conductor-session` (see "Completion pushes" in Conventions — this is one of the moments that keeps it fresh), then read `$CLONE_ROOT/.epic-session` and `SendMessage` that address the issue number and phase if the file is present — skip silently if it's absent or the send fails — and either propose the next action or flag it for the user.
 
 > "Slot monitor started — phase transitions are streaming to `.epic-notifications.log`.
 > Use `/bip-conductor-poll` for a full reconciliation sweep when needed."

--- a/skills/bip-conductor/SKILL.md
+++ b/skills/bip-conductor/SKILL.md
@@ -62,6 +62,9 @@ Issueless spawns break EPIC tracking, PR linking, and conductor polling.
 `ListAgents`/`SendMessage` reach other local Claude tmux sessions and let the conductor push an immediate correction to a live worker without killing and respawning its tmux window.
 Whether a correction needs this channel at all, and whether it's durable or transient, is `/bip-epic`'s call (see that skill's "Correcting a live worker" section) — this section covers the mechanics once the epic has decided and drafted the line, plus the case where the conductor itself spots something worth flagging (a fleet fact, not a scope change — always message-only, since fleet facts never redefine the deliverable).
 
+The same channel also carries completion signals the other direction: a worker pushes the conductor on reaching `needs-human`/`completed` (skills/bip-conductor-spawn/SKILL.md, PUSH NOTIFICATION step), and the conductor pushes the epic on observing the same transition (Step 7 below, and skills/bip-conductor-poll/SKILL.md's "Flag needs-human and completed" section).
+Those pushes share every addressability caveat below — run `ListAgents` first, fall back to the file-based state (`.epic-status.json`, `.epic-notifications.log`, `gh` polling) when no target is addressable, and never treat the push as a hard dependency.
+
 - **Send the correction directly — that is the channel's purpose.**
   No status-file write is a precondition for messaging.
   State the change in at least one line; a bare pointer ("re-read `lead_guidance`") is a no-op for a worker that already reads the status file every step, and it strips the priority signal (drop what you're doing vs. finish the current step).
@@ -251,7 +254,7 @@ The watcher runs forever, exits cleanly on SIGTERM, and emits one event per real
 To also receive events as Claude Code notifications when that pipeline is reliable, additionally start a Monitor with `command: tail -F .epic-notifications.log` and `persistent: true`.
 The notifications log is the contract; Monitor is a latency optimization, not a correctness requirement.
 
-When a transition arrives showing `needs-human` or `completed`, the conductor should react immediately — read the slot's status, check the lead guidance, and either propose the next action or flag it for the user.
+When a transition arrives showing `needs-human` or `completed`, the conductor should react immediately — read the slot's status, check the lead guidance, run `ListAgents` for an addressable epic session and `SendMessage` it the issue number and phase if one exists (same addressability mechanics as "Correcting a live worker" above, just in the other direction), and either propose the next action or flag it for the user.
 
 > "Slot monitor started — phase transitions are streaming to `.epic-notifications.log`.
 > Use `/bip-conductor-poll` for a full reconciliation sweep when needed."

--- a/skills/bip-epic/SKILL.md
+++ b/skills/bip-epic/SKILL.md
@@ -50,6 +50,10 @@ cat .epic-config.json
 
 If this project uses the auto-memory directory, also read its MEMORY.md for topic-level context from previous sessions (decisions, findings, what's next) — some setups deliberately don't use it (e.g. because the directory is keyed by working directory and invisible to other clones), in which case skip this and rely on EPIC bodies and issue history instead.
 
+**Self-register for completion pushes**: resolve `CLONE_ROOT` and write this session's own `ListAgents` name (the "This session is ..." row) as the sole line of `$CLONE_ROOT/.epic-session` — this is how the conductor finds the epic to push a `needs-human`/`completed` notification without guessing among `ListAgents` rows.
+See `/bip-conductor`'s Conventions section ("Completion pushes") for the full mechanics and why guessing isn't safe here.
+Re-run this write every time `/bip-epic` starts a fresh poll cycle, since the address can drift mid-session.
+
 ### Step 2: Fan out scanners
 
 Dispatch two groups of `general-purpose` subagents in parallel — single message, multiple `Agent` tool calls.

--- a/skills/bip-ms-poll/SKILL.md
+++ b/skills/bip-ms-poll/SKILL.md
@@ -130,13 +130,6 @@ If during polling you notice gaps — an experiment that should be run, a compar
 
 4. **Proposed actions**: Concrete list — import figure X, open notebook Y, draft text for finding Z, raise issue for gap W.
 
-Ring the terminal bell and send a phone notification if a major new result arrives (new figure or quantitative finding):
-```bash
-printf '\a'
-NTFY_TOPIC=$(grep ntfy_topic ~/.config/bip/config.yml | awk '{print $2}')
-[ -n "$NTFY_TOPIC" ] && curl -s -H "Title: bip ms" -d "New result: <description>" "ntfy.sh/$NTFY_TOPIC" > /dev/null
-```
-
 ### Verify state before reporting
 
 When mentioning any PR or issue in the poll output, always verify its current state programmatically (`gh pr view --json state`, `gh issue view --json state`) rather than relying on earlier poll results or conversation memory.


### PR DESCRIPTION
## Summary
Workers and the conductor push completion signals (`needs-human`/`completed`) directly to an addressable peer session instead of relying solely on file-based polling — replacing a dead bell/`ntfy` block that never reached anyone (`ntfy_topic` was never configured in `~/.config/bip/config.yml`).

- **Worker → conductor**: a worker reaching `needs-human`/`completed` reads `$CLONE_ROOT/.conductor-session` and `SendMessage`s that exact address (`skills/bip-conductor-spawn/SKILL.md`).
- **Conductor → epic**: the conductor does the same into `$CLONE_ROOT/.epic-session` on observing the same transition (`skills/bip-conductor-poll/SKILL.md`, `skills/bip-conductor/SKILL.md` Step 7).
- Each side **self-registers its own address** rather than the receiver guessing it. Session names derive from working directory, so sessions sharing a clone root share a name prefix, and a display name can drift mid-session — "run `ListAgents`, pick the addressable row" only works when a human is watching the pick, which is how the existing correction channel gets away with that wording. A completion push fires unsupervised, so guessing risks silently messaging the wrong live session. The conductor writes `.conductor-session` at cold start and every poll cycle; `/bip-epic` writes `.epic-session` the same way. This is documented in `skills/bip-conductor/SKILL.md`'s Conventions section ("Completion pushes").
- Neither push is a hard dependency: a missing registration file or a failed send (stale address) falls back silently to the existing `.epic-status.json` / `.epic-notifications.log` / `gh`-polling path.
- Removed the same dead bell/`ntfy` block from `skills/bip-ms-poll/SKILL.md` (manuscript polling) — no replacement, since that skill has no conductor/epic split to push into.

Closes #205

## Test plan
No automated test — this is a skill/prompt change. Verify by hand in a live fleet session:
- Confirm `$CLONE_ROOT/.conductor-session` and `.epic-session` are written at cold start and refreshed on each poll cycle.
- Drive a worker to `needs-human`/`completed` with an addressable conductor session; confirm the conductor receives the push and no bell/`curl` fires.
- Point a registration file at a session that has since exited (or delete it) and repeat; confirm the sender falls back silently with no error and no retry loop.
- With multiple sessions sharing a clone root (a name-collision setup), confirm the push still lands on the correct session, since the address comes from the registration file rather than from scanning `ListAgents`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)