### PR TITLE
Unify s2_api_key into asta_api_key

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,15 +89,16 @@ See the [Getting Started guide](https://matsen.github.io/bipartite/guides/gettin
 
 ## Configuration
 
-For full functionality, add API keys ([Semantic Scholar](https://www.semanticscholar.org/product/api#api-key), [Asta](https://allenai.org/asta/resources/mcp), [GitHub](https://matsen.github.io/bipartite/guides/configuration/#github-authentication), [Slack](https://api.slack.com/apps)) to your config:
+For full functionality, add API keys ([ASTA/Semantic Scholar](https://allenai.org/asta/resources/mcp), [GitHub](https://matsen.github.io/bipartite/guides/configuration/#github-authentication), [Slack](https://api.slack.com/apps)) to your config:
 
 ```yaml
 nexus_path: ~/re/nexus
-s2_api_key: your-key
 asta_api_key: your-key
 github_token: ghp_...
 slack_bot_token: xoxb-...
 ```
+
+`asta_api_key` covers both the ASTA MCP API and the Semantic Scholar Graph API — AI2 issues a single key for both.
 
 Tokens may also be supplied via environment variables, which take precedence
 over the config file — useful for secrets managers (e.g. `op run` from

--- a/cmd/bip/s2.go
+++ b/cmd/bip/s2.go
@@ -25,7 +25,7 @@ Use --human flag for human-readable output.`,
 }
 
 func init() {
-	// Load .env file if present (for S2_API_KEY)
+	// Load .env file if present (for ASTA_API_KEY)
 	_ = godotenv.Load()
 
 	rootCmd.AddCommand(s2Cmd)

--- a/cmd/bip/s2_helpers.go
+++ b/cmd/bip/s2_helpers.go
@@ -143,7 +143,7 @@ func outputGenericRateLimited(err error) error {
 		Error: &S2ErrorResult{
 			Code:       "rate_limited",
 			Message:    "Semantic Scholar rate limit exceeded",
-			Suggestion: fmt.Sprintf("Wait %d seconds or add s2_api_key to ~/.config/bip/config.yml", retryAfter),
+			Suggestion: fmt.Sprintf("Wait %d seconds or add asta_api_key to ~/.config/bip/config.yml", retryAfter),
 			RetryAfter: retryAfter,
 		},
 	}

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -23,7 +23,6 @@ The config file follows the XDG Base Directory specification:
 mkdir -p ~/.config/bip
 cat > ~/.config/bip/config.yml << 'EOF'
 nexus_path: ~/re/nexus
-s2_api_key: your-semantic-scholar-key
 asta_api_key: your-asta-key
 github_token: ghp_your-github-token
 slack_bot_token: xoxb-your-slack-bot-token
@@ -37,8 +36,7 @@ EOF
 | Field | Description |
 |-------|-------------|
 | `nexus_path` | Default bipartite repository path. Allows running bip commands from anywhere. |
-| `s2_api_key` | Semantic Scholar API key for higher rate limits |
-| `asta_api_key` | ASTA MCP API key ([register here](https://allenai.org/asta/resources/mcp)). Also accepts env vars: `BIP_ASTA_API_KEY`, `ASTA_API_KEY` (in that order). |
+| `asta_api_key` | AI2 API key ([register here](https://allenai.org/asta/resources/mcp)), used for both the ASTA MCP API and the Semantic Scholar Graph API — AI2 issues one key for both. Also accepts env vars: `BIP_ASTA_API_KEY`, `ASTA_API_KEY` (in that order). |
 | `github_token` | GitHub personal access token ([setup guide](#github-authentication)). Also accepts env vars: `BIP_GITHUB_TOKEN`, `GITHUB_TOKEN`, `GH_TOKEN` (in that order). |
 | `slack_bot_token` | Slack bot token for reading channel history. Also accepts env vars: `BIP_SLACK_TOKEN`, `SLACK_BOT_TOKEN` (in that order). |
 | `slack_webhooks` | Slack webhook URLs keyed by channel name |

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -13,7 +13,6 @@ import (
 // GlobalConfig represents configuration stored in ~/.config/bip/config.yml.
 type GlobalConfig struct {
 	NexusPath     string            `yaml:"nexus_path,omitempty"`
-	S2APIKey      string            `yaml:"s2_api_key,omitempty"`
 	ASTAAPIKey    string            `yaml:"asta_api_key,omitempty"`
 	SlackBotToken string            `yaml:"slack_bot_token,omitempty"`
 	GitHubToken   string            `yaml:"github_token,omitempty"`
@@ -100,15 +99,6 @@ func firstEnvOrConfig(names []string, configValue string) string {
 	return configValue
 }
 
-// GetS2APIKey returns the Semantic Scholar API key from global config.
-func GetS2APIKey() string {
-	cfg, err := LoadGlobalConfig()
-	if err != nil || cfg == nil {
-		return ""
-	}
-	return cfg.S2APIKey
-}
-
 // ASTAAPIKeyEnvVars lists the environment variables consulted by
 // GetASTAAPIKey, in precedence order. BIP_ASTA_API_KEY is the
 // recommended bip-specific name; ASTA_API_KEY is the conventional
@@ -116,7 +106,9 @@ func GetS2APIKey() string {
 // .env file by cmd/bip/asta.go.
 var ASTAAPIKeyEnvVars = []string{"BIP_ASTA_API_KEY", "ASTA_API_KEY"}
 
-// GetASTAAPIKey returns the ASTA API key.
+// GetASTAAPIKey returns the AI2 API key used for both the ASTA MCP API
+// and the Semantic Scholar Graph API — AI2 issues a single key for both
+// as of the 2026-08 key upgrade.
 //
 // Precedence:
 //  1. $BIP_ASTA_API_KEY

--- a/internal/config/global_test.go
+++ b/internal/config/global_test.go
@@ -78,7 +78,6 @@ func TestLoadGlobalConfig_Valid(t *testing.T) {
 
 	cfgData := GlobalConfig{
 		NexusPath:     "~/re/nexus",
-		S2APIKey:      "test-s2-key",
 		ASTAAPIKey:    "test-asta-key",
 		SlackBotToken: "xoxb-test",
 		GitHubToken:   "ghp_test",
@@ -106,9 +105,6 @@ func TestLoadGlobalConfig_Valid(t *testing.T) {
 		t.Errorf("NexusPath = %q, want %q", cfg.NexusPath, wantPath)
 	}
 
-	if cfg.S2APIKey != "test-s2-key" {
-		t.Errorf("S2APIKey = %q, want test-s2-key", cfg.S2APIKey)
-	}
 	if cfg.ASTAAPIKey != "test-asta-key" {
 		t.Errorf("ASTAAPIKey = %q, want test-asta-key", cfg.ASTAAPIKey)
 	}
@@ -147,38 +143,6 @@ func TestLoadGlobalConfig_InvalidYAML(t *testing.T) {
 	_, err := LoadGlobalConfig()
 	if err == nil {
 		t.Error("LoadGlobalConfig() should return error for invalid YAML")
-	}
-}
-
-func TestGetS2APIKey(t *testing.T) {
-	ResetGlobalConfigCache()
-	defer ResetGlobalConfigCache()
-
-	// Save and restore XDG
-	origXDG := os.Getenv("XDG_CONFIG_HOME")
-	defer os.Setenv("XDG_CONFIG_HOME", origXDG)
-
-	// Point to empty config first
-	tmpDir := t.TempDir()
-	os.Setenv("XDG_CONFIG_HOME", tmpDir)
-
-	// Without config, returns empty
-	got := GetS2APIKey()
-	if got != "" {
-		t.Errorf("GetS2APIKey() = %q, want empty", got)
-	}
-
-	// Create config with key
-	ResetGlobalConfigCache()
-	configDir := filepath.Join(tmpDir, "bip")
-	os.MkdirAll(configDir, 0755)
-	cfgData := GlobalConfig{S2APIKey: "config-s2-key"}
-	data, _ := yaml.Marshal(cfgData)
-	os.WriteFile(filepath.Join(configDir, "config.yml"), data, 0644)
-
-	got = GetS2APIKey()
-	if got != "config-s2-key" {
-		t.Errorf("GetS2APIKey() = %q, want config-s2-key", got)
 	}
 }
 
@@ -240,7 +204,7 @@ func TestGlobalConfigCache(t *testing.T) {
 	tmpDir := t.TempDir()
 	configDir := filepath.Join(tmpDir, "bip")
 	os.MkdirAll(configDir, 0755)
-	cfgData := GlobalConfig{S2APIKey: "cached-key"}
+	cfgData := GlobalConfig{ASTAAPIKey: "cached-key"}
 	data, _ := yaml.Marshal(cfgData)
 	configFile := filepath.Join(configDir, "config.yml")
 	os.WriteFile(configFile, data, 0644)
@@ -249,19 +213,19 @@ func TestGlobalConfigCache(t *testing.T) {
 
 	// First load
 	cfg1, _ := LoadGlobalConfig()
-	if cfg1.S2APIKey != "cached-key" {
-		t.Errorf("First load: S2APIKey = %q, want cached-key", cfg1.S2APIKey)
+	if cfg1.ASTAAPIKey != "cached-key" {
+		t.Errorf("First load: ASTAAPIKey = %q, want cached-key", cfg1.ASTAAPIKey)
 	}
 
 	// Modify file
-	cfgData.S2APIKey = "modified-key"
+	cfgData.ASTAAPIKey = "modified-key"
 	data, _ = yaml.Marshal(cfgData)
 	os.WriteFile(configFile, data, 0644)
 
 	// Second load should return cached value
 	cfg2, _ := LoadGlobalConfig()
-	if cfg2.S2APIKey != "cached-key" {
-		t.Errorf("Second load: S2APIKey = %q, want cached-key (cached)", cfg2.S2APIKey)
+	if cfg2.ASTAAPIKey != "cached-key" {
+		t.Errorf("Second load: ASTAAPIKey = %q, want cached-key (cached)", cfg2.ASTAAPIKey)
 	}
 
 	// Reset cache
@@ -269,8 +233,8 @@ func TestGlobalConfigCache(t *testing.T) {
 
 	// Third load should read modified file
 	cfg3, _ := LoadGlobalConfig()
-	if cfg3.S2APIKey != "modified-key" {
-		t.Errorf("Third load: S2APIKey = %q, want modified-key", cfg3.S2APIKey)
+	if cfg3.ASTAAPIKey != "modified-key" {
+		t.Errorf("Third load: ASTAAPIKey = %q, want modified-key", cfg3.ASTAAPIKey)
 	}
 }
 
@@ -359,7 +323,6 @@ func TestGetters_MalformedConfig(t *testing.T) {
 	clearTokenEnv(t)
 	writeRawConfig(t, "asta_api_key: [unterminated\n")
 	getters := map[string]func() string{
-		"GetS2APIKey":      GetS2APIKey,
 		"GetASTAAPIKey":    GetASTAAPIKey,
 		"GetGitHubToken":   GetGitHubToken,
 		"GetSlackBotToken": GetSlackBotToken,

--- a/internal/s2/client.go
+++ b/internal/s2/client.go
@@ -71,8 +71,9 @@ func NewClient(opts ...ClientOption) *Client {
 		baseURL:    BaseURL,
 	}
 
-	// Check for API key in environment and global config
-	if key := config.GetS2APIKey(); key != "" {
+	// Check for API key in environment and global config. AI2 issues a
+	// single key shared by the ASTA MCP API and the Graph API.
+	if key := config.GetASTAAPIKey(); key != "" {
 		c.apiKey = key
 	}
 

--- a/skills/bip-lit/api-guide.md
+++ b/skills/bip-lit/api-guide.md
@@ -10,7 +10,7 @@ Both `bip s2` and `bip asta` commands access Semantic Scholar's paper database, 
 | Rate limit | 1 req/sec | 10 req/sec |
 | Snippet search | No | Yes |
 | Add to collection | Yes | No (read-only) |
-| Auth | S2_API_KEY | ASTA_API_KEY |
+| Auth | ASTA_API_KEY (shared key) | ASTA_API_KEY |
 
 ## When to Use S2
 
@@ -111,8 +111,7 @@ bip asta search "phylogenetics" --human
 
 ```bash
 # In .env file
-S2_API_KEY=your_s2_api_key      # For bip s2 commands
-ASTA_API_KEY=your_asta_api_key  # For bip asta commands
+ASTA_API_KEY=your_asta_api_key  # For both bip s2 and bip asta commands
 ```
 
 ## Decision Flowchart


### PR DESCRIPTION
🤖

## Summary
- AI2 confirmed the ASTA/Semantic Scholar key upgrade now issues a single key for both the ASTA MCP API and the Graph API — the old `s2_api_key` had started getting hard `403 ForbiddenException` responses from the Graph API gateway (confirmed via plain curl, ruling out a client-library/header-format bug).
- Removes the now-dead `S2APIKey` field/`GetS2APIKey()` getter from `internal/config`; `internal/s2/client.go` now authenticates via `GetASTAAPIKey()`.
- Updates docs (`README.md`, `docs/guides/configuration.md`, `skills/bip-lit/api-guide.md`) and the rate-limit error suggestion in `cmd/bip/s2_helpers.go` to point at `asta_api_key`.

## Test plan
- [x] `go build -o bip ./cmd/bip`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `go test ./...` (full suite green)
- [x] Verified locally with curl: old `s2_api_key` value gets `403`, `asta_api_key` value gets `200` against the Graph API