### PR TITLE
go mod tidy: move fsnotify to the direct-require block

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/matsen/bipartite
 go 1.24.1
 
 require (
+	github.com/fsnotify/fsnotify v1.10.0
 	github.com/joho/godotenv v1.5.1
 	github.com/ledongthuc/pdf v0.0.0-20250511090121-5959a4027728
 	github.com/spf13/cobra v1.10.2
@@ -14,7 +15,6 @@ require (
 
 require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
-	github.com/fsnotify/fsnotify v1.10.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect


### PR DESCRIPTION
🤖

## Summary

`cmd/bip/epic_watch.go:17` imports `github.com/fsnotify/fsnotify` directly — it's the file-watching backend for `bip epic watch` — but `go.mod` listed it in the indirect block. The mislabel is cosmetic (the build resolves identically either way), but it makes `go.mod` misreport the real dependency surface, and it means anyone who runs `go mod tidy` picks up an unrelated diff in their PR. That happened during #220.

- `go mod tidy` produces exactly the one-line move and nothing else: `github.com/fsnotify/fsnotify v1.10.0` leaves the indirect block and joins the direct requires.
- `go.sum` is unchanged. No version bumps, no code changes.

Closes #221

## Test plan

- `go build ./...`, `go vet ./...`, `go test ./...` — all pass, including `tests/integration`.
- `git diff go.sum` is empty, confirming no module-graph movement beyond the label.

## DEFERRED

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)