### PR TITLE
Require citation resolution before acting in bip-epic/bip-conductor

### DIFF
--- a/skills/bip-conductor-poll/SKILL.md
+++ b/skills/bip-conductor-poll/SKILL.md
@@ -180,6 +180,9 @@ Tmux windows named `NNN-YYY` where NNN is the issue number and YYY is the clone/
 **Decision relays are marked `PROVISIONAL` or `FINAL`, nothing unmarked.**
 When this conductor session is the one talking to the user mid-poll and a decision results, push it to `/bip-epic` via `$CLONE_ROOT/.epic-session` prefixed `PROVISIONAL` or `FINAL` and append it to `.epic-decisions.md` — see `/bip-conductor`'s Conventions, "Decision relays: PROVISIONAL and FINAL", for the full mechanics; this is the same rule, restated here because a conductor mid-cycle is reading this skill, not the cold-start one (the durable/transient nudge test above duplicates the same way).
 
+**Resolve a citation before acting on it, here too.**
+A worker's finding forwarded mid-poll carries the same citation risk as at cold start — a bare filename with no directory is unresolved, and reconstructing one from context produces a real `find` result for an invented question. See `/bip-conductor`'s Conventions, "Resolving a citation before acting on it", for the full mechanics; restated here for the same reason as the decision-relay rule above.
+
 ## Layout config (issue #149)
 
 `.epic-config.json` keeps working.

--- a/skills/bip-conductor/SKILL.md
+++ b/skills/bip-conductor/SKILL.md
@@ -116,6 +116,13 @@ If the conductor has its own reading of the finding worth adding, add it as a se
 The failure this prevents: a worker's matrix-provenance finding, forwarded as if it undercut a sibling issue's premise, when the EPIC had already moved that arm for the same reason — the conductor's reading reached the user mid-decision as though it were the worker's own conclusion.
 Append forwarded findings to `.epic-decisions.md` alongside decision relays (see ".epic-decisions.md: the durable fleet-decision log" above), same reasoning: message-only state does not survive compaction.
 
+### Resolving a citation before acting on it
+
+A finding often carries a citation — a file, a line range, a symbol — and forwarding it verbatim (above) does not excuse skipping resolution before acting on it locally. Never reconstruct a missing path component from surrounding context: a citation like `run_heavy_baselines.py:30-43` with no directory is unresolved, not incomplete-but-inferable. Resolve it against the repo (`find`/`grep -r`) or ask the sender which copy they meant.
+**A `find` run against a reconstructed path returns a real result for an invented question.** The result looking concrete does not make the resolution correct, and a "missing file" found this way is not evidence of an error in the citation — it is evidence of an error in the reconstruction.
+The same caution applies to a bare symbol name in a repo with duplicated modules: two files can define the same name for different things, and matching on the name alone is not resolution.
+Verification shell calls should carry their own working directory — `cd` inside the same command, or an absolute path — rather than relying on a `cd` from an earlier call in the same session persisting into this one.
+
 ### `.epic-decisions.md`: the durable fleet-decision log
 
 Every `FINAL` relay (above), every forwarded worker finding (above), and every negative-list entry (Step 5's dashboard) appends here — in the conductor cwd, gitignored the same way as `.epic-status.json` (see the gitignore note near that spec below).

--- a/skills/bip-conductor/SKILL.md
+++ b/skills/bip-conductor/SKILL.md
@@ -122,6 +122,7 @@ A finding often carries a citation — a file, a line range, a symbol — and fo
 **A `find` run against a reconstructed path returns a real result for an invented question.** The result looking concrete does not make the resolution correct, and a "missing file" found this way is not evidence of an error in the citation — it is evidence of an error in the reconstruction.
 The same caution applies to a bare symbol name in a repo with duplicated modules: two files can define the same name for different things, and matching on the name alone is not resolution.
 Verification shell calls should carry their own working directory — `cd` inside the same command, or an absolute path — rather than relying on a `cd` from an earlier call in the same session persisting into this one.
+This cuts both ways: when relaying a finding or citing a file in a message to another session — a worker report, a push to the epic — include the directory. A bare filename plus line number is not an address, and a sender who includes the directory removes the ambiguity at its cheapest point, before it costs the receiver a resolution or a round-trip question.
 
 ### `.epic-decisions.md`: the durable fleet-decision log
 

--- a/skills/bip-epic/SKILL.md
+++ b/skills/bip-epic/SKILL.md
@@ -147,16 +147,16 @@ Run this before proposing any issue as ready to spawn, not after — once a bran
 
 This is a distinct analysis from 4a, not a second pass over the same reading — it automates what has so far been a manual capability: extracting file paths from issue bodies and building an overlap matrix.
 
-1. From every currently open, unassigned (or about-to-be-spawned) issue body, extract mentioned file/module paths — code blocks, a "Files:" section, or explicit paths in prose.
+1. From every currently open, unassigned (or about-to-be-spawned) issue body, extract mentioned file/module paths — code blocks, a "Files:" section, or explicit paths in prose. **A path extracted this way is a candidate, not a location** — resolve it before recording it as anything else.
 2. Build an overlap matrix: any two open issues naming the same file or module are a candidate collision.
 3. For each overlap, this is not the same question as 4a's — file overlap alone (two issues touching the same file, in disjoint regions or compatible ways) is not itself a dependency-direction conflict, and clearing a pair on dependency grounds in 4a does not clear it here.
    Confirm whether the overlapping regions can coexist or whether one issue's edit invalidates the other's, even absent any direction conflict.
 4. Record findings the same way as 4a: a dashboard note, and a brief warning for any issue about to be handed off (Step 6).
 
-**A path extracted from prose is a candidate, not a location.**
-Resolve it with `find`/`grep -r` against the actual repo before recording an overlap or its absence — a filename with no directory component is unresolved, and two issues naming `common.py` are not evidence of overlap by themselves.
+Resolve with `find`/`grep -r` against the actual repo before recording an overlap or its absence — a filename with no directory component is unresolved, and two issues naming `common.py` are not evidence of overlap by themselves.
 This matters most in a repo with per-experiment `scripts/` copies, where the same filename can resolve to unrelated files, and the same symbol name can appear in several of them meaning different things.
 Verification shell calls should carry their own working directory — `cd` inside the same command, or an absolute path — rather than relying on a `cd` from an earlier call persisting into this one.
+When *naming* a file in a brief or message to another session (Step 6, or any epic→conductor relay), include the directory — a bare filename plus line number is not an address, and pushing resolution onto the receiver costs a round trip that including the directory up front would have avoided.
 
 **Completion criterion**: every pair of currently-open, about-to-be-spawned issues naming an overlapping file/module has an explicit overlap verdict — "compatible" or "conflicts, because ___" — not merely "no dependency conflict found in 4a."
 **A pair cleared in 4a is not thereby cleared here** — this is the check that "No collisions" wrongly skipped when two issues sharing a dependency-independent EPIC both edited `experiments/2026-08-27-2051-heavy-v2-stated-estimator/scripts/rescore_cell.py`.

--- a/skills/bip-epic/SKILL.md
+++ b/skills/bip-epic/SKILL.md
@@ -153,6 +153,11 @@ This is a distinct analysis from 4a, not a second pass over the same reading —
    Confirm whether the overlapping regions can coexist or whether one issue's edit invalidates the other's, even absent any direction conflict.
 4. Record findings the same way as 4a: a dashboard note, and a brief warning for any issue about to be handed off (Step 6).
 
+**A path extracted from prose is a candidate, not a location.**
+Resolve it with `find`/`grep -r` against the actual repo before recording an overlap or its absence — a filename with no directory component is unresolved, and two issues naming `common.py` are not evidence of overlap by themselves.
+This matters most in a repo with per-experiment `scripts/` copies, where the same filename can resolve to unrelated files, and the same symbol name can appear in several of them meaning different things.
+Verification shell calls should carry their own working directory — `cd` inside the same command, or an absolute path — rather than relying on a `cd` from an earlier call persisting into this one.
+
 **Completion criterion**: every pair of currently-open, about-to-be-spawned issues naming an overlapping file/module has an explicit overlap verdict — "compatible" or "conflicts, because ___" — not merely "no dependency conflict found in 4a."
 **A pair cleared in 4a is not thereby cleared here** — this is the check that "No collisions" wrongly skipped when two issues sharing a dependency-independent EPIC both edited `experiments/2026-08-27-2051-heavy-v2-stated-estimator/scripts/rescore_cell.py`.
 
@@ -164,6 +169,10 @@ Do this whenever findings come in, items complete, or new work starts — not on
 **Prune on every write, not on a separate sweep.**
 The observed failure mode is accretion, not staleness: a body cut from 524 to 146 lines had almost nothing stale in what was removed — it was cut because the work had *finished* (checked-off phases, a fully-ticked table) and kept getting appended around instead of trimmed.
 Whenever you touch a body to add a finding or check a box, also look for sections whose work is now fully complete and cut them in the same edit, rather than letting them ride to the next dedicated cleanup.
+
+**A correction that reduces a previously-reported quantity to *no* information deserves a second look before it's written.**
+Debunking has its own momentum: before recording the stronger retraction, check whether a weaker, still-true claim survives.
+A count found to be guaranteed in direction by construction is not thereby guaranteed in magnitude — "carries no information" is a more quotable sentence than "carries less than it appears to, in this specific way," and only one of them is usually true.
 
 **Fleet state is derived, never authored — don't let it back into the body.**
 Which clone holds which issue, which slots are free, which tmux windows are live: recompute this from `git`/`tmux`/`gh` (that's `/bip-conductor`'s Step 5 dashboard) whenever you need it.


### PR DESCRIPTION
## Summary

One full EPIC run (`matsengrp/phyz`#369, under #207/PR #208's new cross-session verification loop) produced four failures of the verification step itself, all the same shape: a check executed correctly against the wrong resolution context and returned a confident wrong answer (inherited `cd`, a path reconstructed from surrounding context, a symbol/filename shared across per-experiment copies). A fifth, related failure: a correction that found a reported number's *direction* was guaranteed by construction also concluded — wrongly — that the number "carries no information."

- `skills/bip-epic/SKILL.md` Step 4b: a path extracted from prose is a candidate, not a location — resolve with `find`/`grep -r` before recording an overlap or its absence; a filename with no directory component is unresolved.
- `skills/bip-conductor/SKILL.md`, new "Resolving a citation before acting on it" section beside "Forwarding worker findings": never reconstruct a missing path component from context — resolve it or ask the sender. Names the trap directly: a `find` against a reconstructed path returns a real result for an invented question.
- Both skills: verification shell calls should carry their own working directory (`cd` in the same command, or absolute paths) rather than relying on inherited cwd.
- `skills/bip-epic/SKILL.md` Step 5: a correction that would reduce a previously-reported quantity to *no* information should first check whether a weaker, still-true claim survives.

## Test plan

- Documentation-only change to two skill files; no code paths affected.
- Read both edited sections in context to confirm they fit the surrounding structure and don't duplicate existing rules.

Closes #209