### PR TITLE
Replace the pre-set SkippedReason with an actual per-cause skip breakdown

### DIFF
--- a/cmd/bip/index.go
+++ b/cmd/bip/index.go
@@ -33,13 +33,14 @@ var indexCmd = &cobra.Command{
 
 // IndexBuildResult is the response for index build command.
 type IndexBuildResult struct {
-	Status          string  `json:"status"`
-	PapersIndexed   int     `json:"papers_indexed"`
-	PapersSkipped   int     `json:"papers_skipped"`
-	SkippedReason   string  `json:"skipped_reason"`
-	DurationSeconds float64 `json:"duration_seconds"`
-	Model           string  `json:"model"`
-	IndexSizeBytes  int64   `json:"index_size_bytes"`
+	Status               string  `json:"status"`
+	PapersIndexed        int     `json:"papers_indexed"`
+	PapersSkipped        int     `json:"papers_skipped"`
+	SkippedNoAbstract    int     `json:"skipped_no_abstract"`
+	SkippedShortAbstract int     `json:"skipped_short_abstract"`
+	DurationSeconds      float64 `json:"duration_seconds"`
+	Model                string  `json:"model"`
+	IndexSizeBytes       int64   `json:"index_size_bytes"`
 }
 
 var indexBuildCmd = &cobra.Command{
@@ -57,19 +58,22 @@ func outputBuildResults(provider *embedding.OllamaProvider, stats *semantic.Buil
 	if humanOutput {
 		fmt.Printf("\nBuild complete:\n")
 		fmt.Printf("  Papers indexed: %d\n", stats.PapersIndexed)
-		fmt.Printf("  Papers skipped: %d (no abstract)\n", stats.PapersSkipped)
+		fmt.Printf("  Papers skipped: %d (%d no abstract, %d under %d chars)\n",
+			stats.PapersSkipped, stats.SkippedNoAbstract, stats.SkippedShortAbstract,
+			semantic.MinAbstractLength)
 		fmt.Printf("  Time elapsed: %s\n", formatDuration(stats.Duration))
 		fmt.Printf("  Index size: %s\n", formatBytes(stats.IndexSizeBytes))
 		fmt.Printf("  Model: %s\n", provider.ModelName())
 	} else {
 		outputJSON(IndexBuildResult{
-			Status:          "complete",
-			PapersIndexed:   stats.PapersIndexed,
-			PapersSkipped:   stats.PapersSkipped,
-			SkippedReason:   stats.SkippedReason,
-			DurationSeconds: stats.Duration.Seconds(),
-			Model:           provider.ModelName(),
-			IndexSizeBytes:  stats.IndexSizeBytes,
+			Status:               "complete",
+			PapersIndexed:        stats.PapersIndexed,
+			PapersSkipped:        stats.PapersSkipped,
+			SkippedNoAbstract:    stats.SkippedNoAbstract,
+			SkippedShortAbstract: stats.SkippedShortAbstract,
+			DurationSeconds:      stats.Duration.Seconds(),
+			Model:                provider.ModelName(),
+			IndexSizeBytes:       stats.IndexSizeBytes,
 		})
 	}
 }

--- a/internal/semantic/builder.go
+++ b/internal/semantic/builder.go
@@ -59,9 +59,7 @@ func (b *Builder) Build(ctx context.Context, refs []reference.Reference) (*Seman
 	startTime := time.Now()
 
 	idx := NewSemanticIndex(b.provider.ModelName(), b.provider.Dimensions())
-	stats := &BuildStats{
-		SkippedReason: "no_abstract",
-	}
+	stats := &BuildStats{}
 
 	// Clear existing embedding metadata
 	if b.db != nil {
@@ -88,9 +86,16 @@ func (b *Builder) Build(ctx context.Context, refs []reference.Reference) (*Seman
 			b.progress.OnProgress(papersExamined, total)
 		}
 
-		// Skip papers without abstracts or with short abstracts
-		if ref.Abstract == "" || len(ref.Abstract) < MinAbstractLength {
+		// Skip papers without abstracts or with short abstracts, recording
+		// which of the two it was.
+		if ref.Abstract == "" {
 			stats.PapersSkipped++
+			stats.SkippedNoAbstract++
+			continue
+		}
+		if len(ref.Abstract) < MinAbstractLength {
+			stats.PapersSkipped++
+			stats.SkippedShortAbstract++
 			continue
 		}
 

--- a/internal/semantic/builder_test.go
+++ b/internal/semantic/builder_test.go
@@ -106,9 +106,15 @@ func TestBuild(t *testing.T) {
 	if stats.PapersIndexed != 2 {
 		t.Errorf("expected 2 papers indexed, got %d", stats.PapersIndexed)
 	}
-	// Both the empty and the short abstract are skipped.
+	// Both the empty and the short abstract are skipped, one for each reason.
 	if stats.PapersSkipped != 2 {
 		t.Errorf("expected 2 papers skipped, got %d", stats.PapersSkipped)
+	}
+	if stats.SkippedNoAbstract != 1 {
+		t.Errorf("expected 1 paper skipped for no abstract, got %d", stats.SkippedNoAbstract)
+	}
+	if stats.SkippedShortAbstract != 1 {
+		t.Errorf("expected 1 paper skipped for a short abstract, got %d", stats.SkippedShortAbstract)
 	}
 	if stats.Duration <= 0 {
 		t.Error("expected a positive build duration")
@@ -164,6 +170,102 @@ func TestBuildEmptyInput(t *testing.T) {
 	}
 	if len(idx.Embeddings) != 0 {
 		t.Errorf("expected an empty index, got %d embeddings", len(idx.Embeddings))
+	}
+}
+
+// TestBuildSkipBreakdownOnlyCountsActualSkips guards the defect the old
+// scalar SkippedReason field had: it was set on the BuildStats literal before
+// the loop, so it named a skip reason even on a run that skipped nothing.
+func TestBuildSkipBreakdownOnlyCountsActualSkips(t *testing.T) {
+	refs := []reference.Reference{
+		loadFixture(t, "ml_methods.json"),
+		loadFixture(t, "phylogenetics.json"),
+	}
+
+	_, stats, err := NewBuilder(newStubProvider(), nil).Build(context.Background(), refs)
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if stats.PapersIndexed != 2 {
+		t.Fatalf("expected both papers indexed, got %d", stats.PapersIndexed)
+	}
+	if stats.PapersSkipped != 0 {
+		t.Errorf("expected 0 papers skipped, got %d", stats.PapersSkipped)
+	}
+	if stats.SkippedNoAbstract != 0 {
+		t.Errorf("expected no no-abstract skips, got %d", stats.SkippedNoAbstract)
+	}
+	if stats.SkippedShortAbstract != 0 {
+		t.Errorf("expected no short-abstract skips, got %d", stats.SkippedShortAbstract)
+	}
+}
+
+// TestBuildSkipBreakdownDistinguishesCauses pins the two causes apart: an
+// absent abstract and a present-but-too-short one are different counters, not
+// the single "no_abstract" label the old field reported for both.
+func TestBuildSkipBreakdownDistinguishesCauses(t *testing.T) {
+	tests := []struct {
+		name         string
+		abstract     string
+		wantNoAbs    int
+		wantShortAbs int
+	}{
+		{name: "absent", abstract: "", wantNoAbs: 1, wantShortAbs: 0},
+		{name: "one char", abstract: "x", wantNoAbs: 0, wantShortAbs: 1},
+		{
+			name:         "one char below the threshold",
+			abstract:     strings.Repeat("x", MinAbstractLength-1),
+			wantNoAbs:    0,
+			wantShortAbs: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			refs := []reference.Reference{{ID: "skip-001", Abstract: tt.abstract}}
+
+			_, stats, err := NewBuilder(newStubProvider(), nil).Build(context.Background(), refs)
+			if err != nil {
+				t.Fatalf("Build failed: %v", err)
+			}
+
+			if stats.PapersSkipped != 1 {
+				t.Fatalf("expected the paper to be skipped, got PapersSkipped=%d", stats.PapersSkipped)
+			}
+			if stats.SkippedNoAbstract != tt.wantNoAbs {
+				t.Errorf("expected SkippedNoAbstract %d, got %d", tt.wantNoAbs, stats.SkippedNoAbstract)
+			}
+			if stats.SkippedShortAbstract != tt.wantShortAbs {
+				t.Errorf("expected SkippedShortAbstract %d, got %d", tt.wantShortAbs, stats.SkippedShortAbstract)
+			}
+			// The breakdown must always account for every skip.
+			if sum := stats.SkippedNoAbstract + stats.SkippedShortAbstract; sum != stats.PapersSkipped {
+				t.Errorf("breakdown sums to %d but PapersSkipped is %d", sum, stats.PapersSkipped)
+			}
+		})
+	}
+}
+
+// TestBuildIndexesAtExactlyMinAbstractLength pins the boundary: the skip is
+// strictly below MinAbstractLength, so an abstract of exactly that length is
+// indexed rather than skipped.
+func TestBuildIndexesAtExactlyMinAbstractLength(t *testing.T) {
+	refs := []reference.Reference{
+		{ID: "boundary-001", Abstract: strings.Repeat("x", MinAbstractLength)},
+	}
+
+	_, stats, err := NewBuilder(newStubProvider(), nil).Build(context.Background(), refs)
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	if stats.PapersIndexed != 1 {
+		t.Errorf("expected an abstract of exactly %d chars to be indexed, got PapersIndexed=%d",
+			MinAbstractLength, stats.PapersIndexed)
+	}
+	if stats.PapersSkipped != 0 {
+		t.Errorf("expected no skips, got %d", stats.PapersSkipped)
 	}
 }
 

--- a/internal/semantic/types.go
+++ b/internal/semantic/types.go
@@ -29,9 +29,17 @@ type SearchResult struct {
 
 // BuildStats contains statistics from index building.
 type BuildStats struct {
-	PapersIndexed  int           `json:"papers_indexed"`
-	PapersSkipped  int           `json:"papers_skipped"`
-	SkippedReason  string        `json:"skipped_reason"`
+	PapersIndexed int `json:"papers_indexed"`
+	PapersSkipped int `json:"papers_skipped"`
+
+	// SkippedNoAbstract and SkippedShortAbstract break PapersSkipped down by
+	// cause and sum to it. A paper with no abstract at all counts as
+	// no-abstract; one whose abstract is shorter than MinAbstractLength counts
+	// as short. The distinction is actionable: a missing abstract can often be
+	// fetched, whereas a short one is usually all the source provides.
+	SkippedNoAbstract    int `json:"skipped_no_abstract"`
+	SkippedShortAbstract int `json:"skipped_short_abstract"`
+
 	Duration       time.Duration `json:"duration"`
 	IndexSizeBytes int64         `json:"index_size_bytes"`
 }


### PR DESCRIPTION
🤖

## Summary

`bip index build` now reports *why* papers were skipped, correctly. `BuildStats.SkippedReason` is replaced by two counters, `SkippedNoAbstract` and `SkippedShortAbstract`, incremented at the point of the skip and summing to `PapersSkipped`.

The old field was assigned on the `BuildStats` struct literal before the loop ever ran (`builder.go:62-64`), which made it wrong in two directions: it reported `"no_abstract"` on a run that skipped nothing, and it reported `"no_abstract"` for a paper skipped merely for having an abstract under `MinAbstractLength`. Found while reviewing #227 and deferred there as out of scope for a test-only PR.

This was user-visible, not just internal:

- `bip index build --json` emitted `"skipped_reason": "no_abstract"` unconditionally (`cmd/bip/index.go:39,69`).
- The human-readable path hardcoded the same claim independently — `Papers skipped: %d (no abstract)` (`cmd/bip/index.go:60`) — so it stayed wrong regardless of the struct field.

The skip condition is split so the causes are actually distinguishable. Note the two are not disjoint under the old predicate: `""` also satisfies `len < MinAbstractLength`, so an absent abstract is now attributed to the absent counter rather than to both or to whichever branch happened to be first.

## Interface change

`skipped_reason` (string) is gone from the `bip index build --json` output, replaced by `skipped_no_abstract` and `skipped_short_abstract` (ints). Nothing in this repo, `docs/`, or `skills/` consumed the old key — checked by grep — so this breaks no known caller.

Human-readable output goes from:

```
  Papers skipped: 412 (no abstract)
```

to:

```
  Papers skipped: 412 (37 no abstract, 375 under 50 chars)
```

The distinction is the point: a missing abstract can often be fetched, whereas a short one is usually all the source has.

## Test plan

Three new tests in `internal/semantic/builder_test.go`:

| Test | Behavior |
|---|---|
| `TestBuildSkipBreakdownOnlyCountsActualSkips` | A run of two indexable papers reports zero for both counters — the exact case the old field got wrong |
| `TestBuildSkipBreakdownDistinguishesCauses` | Absent vs. 1-char vs. `MinAbstractLength-1` land in the right counter, and the breakdown always sums to `PapersSkipped` |
| `TestBuildIndexesAtExactlyMinAbstractLength` | The threshold is strictly-below, so an abstract of exactly `MinAbstractLength` is indexed, not skipped |

`TestBuild` additionally asserts the fixture set yields one skip of each cause.

Package coverage 88.1% → 88.5% of statements. `go vet ./...`, `gofmt`, and the full `go test ./...` are clean.

Mutation-checked: making the no-abstract branch increment `SkippedShortAbstract` instead fails `TestBuild` (2 assertions) and `TestBuildSkipBreakdownDistinguishesCauses/absent` (2 assertions).

`bip index build` itself was not executed end-to-end — it requires a running Ollama with the embedding model — so the CLI wiring is verified by compilation and by the unit tests behind it, not by a live run.

Closes the first DEFERRED item from #227.

🤖 Generated with [Claude Code](https://claude.com/claude-code)