### PR TITLE
kaizen: tell a worker to re-create .epic-status.json if it resumes after landing

### DIFF
--- a/skills/bip-conductor-spawn/SKILL.md
+++ b/skills/bip-conductor-spawn/SKILL.md
@@ -292,8 +292,8 @@ EPIC STATUS PROTOCOL — You MUST follow this:
   lead_notes — list of lead evaluation entries (set by lead)
   completed_at — ISO 8601 timestamp set by the lead after the
     terminal completed ceremony (idempotency signal; do not set
-    yourself). Record deferred work in the PR body DEFERRED section;
-    the lead will file legitimate ones as follow-up issues.
+    yourself). If you resume work after landing, re-create this file —
+    see the landing step.
   awaiting — set when waiting for experiment results (description, check_cmd, check_files, started_at, timeout_hours)
 
 .epic-worklog.md format (append-only, never edit previous entries):
@@ -511,6 +511,16 @@ COMPLETION: When done (or when lead says completed):
    - Do NOT spawn the next slot. Handing off needs explicit permission.
    - Invoke the issue-lead one final time — it sets phase to completed
      and files any follow-ups from the PR body's DEFERRED section
+
+   IF YOU RESUME WORK AFTER THIS POINT, RE-CREATE `.epic-status.json`
+   FIRST. Landing deletes it and the worklog, and both the conductor's
+   reclaim gate and `bip epic watch` key on the file EXISTING — a slot
+   without one emits no phase transition and reads as finished. So a
+   break you notice after standing down, including one your own merged
+   PR caused, is invisible to every fleet mechanism until you write a
+   status file naming the issue and a live phase. And commit+push
+   before verifying, not after: the clone is pooled, and the next
+   spawn's prep runs `git checkout main`.
 
    IF THIS ISSUE'S PROMPT REQUIRES A JOINT LANDING GATE (some do — a
    result that re-reads a parent EPIC's status line, or changes a live


### PR DESCRIPTION
A slot that lands, preserves its worklog and clears its `.epic-status.json` — all correct — becomes invisible to every fleet mechanism, and nothing tells it to re-appear. This adds that instruction to the worker prompt template, at the landing step.

## The gap

Both readers key on the file **existing**: `cmd/bip/epic_watch.go`'s `processStatus` returns early on `os.ErrNotExist`, and the conductor's reclaim gate has nothing to read. So work resumed after standing down emits no phase transition and reads as finished. It is invisible by construction, not by oversight.

Measured on `matsengrp/phyz`, 2026-09-07: `birch` landed #2327, preserved and cleared correctly, then found and fixed a **red `main`** its own merged PR had caused. For roughly an hour that fix was an **uncommitted working-tree change in a pooled clone** with no phase, no worklog and no watcher event, about 5h from a red nightly. It surfaced from a `/proc` walk during a reclaim gate, not from any fleet signal.

## Placement

At the landing step, not in the `completed_at` field description where it was first drafted. At the moment the rule applies the file does not exist, so a worker has no reason to be reading its schema — which is the same invisible-when-needed defect the rule fixes. The landing step is the last instruction a worker reads before standing down. A one-line pointer stays in the schema so it remains self-describing.

## Net +12 / −2

The two deletions are the deferral policy, which had no business in a field description and is stated three more times in the same template: the operative instruction with its format string, the recording rule, and the lead's side. Verified present after the cut.

## Provenance

**No existing rule.** `grep -riE 'stand.?down|stood down|re-?entry|reopen|re-?creat|resume work'` over `skills/ *.md` finds only *preserve-before-reclaim* guidance (the conductor's side, in `bip-conductor`, `bip-conductor-poll`, and `bip-pr-land` Step 6a). Nothing told a worker what to do when it resumes after its own files are gone.

`bip-conductor`'s reclaim gate and `bip-conductor-poll`'s sweep are deliberately unchanged: the fix is worker-side, and once the file is re-created both read it correctly. The one residual — a re-entered slot invisible to idle-clone selection — requires being on `main`, clean, and file-less simultaneously; uncommitted work trips the dirty filter and committed work trips the branch filter, and the new commit-before-verifying line closes the remaining sliver by pushing workers onto a branch earlier.

Reviewed by the epic session, which verified both checkable claims independently and required the placement change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)