### PR TITLE
bip-issue-check: revalidate a stale draft's measurements, not just its line pins

### DIFF
--- a/skills/bip-issue-check/SKILL.md
+++ b/skills/bip-issue-check/SKILL.md
@@ -231,6 +231,29 @@ Spell out denominator, population, and weighting explicitly — these are the de
 `<placeholder>`, `[NEEDS CLARIFICATION]`, `XXX`, or similar markers that indicate unfinished thinking.
 Every placeholder must be resolved with concrete content before the issue is submitted.
 
+#### Staleness of a pre-existing draft
+
+10d.
+**If the issue file predates this session — a draft carried in a clone, a deferral written days ago, a body being re-filed — revalidate its MEASUREMENTS and its GATES, not only its line numbers.**
+Line pins are the cheap part and the part everyone checks.
+The expensive part is that a draft's load-bearing *number* was taken on a binary that has since moved, or its success criterion gates on an artifact that turns out not to exist.
+Both look fine to a reference-checking pass and both invalidate the issue.
+
+**How to check:**
+- For every quoted measurement, identify the commit or binary it was taken on (the draft usually names a PR or issue).
+  Then `git log --oneline <that-commit>..HEAD -- <the-source-files-it-depends-on>` and ask whether anything in that range could move the number.
+  If it could, **re-run the measurement** rather than re-pinning the citation.
+- For every success criterion or test-plan gate that names a file, confirm the file is git-tracked (`git ls-files --error-unmatch <path>`).
+  A gate on "byte-identity of committed results" is not a gate if the named results are gitignored.
+
+**Flag as HIGH** when a quoted measurement's source files changed in the interval, or when a gate names an untracked artifact.
+
+**Worked examples, both from 2026-09-08 and both from drafts whose line pins were current:**
+- A draft's decisive claim — that two CLI arms give identical `final_lnl` — was taken before a PR rewrote 173 lines of `stochastic_search.zig` underneath it.
+  Re-measured and it survived, but nothing about re-pinning the line numbers would have established that.
+- Another draft's test plan gated on byte-identity of five committed artifacts; **two of them were outside the experiment's `.gitignore` allowlist** and could never have been diffed.
+  The gate would have passed or failed for reasons unrelated to the change.
+
 #### Prose discipline
 
 10c.


### PR DESCRIPTION
Adds check `10d` to `/bip-issue-check`, for issue files that predate the current session — a draft carried in a clone, an old deferral, a body being re-filed.

Line pins are the cheap part and the part everyone checks. The expensive part is a load-bearing **number** taken on a binary that has since moved, or a **gate** naming an artifact that doesn't exist. Both look fine to a reference-checking pass and both invalidate the issue.

The check: for each quoted measurement, `git log <its-commit>..HEAD -- <source files it depends on>` and re-run rather than re-pin if anything in that range could move it; for each gate naming a file, `git ls-files --error-unmatch`.

## Evidence

Both from 2026-09-08, both from drafts whose line pins were current:

- matsengrp/phyz#2369's decisive claim (two CLI arms give identical `final_lnl`) was taken before a PR rewrote 173 lines of `stochastic_search.zig` underneath it. Re-measured and it held — but nothing about re-pinning would have established that, and it was a coin-flip.
- matsengrp/phyz#2368's test plan gated on byte-identity of five committed artifacts; **two were outside the experiment's `.gitignore` allowlist** and could never have been diffed. The gate would have passed or failed for reasons unrelated to the change.

Skill text only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)