### PR TITLE
Harden the epic/conductor seam: six interface rules, durable decisions file

### DIFF
--- a/skills/bip-conductor-poll/SKILL.md
+++ b/skills/bip-conductor-poll/SKILL.md
@@ -115,9 +115,11 @@ Skip the nudge entirely for a worker in `awaiting-results` with a live `check_cm
 
 3. **Needs human**: Clones in `needs-human` phase — show the lead's assessment and what decision is needed.
 
-4. **Recently landed** (brief): PRs merged since last poll, only if noteworthy.
+4. **Decisions and negative list**: read new entries from `.epic-decisions.md` in the conductor cwd since the last poll (`FINAL` relays, forwarded worker findings, negative-list entries — see `/bip-conductor`'s Conventions, "Decision relays" and ".epic-decisions.md: the durable fleet-decision log") and report them here; this is the file's canonical output surface for a poll cycle, not a fresh derivation.
 
-5. **Execute pending spawns**: If spawn intent files and idle clones both exist, propose running `/bip-conductor-spawn` for them.
+5. **Recently landed** (brief): PRs merged since last poll, only if noteworthy.
+
+6. **Execute pending spawns**: If spawn intent files and idle clones both exist, propose running `/bip-conductor-spawn` for them.
    Wait for confirmation.
 
 ### Housekeeping (do silently, don't report unless problems)
@@ -167,13 +169,16 @@ Before recording anything anywhere, run each candidate fleet-level finding throu
 2. **Is it already recorded?**
    A finding that produced an issue, PR, test, or doc needs no second copy.
 
-Only what survives both gates gets a destination: a durable clone-pool layout decision → a `CLAUDE.md`; a workflow rule → a skill; a topic-level decision → `/bip-epic`'s own memory, not here.
+Only what survives both gates gets a destination: a durable clone-pool layout decision → a `CLAUDE.md`; a workflow rule → a skill; a **fleet-level decision** (a `FINAL` relay, a forwarded worker finding, a negative-list entry) → `.epic-decisions.md` in the conductor cwd, not `/bip-epic`'s own memory — that memory is unavailable wherever the auto-memory directory is deliberately skipped (`bip-epic/SKILL.md`'s Step 1 explicitly allows this, and some setups do it), and `.epic-decisions.md` has no such gap since it's a plain file, not a memory-directory feature.
 Nothing else fits → the poll report itself.
 
 ## Conventions
 
 Same as `/bip-epic`: `iN`/`pN` prefixes, full URLs on first mention.
 Tmux windows named `NNN-YYY` where NNN is the issue number and YYY is the clone/slot name (e.g. `281-cedar` in clone mode, `281-issue-281` in worktree mode).
+
+**Decision relays are marked `PROVISIONAL` or `FINAL`, nothing unmarked.**
+When this conductor session is the one talking to the user mid-poll and a decision results, push it to `/bip-epic` via `$CLONE_ROOT/.epic-session` prefixed `PROVISIONAL` or `FINAL` and append it to `.epic-decisions.md` — see `/bip-conductor`'s Conventions, "Decision relays: PROVISIONAL and FINAL", for the full mechanics; this is the same rule, restated here because a conductor mid-cycle is reading this skill, not the cold-start one (the durable/transient nudge test above duplicates the same way).
 
 ## Layout config (issue #149)
 

--- a/skills/bip-conductor/SKILL.md
+++ b/skills/bip-conductor/SKILL.md
@@ -95,6 +95,46 @@ To push, a role reads the other's file for the exact address and `SendMessage`s 
 A failed `SendMessage` to a drifted name comes back with `success: false` and a "Did you mean: ..." suggestion list of other live sessions — **never act on that suggestion**; trying it is exactly the guessing this design exists to avoid, just prompted by the tool instead of self-initiated.
 The residual risk this doesn't close — an unrelated session claiming the exact same name string in the gap before a refresh — is accepted as rare; the push is a latency optimization, never a hard dependency.
 
+### Decision relays: PROVISIONAL and FINAL
+
+No skill documents a conductor→epic path for user decisions before this — the only documented pushes in that direction are the `needs-human`/`completed` completion pushes above; everything else in these Conventions runs epic→conductor→worker.
+This section creates that convention rather than annotating an existing one.
+
+When the conductor is the session talking to the user and a decision results, push it to `/bip-epic` rather than letting it sit only in this session's own conversation: read `$CLONE_ROOT/.epic-session` for the epic's self-registered address (same mechanics as "Completion pushes" above) and `SendMessage` it the decision, **prefixed `PROVISIONAL` or `FINAL`. Nothing goes unmarked.**
+
+- **`PROVISIONAL`**: the decision is still being discussed, or the conductor is relaying a first read before the user has confirmed it. `/bip-epic` may note that a decision is pending but must not write it into an EPIC body — see that skill's "Fleet state is derived" section for the FINAL-only body rule this feeds.
+- **`FINAL`**: the user has confirmed the decision's shape. This, and only this, authorizes `/bip-epic` to write the decision into an EPIC body.
+- Append every `FINAL` relay (and, once it firms up, the `PROVISIONAL` relay it followed from) to `.epic-decisions.md` in the conductor cwd, timestamped and attributed — see ".epic-decisions.md: the durable fleet-decision log" below. A relay that lives only in the message is gone the moment either session compacts; the body-write authorization in `/bip-epic` depends on being able to re-derive that a `FINAL` marker was actually sent.
+
+This is one-directional: epic→conductor relays (spawn intent, worker corrections) are unaffected by this rule, since the conductor writes no citable artifact from them.
+
+### Forwarding worker findings
+
+A worker's semantic finding — "this assumption doesn't hold," "this arm was already moved" — reaches the epic through the conductor, and passing it through invites the conductor to interpret it along the way.
+Don't. Forward the finding **verbatim and attributed** to the worker (issue/slot) that produced it.
+If the conductor has its own reading of the finding worth adding, add it as a separate, clearly marked line — never blended into the forwarded text so that the epic (or the user) cannot tell which parts are the worker's observation and which are the conductor's interpretation.
+The failure this prevents: a worker's matrix-provenance finding, forwarded as if it undercut a sibling issue's premise, when the EPIC had already moved that arm for the same reason — the conductor's reading reached the user mid-decision as though it were the worker's own conclusion.
+Append forwarded findings to `.epic-decisions.md` alongside decision relays (see ".epic-decisions.md: the durable fleet-decision log" above), same reasoning: message-only state does not survive compaction.
+
+### `.epic-decisions.md`: the durable fleet-decision log
+
+Every `FINAL` relay (above), every forwarded worker finding (above), and every negative-list entry (Step 5's dashboard) appends here — in the conductor cwd, gitignored the same way as `.epic-status.json` (see the gitignore note near that spec below).
+Format is timestamped markdown, append-only, never edit a previous entry — the same convention as `.epic-worklog.md`, because this is attributed narrative for a human (or a fresh epic session) to read, not a machine-parsed event stream like the JSONL `.epic-notifications.log`.
+
+```
+## 2026-08-28T14:30:00Z — RELAY:FINAL (conductor→epic)
+<the decision, restated in full, not a paraphrase of sentiment>
+
+## 2026-08-28T14:32:00Z — FINDING (worker i2098, forwarded by conductor)
+<the worker's finding, verbatim>
+Conductor's own reading, if any, marked separately: <...>
+
+## 2026-08-28T09:00:00Z — NEGATIVE (conductor)
+<action not taken, and why — e.g. "i2080 not proposed: clone stood down 08-27 for <reason>, prerequisites merging today doesn't reopen it">
+```
+
+**Not `.epic-worklog.md`.** That file is per-slot and gets `rm -f`'d on slot cleanup, so a fleet-level entry written there is destroyed by unrelated housekeeping the moment that slot is cleaned up.
+
 ## Configuration
 
 The conductor skill reads `.epic-config.json` from the repo root — the same file `/bip-epic` reads.
@@ -231,6 +271,11 @@ The dashboard is **slot-centric** — the epic's dashboard is issue-centric; thi
 
 **Pending spawn intent**: list any `.spawn-prompts/` files found in Step 3/4 (either naming pattern), with the available slots that could run them.
 
+**Negative list**: also surface decisions already taken *against* an action, with reasons — sequencing already applied, an issue already stood down for a reason that would otherwise look resolved, and similar.
+This is the one category of fleet fact the epic (or a fresh conductor) cannot re-derive from `git`/`tmux`/`gh`: it's the absence of work, which leaves no trace in any of those.
+Read `.epic-decisions.md` in the conductor cwd (see Conventions, "Decision relays" and ".epic-decisions.md: the durable fleet-decision log") for prior entries and append any new one here, timestamped and attributed, in the same step you surface it — don't let it live only in this dashboard render.
+Concrete shape from the run that motivated this: an issue whose stated prerequisites both merged the same day reads as unblocked, but the conductor had already stood a clone down for it for an unrelated reason — without the negative list, that reads as ready to the epic and gets proposed again.
+
 ### Step 6: Propose next action
 
 First, do housekeeping automatically (no need to ask):
@@ -301,7 +346,7 @@ nohup bip epic watch --poll >/dev/null 2>&1 &
 }
 ```
 
-- Must be `.gitignored` (along with `.epic-worklog.md`)
+- Must be `.gitignored` (along with `.epic-worklog.md` and `.epic-decisions.md` — see Conventions, "Decision relays" and ".epic-decisions.md: the durable fleet-decision log")
 - Stale after 30 minutes with no tmux window
 - `remote_run` optional — set when work dispatched to remote server
 - `quality` optional — set during `quality-gate` phase:

--- a/skills/bip-conductor/SKILL.md
+++ b/skills/bip-conductor/SKILL.md
@@ -122,15 +122,15 @@ Every `FINAL` relay (above), every forwarded worker finding (above), and every n
 Format is timestamped markdown, append-only, never edit a previous entry — the same convention as `.epic-worklog.md`, because this is attributed narrative for a human (or a fresh epic session) to read, not a machine-parsed event stream like the JSONL `.epic-notifications.log`.
 
 ```
+## 2026-08-28T09:00:00Z — NEGATIVE (conductor)
+<action not taken, and why — e.g. "i2080 not proposed: clone stood down 08-27 for <reason>, prerequisites merging today doesn't reopen it">
+
 ## 2026-08-28T14:30:00Z — RELAY:FINAL (conductor→epic)
 <the decision, restated in full, not a paraphrase of sentiment>
 
 ## 2026-08-28T14:32:00Z — FINDING (worker i2098, forwarded by conductor)
 <the worker's finding, verbatim>
 Conductor's own reading, if any, marked separately: <...>
-
-## 2026-08-28T09:00:00Z — NEGATIVE (conductor)
-<action not taken, and why — e.g. "i2080 not proposed: clone stood down 08-27 for <reason>, prerequisites merging today doesn't reopen it">
 ```
 
 **Not `.epic-worklog.md`.** That file is per-slot and gets `rm -f`'d on slot cleanup, so a fleet-level entry written there is destroyed by unrelated housekeeping the moment that slot is cleaned up.

--- a/skills/bip-epic/SKILL.md
+++ b/skills/bip-epic/SKILL.md
@@ -62,8 +62,10 @@ Group A's step 3 re-verifies every open child item's state one `gh issue view` a
 In the run that motivated this rule, Group A spent ~58k tokens re-verifying 10 issues this way, 9 of which the conductor's own report covered a minute and a half later.
 
 - Resolve `CLONE_ROOT`, read `$CLONE_ROOT/.conductor-session` for the conductor's self-registered address (see `/bip-conductor`'s Conventions section, "Completion pushes"), and `SendMessage` it a request for its current slot→issue occupancy table (Step 5's dashboard) and its negative list (decisions already taken against an action — see `/bip-conductor`'s Step 5).
-- **Payload**: the slot→issue occupancy table (which issue, if any, each slot holds) plus the negative list.
-- **Scope**: "what the conductor does not already own" means issues with no live slot in that table. Pass this table down to each Group A subagent and have it skip step 3's `gh issue view` confirmation for any child item the table already shows occupied — the conductor's own dashboard just reconfirmed that item is open and active. Everything else about the subagent's job (reading the EPIC body, parsing findings, flagging surprises) is unaffected; only the redundant per-item open/closed check is skipped.
+- **Payload**: the slot→issue occupancy table (which issue, and which **phase**, each slot holds) plus the negative list.
+- **Scope**: "what the conductor does not already own" means issues with no live slot in that table, **and only for slots in an in-progress phase** (`coding`, `exploring`, `testing`, `awaiting-results`, `quality-gate`) — occupancy is evidence about the fleet, not about GitHub, and a slot's issue can close while the slot itself still shows occupied.
+  Never skip the confirmation for `completed` or `needs-human` phases: a slot that just finished is *more* likely to have a closed issue than one still mid-flight, since finishing is exactly what triggers the issue closing, and slot cleanup (which would otherwise clear the slot) is a separate housekeeping step that can lag behind.
+  Pass the table (with phase) down to each Group A subagent and have it skip step 3's `gh issue view` confirmation only for child items on an in-progress-phase slot. Everything else about the subagent's job (reading the EPIC body, parsing findings, flagging surprises) is unaffected; only the redundant per-item open/closed check is narrowed.
 - **Fallback**: if `$CLONE_ROOT/.conductor-session` is absent, or the send fails (no conductor addressable), proceed with the full Group A dispatch below, unscoped — run step 3's confirmation for every item, and do not block waiting for a conductor that may never exist.
   A solo `/bip-epic` run with no separate conductor session must not deadlock here (see Step 6's conductor-absent handling for the same fallback shape).
 
@@ -86,7 +88,7 @@ Brief:
 > 1. `gh issue view <N> --json title,body,updatedAt`.
 > 2. Parse the Status dashboard and Key findings.
 >    (Older EPIC bodies may still carry a legacy clone-assignment table from before the fleet/topic split — that's fleet state that shouldn't have been authored here; note it as a `surprise` for cleanup, don't treat it as current truth.)
-> 3. For each open item the dashboard lists, run `gh issue view <child-N> --json state,stateReason` to confirm it is still open — **except** items the conductor's occupancy table (handshake above) already shows holding a live slot; take "open" as given for those and skip the query.
+> 3. For each open item the dashboard lists, run `gh issue view <child-N> --json state,stateReason` to confirm it is still open — **except** items the conductor's occupancy table (handshake above) shows holding a slot in an **in-progress** phase (`coding`, `exploring`, `testing`, `awaiting-results`, `quality-gate`); take "open" as given only for those and skip the query. Still confirm for `completed`/`needs-human` slots, and for anything the table doesn't cover — a slot can finish and its issue close before the slot itself is cleaned up, so occupancy alone never implies "still open."
 >
 > Return under 400 words:
 > - `changes_since_baseline`: completed items, new findings, items newly opened

--- a/skills/bip-epic/SKILL.md
+++ b/skills/bip-epic/SKILL.md
@@ -10,7 +10,8 @@ Fleet mechanics — clone/tmux inventory, staleness checks, spawning, pruning of
 The two roles coordinate over `SendMessage` and a shared `.spawn-prompts/` directory (see "Handing spawn intent to the conductor" below); they do not need to be the same session, though they may run side-by-side in one tmux host.
 
 Use this at **session start** to establish topic context.
-For fleet state (which clones are free, what's running where, tmux/host occupancy), ask `/bip-conductor` instead — this skill does not scan clones or tmux, and has no visibility into them.
+For fleet state (which clones are free, what's running where, tmux/host occupancy), ask `/bip-conductor` instead — this skill does not scan clones or tmux itself.
+It does *consume* a conductor-supplied occupancy table when a conductor handshake succeeds (Step 2 below), but that table is read-only input to scoping, not something this skill goes and gets on its own.
 
 ## Role
 
@@ -56,6 +57,19 @@ Re-run this write every time `/bip-epic` starts a fresh poll cycle, since the ad
 
 ### Step 2: Fan out scanners
 
+**Handshake with the conductor before dispatching Group A.**
+Group A's step 3 re-verifies every open child item's state one `gh issue view` at a time; most of that is exactly what `/bip-conductor`'s own Step 5 dashboard already computed 90 seconds earlier from `git`/`tmux`.
+In the run that motivated this rule, Group A spent ~58k tokens re-verifying 10 issues this way, 9 of which the conductor's own report covered a minute and a half later.
+
+- Resolve `CLONE_ROOT`, read `$CLONE_ROOT/.conductor-session` for the conductor's self-registered address (see `/bip-conductor`'s Conventions section, "Completion pushes"), and `SendMessage` it a request for its current slot→issue occupancy table (Step 5's dashboard) and its negative list (decisions already taken against an action — see `/bip-conductor`'s Step 5).
+- **Payload**: the slot→issue occupancy table (which issue, if any, each slot holds) plus the negative list.
+- **Scope**: "what the conductor does not already own" means issues with no live slot in that table. Pass this table down to each Group A subagent and have it skip step 3's `gh issue view` confirmation for any child item the table already shows occupied — the conductor's own dashboard just reconfirmed that item is open and active. Everything else about the subagent's job (reading the EPIC body, parsing findings, flagging surprises) is unaffected; only the redundant per-item open/closed check is skipped.
+- **Fallback**: if `$CLONE_ROOT/.conductor-session` is absent, or the send fails (no conductor addressable), proceed with the full Group A dispatch below, unscoped — run step 3's confirmation for every item, and do not block waiting for a conductor that may never exist.
+  A solo `/bip-epic` run with no separate conductor session must not deadlock here (see Step 6's conductor-absent handling for the same fallback shape).
+
+This narrows Group A's redundant re-verification; it does not narrow Group A's judgment.
+In the run that motivated this rule, Group A independently found an open PR and three dependency corrections the conductor's dashboard had no way to see — occupancy and dependency reasoning are different questions, and the conductor's table answers only the first.
+
 Dispatch two groups of `general-purpose` subagents in parallel — single message, multiple `Agent` tool calls.
 Follow the dispatch pattern in `SUBAGENT-SCAN.md` (bipartite repo root).
 Start with the cheap structured listing the primary can do directly:
@@ -72,7 +86,7 @@ Brief:
 > 1. `gh issue view <N> --json title,body,updatedAt`.
 > 2. Parse the Status dashboard and Key findings.
 >    (Older EPIC bodies may still carry a legacy clone-assignment table from before the fleet/topic split — that's fleet state that shouldn't have been authored here; note it as a `surprise` for cleanup, don't treat it as current truth.)
-> 3. For each open item the dashboard lists, run `gh issue view <child-N> --json state,stateReason` to confirm it is still open.
+> 3. For each open item the dashboard lists, run `gh issue view <child-N> --json state,stateReason` to confirm it is still open — **except** items the conductor's occupancy table (handshake above) already shows holding a live slot; take "open" as given for those and skip the query.
 >
 > Return under 400 words:
 > - `changes_since_baseline`: completed items, new findings, items newly opened
@@ -114,19 +128,31 @@ Compose the reconciliation from the two reports — do not paste subagent prose 
 - Flag anything merged/closed that an EPIC body doesn't reflect yet
 - If either group's report has zero `surprises` and zero `changes_since_baseline`, send a follow-up to that subagent with a narrower question before concluding "nothing changed there."
 
-Clone/tmux occupancy is not part of this reconciliation — it's `/bip-conductor`'s dashboard, not this one.
+This reconciliation itself does not scan clone/tmux occupancy — that's `/bip-conductor`'s dashboard, not this one — though Step 2's handshake may already have pulled the conductor's occupancy table in for scoping purposes by the time you reach this step.
 
-### Step 4: Dependency-direction and collision detection
+### Step 4a: Dependency-direction detection
 
 Run this before proposing any issue as ready to spawn, not after — once a branch exists the cost of a collision is sunk.
-This automates what has so far been a manual capability: extracting file paths from issue bodies and building an overlap matrix.
+
+1. For every currently open, unassigned (or about-to-be-spawned) issue, read its body against every other such issue's body and ask: can both land as currently written, in either order?
+   Or does one delete, rename, or restructure something the other's patch depends on — a dependency-direction conflict that no ordering fixes, because one issue has to change shape?
+   (Concrete shape: one issue deletes a function a sibling issue is patching; one issue's test assertion contradicts a value a sibling issue is about to change.)
+2. Record findings where a future spawn will see them: a note in the EPIC body's dashboard, and — if either issue is about to be handed off as spawn intent (Step 6) — the warning goes directly into that issue's brief.
+
+**Completion criterion**: every pair of currently-open, about-to-be-spawned issues has been read against each other for dependency direction, not just for whether one references the other's issue number.
+
+### Step 4b: File-overlap collision detection
+
+This is a distinct analysis from 4a, not a second pass over the same reading — it automates what has so far been a manual capability: extracting file paths from issue bodies and building an overlap matrix.
 
 1. From every currently open, unassigned (or about-to-be-spawned) issue body, extract mentioned file/module paths — code blocks, a "Files:" section, or explicit paths in prose.
 2. Build an overlap matrix: any two open issues naming the same file or module are a candidate collision.
-3. For each overlap, read both issue bodies against each other and ask the harder question, not just "who goes first": can both land as currently written, in either order?
-   Or does one delete, rename, or restructure something the other's patch depends on — a dependency-direction conflict that no ordering fixes, because one issue has to change shape?
-   (Concrete shape: one issue deletes a function a sibling issue is patching; one issue's test assertion contradicts a value a sibling issue is about to change.)
-4. Record findings where a future spawn will see them: a note in the EPIC body's dashboard, and — if either issue is about to be handed off as spawn intent (Step 6) — the warning goes directly into that issue's brief.
+3. For each overlap, this is not the same question as 4a's — file overlap alone (two issues touching the same file, in disjoint regions or compatible ways) is not itself a dependency-direction conflict, and clearing a pair on dependency grounds in 4a does not clear it here.
+   Confirm whether the overlapping regions can coexist or whether one issue's edit invalidates the other's, even absent any direction conflict.
+4. Record findings the same way as 4a: a dashboard note, and a brief warning for any issue about to be handed off (Step 6).
+
+**Completion criterion**: every pair of currently-open, about-to-be-spawned issues naming an overlapping file/module has an explicit overlap verdict — "compatible" or "conflicts, because ___" — not merely "no dependency conflict found in 4a."
+**A pair cleared in 4a is not thereby cleared here** — this is the check that "No collisions" wrongly skipped when two issues sharing a dependency-independent EPIC both edited `experiments/2026-08-27-2051-heavy-v2-stated-estimator/scripts/rescore_cell.py`.
 
 ### Step 5: Prune and update the EPIC body
 
@@ -142,9 +168,15 @@ Which clone holds which issue, which slots are free, which tmux windows are live
 Never write it into an EPIC body or a continuation doc — it goes stale within a day and there is no mechanism to notice, which is exactly the failure a hand-maintained clone table caused when it went stale twice in one day.
 Handoff artifacts (spawn intent, unfiled drafts) are the opposite category: authored deliberately, to a durable path outside git, precisely so they survive clone churn — pruning them (Step 6, below) is about cleaning up finished authored state, not about avoiding writing derived state down in the first place.
 
+**A user decision may be written into the EPIC body only against a `FINAL` shape.**
+When the session talking to the user is the conductor, not this one, the decision arrives here as a relay — see `/bip-conductor`'s "Decision relays: PROVISIONAL and FINAL" — and every relay is marked one or the other.
+A `PROVISIONAL` relay is discussion in progress, not yet a settled decision; write nothing into the body from it beyond noting that a decision is pending, and check `.epic-decisions.md` in the conductor cwd (see `/bip-conductor`'s ".epic-decisions.md: the durable fleet-decision log") for the eventual `FINAL` entry before composing the body edit.
+Only a `FINAL` relay — or a decision reached directly in this session — authorizes the write, and the body text should restate the decision's substance, not a paraphrase of the sentiment that led to it: "burn everything down and make it right" said in conversation is not "make parity diverges permanently" written into an EPIC body: the paraphrase is a second-hand summary as if it were the specification itself.
+If the deciding session's shape is unclear, treat it as `PROVISIONAL` and ask before writing.
+
 ### Step 6: Hand spawn intent to the conductor
 
-For each issue judged ready (unblocked per Step 3, no unresolved collision or dependency-direction conflict per Step 4), draft the semantic brief — why it matters, scope, any dependency/collision warnings from Step 4 — and write it to:
+For each issue judged ready (unblocked per Step 3, no unresolved dependency-direction conflict per Step 4a, no unresolved file-overlap collision per Step 4b), draft the semantic brief — why it matters, scope, any dependency/collision warnings from Step 4a/4b — and write it to:
 
 ```bash
 source "$(dirname "<this-skill's-base-directory>")/lib/spawn-intent.sh"


### PR DESCRIPTION
## Summary

`ba06e87` split `bip-epic` (topic strategy) from `bip-conductor` (fleet ops). One 9-slot EPIC run of that split (`matsengrp/phyz`#369) produced three seam errors, all in the interface between the two roles rather than inside either one's own domain: a missed file collision (`bip-epic` cleared two issues as dependency-independent while both edited the same script), a worker finding forwarded by the conductor with its own reading blended into the worker's, and user sentiment relayed through the conductor written into an EPIC body as if it were the decision's substance.

Six edits, documentation-only (`skills/bip-epic/SKILL.md`, `skills/bip-conductor/SKILL.md`, `skills/bip-conductor-poll/SKILL.md`):

1. **Decision-relay channel, marked `PROVISIONAL`/`FINAL`.** New `### Decision relays` subsection in `bip-conductor` — when the conductor is the session talking to the user, it pushes the resulting decision to `/bip-epic`'s self-registered address, prefixed one or the other. Mirrored in `bip-conductor-poll`'s Conventions (a conductor mid-cycle reads that skill, not the cold-start one).
2. **`FINAL`-only EPIC body writes.** `bip-epic`'s "Fleet state is derived" section gains a rule: a user decision may be written into an EPIC body only against a `FINAL` relay (or a decision reached directly in that session) — never a paraphrase of sentiment from a `PROVISIONAL` one.
3. **Step 4a/4b split.** `bip-epic` Step 4 (dependency-direction + file-overlap) had bundled two analyses that share no method. Split into 4a (dependency direction) and 4b (file overlap), each with its own completion criterion; 4b states explicitly that clearing a pair on dependency grounds does not clear it on file grounds — the exact gap that produced the missed collision.
4. **Conductor handshake before Group A.** `bip-epic` Step 2 now resolves the conductor's address and requests its slot→issue occupancy table (issue + **phase**) before fanning out Group A subagents, and scopes each subagent to skip its redundant per-issue "confirm still open" check only for slots in an **in-progress** phase (`coding`/`exploring`/`testing`/`awaiting-results`/`quality-gate`). `completed`/`needs-human` slots are always re-confirmed, since a slot can hold an already-closed issue right up until the separate slot-cleanup housekeeping step runs — occupancy is evidence about the fleet, not about GitHub. Falls back to the full unscoped dispatch when no conductor is addressable, so a solo `/bip-epic` run doesn't deadlock. (In the motivating run, this specific re-verification cost ~58k tokens confirming state the conductor's own report covered 90 seconds later — Group A's independent judgment, e.g. catching an open PR or a dependency issue the conductor's table can't see, is unaffected.)
5. **Verbatim, attributed forwarding.** New `### Forwarding worker findings` subsection in `bip-conductor` — a worker's finding forwards as-is, with any conductor reading marked as a separate, clearly attributed line.
6. **`.epic-decisions.md`.** A durable, gitignored, conductor-cwd file (timestamped markdown, append-only, chronological — same convention as `.epic-worklog.md`, distinct file) that every `FINAL` relay, every forwarded worker finding, and every negative-list entry (decisions already taken *against* an action, with reasons — the one category of fleet fact that leaves no trace in `git`/`tmux`/`gh`) appends to. Explicitly not `.epic-worklog.md`, which is per-slot and `rm -f`'d on cleanup. `bip-conductor-poll`'s routing filter and Output structure now point fleet-level decisions here instead of `/bip-epic`'s own memory, which is unavailable wherever a setup deliberately skips the auto-memory directory.

Two existing boundary claims (`bip-epic`'s intro and its Step 3 reconciliation note) are softened to reflect item 4: the epic still does not *scan* clone/tmux state itself, but it now *consumes* a conductor-supplied table when one is offered.

## Out of scope (per the issue)

Redrawing role ownership, merging the two skills, and a CI-checkable regression gate for skill-heading structure are all explicitly deferred — see the issue's Scope boundaries.

## DEFERRED

- `.epic-decisions.md` needs a real `.gitignore` entry in each EPIC-consuming repo (this repo's own `.gitignore` doesn't list the fleet-state files at all, since they're created per-consuming-repo, not here). First conductor session to append will dirty a worktree until that repo's `.gitignore` is updated — a one-line addition per repo, not blocking this PR.

## Test plan

- Documentation-only change to three `skills/*/SKILL.md` files; no Go code touched (`go build ./...` unaffected).
- Read each edited section against the issue's six success criteria and the cross-file references (`bip-epic` ↔ `bip-conductor` ↔ `bip-conductor-poll`) for internal consistency — no dangling "Step 4" references, no stale line-number pointers.
- Reviewed by `phyz-9f` (the epic session from the `phyz`#369 run this issue is based on) against the six success criteria; one HIGH finding (item 4's occupancy-skip didn't account for `completed`/`needs-human` slots holding already-closed issues) fixed in place.

Closes #207
